### PR TITLE
Handle labels with different cases

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -255,8 +255,8 @@ class Atomic(object):
 
     def _get_args(self, label):
         labels = self._get_labels()
-        if label in labels:
-            return labels[label].split()
+        for l in label, label.lower(), label.capitalize(), label.upper():
+            return labels[l].split()
         return None
 
     def _check_latest(self):
@@ -537,8 +537,8 @@ removes all containers based on an image.
                 for i in self.get_images():
                     if i["Name"] == name:
                         if i["Version"] > layer["Version"]:
-                            buf = ("Image '%s' contains a layer '%s' that is out of date image version '%s' is available." % (self.image, layer["Version"], i["Version"]))
-                            buf += ("You should rebuild the '%s' image useing docker build, it could be vulnerable." % (self.image))
+                            buf = ("Image '%s' contains a layer '%s' that is out of date.\nImage version '%s' is available, current version could container vulnerabilities." % (self.image, layer["Version"], i["Version"]))
+                            buf += ("You should rebuild the '%s' image using docker build." % (self.image))
                             break
         return buf
 

--- a/atomic
+++ b/atomic
@@ -99,7 +99,7 @@ if __name__ == '__main__':
 
     runp = subparser.add_parser("run",
                                 help=_("execute container image run method"),
-                                epilog="atomic run defaults to the following command, if image does not specify LABEL RUN\n'%s'" % atomic.print_run() )
+                                epilog="atomic run defaults to the following command, if image does not specify LABEL run\n'%s'" % atomic.print_run() )
     runp.set_defaults(func=atomic.run)
     runp.add_argument("-n", "--name", dest="name",
                       default=None,


### PR DESCRIPTION
We are working on the labeling standard, and one of the things that has come up
is a discussion on what case the labels should be Uppercase, Lowercase, or capatalized
This patch will match all three.

Also fix a couple of small bugs