### PR TITLE
Add additional support for atomic version

### DIFF
--- a/atomic
+++ b/atomic
@@ -51,6 +51,16 @@ except IOError:
     import builtins
     builtins.__dict__['_'] = str
 
+images=[]
+def findRepoTag(d, id):
+    global images
+    if len(images) == 0:
+        images = d.images()
+    for image in images:
+        if id == image["Id"]:
+            return image["RepoTags"][0]
+    return ""
+
 class Atomic(object):
     INSTALL_ARGS = ["/usr/bin/docker", "run",
                     "-t",
@@ -102,10 +112,20 @@ class Atomic(object):
         self.spc = False
         self.inspect = None
         self.force = False
+        self.images = []
 
     def writeOut(self, output, lf="\n"):
         sys.stdout.flush()
         sys.stdout.write(output + lf)
+
+    def get_label(self, label, image=None):
+        inspect = self._inspect_image(image)
+        cfg = inspect.get("Config", None)
+        if cfg:
+            labels = cfg.get("Labels", [])
+            if labels and label in labels:
+                return labels[label]
+        return ""
 
     def force_delete_containers(self):
         if self._inspect_image():
@@ -251,8 +271,10 @@ class Atomic(object):
             else:
                 return subprocess.check_call(["/usr/bin/docker", "start", self.name], stderr=DEVNULL)
 
-    def _inspect_image(self):
+    def _inspect_image(self, image=None):
         try:
+            if image:
+                return self.d.inspect_image(image)
             return self.d.inspect_image(self.image)
         except docker.errors.APIError:
             pass
@@ -484,6 +506,23 @@ removes all containers based on an image.
     def print_uninstall(self):
         return " ".join(self.INSTALL_ARGS) + " /usr/bin/UNINSTALLCMD"
 
+    def _get_layer(self, image):
+        def get_label(label):
+            return self.get_label(label, image["Id"])
+        image = self._inspect_image(image)
+        if not image:
+            raise ValueError("Image '%s' does not exist" % self.image)
+        return({ "Id": image['Id'], "Name": get_label("Name"), "Version" : ("%s:%s:%s" % (get_label("Name"),get_label("Version"),get_label("Release"))).strip(":"), "Tag": findRepoTag(self.d, image['Id']), "Parent": image['Parent']})
+
+    def get_layers(self):
+        layers = []
+        layer = self._get_layer(self.image)
+        layers.append(layer)
+        while layer["Parent"] != "":
+                layer = self._get_layer(layer["Parent"])
+                layers.append(layer)
+        return layers
+
     def version(self):
         def get_label(label):
             val = self._get_args(label)
@@ -497,7 +536,13 @@ removes all containers based on an image.
             self.update()
             self.inspect = self.d.inspect_image(self.image)
 
-        self.writeOut(("%s %s %s" % (get_label("Name"), get_label("Version"), get_label("Release"))).strip())
+        if self.args.recurse:
+            for layer in self.get_layers():
+                self.writeOut("%s %s %s" % (layer["Id"],layer["Version"],layer["Tag"]))
+        else:
+            layer = self._get_layer(self.image)
+            self.writeOut("%s %s %s" % (layer["Id"],layer["Version"],layer["Tag"]))
+
 
 def SetFunc(function):
     class customAction(argparse.Action):
@@ -584,6 +629,7 @@ if __name__ == '__main__':
                             help=_("name of container"))
     uninstallp.add_argument("-f", "--force",
                             default=False,
+                            dest="force",
                             action="store_true",
                             help=_("remove all containers based on this image"))
     uninstallp.add_argument("image", help=_("container image"))
@@ -593,6 +639,7 @@ if __name__ == '__main__':
     updatep.set_defaults(func=atomic.update)
     updatep.add_argument("-f", "--force",
                          default=False,
+                         dest="force",
                          action="store_true",
                          help=_("remove all containers based on this image"))
     updatep.add_argument("image", help=_("container image"))
@@ -626,6 +673,11 @@ if __name__ == '__main__':
     versionp = subparser.add_parser("version",
                                     help=_("display image 'Name Version Release' label"),
                                     epilog="atomic version displays the image version information, if it is provided")
+    versionp.add_argument("-r", "--recurse",
+                         default=False,
+                         dest="recurse",
+                         action="store_true",
+                         help=_("recurse through all layers"))
     versionp.set_defaults(func=atomic.version)
     versionp.add_argument("image", help=_("container image"))
 

--- a/atomic
+++ b/atomic
@@ -523,6 +523,48 @@ removes all containers based on an image.
                 layers.append(layer)
         return layers
 
+    def _get_image(self, image):
+        def get_label(label):
+            return self.get_label(label, image["Id"])
+
+        return { "Id": image['Id'], "Name": get_label("Name"), "Version" : ("%s:%s:%s" % (get_label("Name"),get_label("Version"),get_label("Release"))).strip(":"), "Tag": image["RepoTags"][0]}
+
+    def get_images(self):
+        if len(self.images) > 0:
+            return self.images
+
+        images = self.d.images()
+        for image in images:
+            self.images.append(self._get_image(image))
+
+        return self.images
+
+    def verify(self):
+        def get_label(label):
+            val = self._get_args(label)
+            if val:
+                return val[0]
+            return ""
+        self.inspect = self._inspect_image()
+        current_name = get_label("Name")
+        version = ""
+        if current_name:
+            version = "%s:%s:%s" % (current_name,get_label("Version"),get_label("Release"))
+
+        prev = ""
+        name = None
+        for layer in self.get_layers():
+            if name == layer["Name"]:
+                continue
+            name = layer["Name"]
+            if len(name)>0:
+                for i in self.get_images():
+                    if i["Name"] == name:
+                        if i["Version"] > layer["Version"]:
+                            self.writeOut("Image '%s' contains a layer '%s' that is out of date image version '%s' is available." % (self.image, layer["Version"], i["Version"]))
+                            self.writeOut("You should rebuild the '%s' image useing docker build, it could be vulnerable." % (self.image))
+                            break
+
     def version(self):
         def get_label(label):
             val = self._get_args(label)
@@ -680,6 +722,12 @@ if __name__ == '__main__':
                          help=_("recurse through all layers"))
     versionp.set_defaults(func=atomic.version)
     versionp.add_argument("image", help=_("container image"))
+
+    verifyp = subparser.add_parser("verify",
+                                    help=_("verify image is fully updated"),
+                                    epilog="atomic verify checks whether there is a newer image available and scans through all layers to see if any of the sublayers have a new version available")
+    verifyp.set_defaults(func=atomic.verify)
+    verifyp.add_argument("image", help=_("container image"))
 
     try:
         args = parser.parse_args()

--- a/bash/atomic
+++ b/bash/atomic
@@ -160,10 +160,21 @@ _atomic_info() {
 	esac
 }
 
+_atomic_version() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--recurse -r" -- "$cur" ) )
+			;;
+		*)
+		    __atomic_image_repos_and_tags
+		    ;;
+	esac
+}
+
 _atomic_update() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--force -t" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--force -f" -- "$cur" ) )
 			;;
 		*)
 		    __atomic_image_repos_and_tags
@@ -319,6 +330,7 @@ _atomic() {
 		install
 		stop
 		run
+		version
 		uninstall
 		update
 	)

--- a/bash/atomic
+++ b/bash/atomic
@@ -160,6 +160,14 @@ _atomic_info() {
 	esac
 }
 
+_atomic_verify() {
+	case "$cur" in
+		*)
+		    __atomic_image_repos_and_tags
+		    ;;
+	esac
+}
+
 _atomic_version() {
 	case "$cur" in
 		-*)
@@ -330,6 +338,7 @@ _atomic() {
 		install
 		stop
 		run
+		verify
 		version
 		uninstall
 		update

--- a/docs/atomic-verify.1.md
+++ b/docs/atomic-verify.1.md
@@ -1,0 +1,22 @@
+% ATOMIC(1) Atomic Man Pages
+% Dan Walsh
+% May 2015
+# NAME
+atomic-verify - Verify image is fully updated
+
+# SYNOPSIS
+**atomic verify**
+[**-h**]
+IMAGE
+
+# DESCRIPTION
+**atomic verify** checks whether there is a newer image available and scans
+through all layers to see if any of the sublayers have a new version available.
+If the tool finds a out of date image it will tell user to update the image.
+
+# OPTIONS:
+**--help**
+  Print usage statement
+
+# HISTORY
+May 2015, Originally compiled by Daniel Walsh (dwalsh at redhat dot com)

--- a/docs/atomic-version.1.md
+++ b/docs/atomic-version.1.md
@@ -7,12 +7,14 @@ atomic-version - Display image 'Name Version Release' label
 # SYNOPSIS
 **atomic version**
 [**-h**]
+[**-r**], [**--recurse**]
 IMAGE
 
 # DESCRIPTION
-**atomic version** display image 'Name Version Release' label
+**atomic version** display image 'Id Name:Version:Release RepoTag' label
 
 # OPTIONS:
+**-r**, **--recurse**   Recurse through all layers of the specified image.
 **--help**
   Print usage statement
 


### PR DESCRIPTION
Want to be able to display atomic version including layers ID, NAME:VERSION:RELEASE Repository/Tag

Will also display recursively all layers in the image.

atomic version test
afecc5f6a3c4d8f2326901c94cdf84aab0890ea827c38f2b0d2e2a4ba5ace7d6 Apache:1.0:1 test:latest

Another feature I have added is, the ability to recurse though all of the layers of the image.

atomic version -r test
afecc5f6a3c4d8f2326901c94cdf84aab0890ea827c38f2b0d2e2a4ba5ace7d6 Apache:1.0:1 test:latest
21b2d6e4171b024cb48bb2d02d626481e37724a6e03dac7962e44cc8612fbf22 Apache:1.0:1
83202d54cf27439381b3d668d02f3a21cb75ebba4623d86e1fdbad614660424e Apache:1.0:1
90ff7403d883c0ccde72bf630cb77e224fd6b517fc4b61b84f8d9739dab93c9f Apache:1.0:1
12f19f77bc52483d902727b6c142f20cc79109ad45e36869f30c15228534eb5b Apache:1.0:1
4bcd0ad4dbe8c39f49094c3f13c8aa517efe6c76de1aacb6fca413ee3372dd98 Apache:1.0:1
fabaf6ef3297a7d6006ee24034aa2ba525f064f108580d4b44944e24b1581513 Apache:1.0:1
eb10dd5ab6a2a649d5e069c67fdd71506db0b0a1e4a5b5680c1d3f317bfa320a Apache:1.0:1
b0bc3c982c88037a5e7b6e7e6de900981c9f90516014b7071fe860ca39a22d02 Apache:1.0:1
99878fca96575b6ccac2fa54a2f2a44ad85d94344e8fbde5ae2350e3b5eec98b Apache:1.0:
fc8782dfd543be2a582cf8ee7eff4e39c46a980f212891342ac4c6c6917ee211 Apache::
cf6c210ea5b979204df75ad4aeaa3dcb971589c2399d79e6c2a71e7588e95cd9 ::
4dab839254d036da5ad52f459d6602b1a84f379fe94c722bd969db14e119189a ::
011c13014fd9ede3e53119f380e20b88af2e8bd40afb1b3925ed39cbd067e453 ::
834629358fe214f210b0ed606fba2c17827d7a46dd74bd3309afc2a103ad0e89 :: fedora:21
00a0c78eeb6d81442efcd1d7c02e8b141745e3a06f1ee3458e1bae628e0067d3 ::
511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158 ::