### PR TITLE
Use image metadata if container does not exist on atomic stop

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -340,7 +340,12 @@ removes all containers based on an image.
 
 
     def stop(self):
+        inspected_image = False
         self.inspect = self._inspect_container()
+        if self.instpect is None:
+            self.inspect = self._inspect_image()
+            inspected_image = True
+
         args = self._get_args("STOP")
         if args:
             cmd = self.gen_cmd(args)
@@ -353,7 +358,9 @@ removes all containers based on an image.
 
 
         # Container exists
-        if self.inspect["State"]["Running"]:
+        if inspected_image:
+            self.inspect = self._inspect_container()
+        if self.inspect and self.inspect["State"]["Running"]:
             self.d.stop(self.name)
 
     def _rpmostree(self, *args):


### PR DESCRIPTION
When you call atomic stop it expects existing container which does not
have to be always true. We `--rm` our container in label `RUN` for atomicapp
because it's not useful after it finishes it's work.

This commit checks if the inspect of container was successful and if
not, it uses loads image metadata and uses `STOP` label from it