### PR TITLE
build: "all" should be default, don't run tests on install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ SYSCONFDIR ?= $(DESTDIR)/etc/sysconfig
 PROFILEDIR ?= $(DESTDIR)/etc/profile.d
 PYTHON ?= /usr/bin/python
 
+all: python-build
+
 test:
 	sh ./test.sh
-
-all: python-build
 
 python-build: atomic
 	$(PYTHON) setup.py build
@@ -17,7 +17,7 @@ clean:
 	$(PYTHON) setup.py clean
 	-rm -rf build *~ \#* *pyc .#*
 
-install: test all 
+install: all 
 	$(PYTHON) setup.py install `test -n "$(DESTDIR)" && echo --root $(DESTDIR)`
 	[ -d $(SYSCONFDIR) ] || mkdir -p $(SYSCONFDIR)
 	install -m 644 atomic.sysconfig $(SYSCONFDIR)/atomic


### PR DESCRIPTION
Neither "make" or "make install" should not run tests.  Further,
change the default target to be "all" by listing it first.