### PR TITLE
use /usr/local as prefix in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ install: all
 	install -m 644 atomic.sh $(PROFILEDIR)
 
 	install -d $(PREFIX)/share/man/man1
-	install $(basename $(MANPAGES_MD)) $(PREFIX)/share/man/man1
+	install -m 644 $(basename $(MANPAGES_MD)) $(PREFIX)/share/man/man1
 	-mkdir -p $(BASHCOMPLETIONDIR)
 	install -m 644 bash/atomic $(BASHCOMPLETIONDIR)
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Installation directories.
-PREFIX ?= $(DESTDIR)/usr
+PREFIX ?= $(DESTDIR)/usr/local
 SYSCONFDIR ?= $(DESTDIR)/etc/sysconfig
 PROFILEDIR ?= $(DESTDIR)/etc/profile.d
 PYTHON ?= /usr/bin/python


### PR DESCRIPTION
This will keep the 'make install'-ed package isolated from distro managed
packages.

rpms can use PREFIX=%{prefix} to install to /usr.
My guess is other formats can do something similar too.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>