### PR TITLE
Pass additional arguments to the atomic install/uninstall line

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -406,7 +406,7 @@ removes all containers based on an image.
         self.inspect = self._inspect_image()
         args = self._get_args("UNINSTALL")
         if args:
-            cmd = self.gen_cmd(args)
+            cmd = self.gen_cmd(args + self.args.args)
             self.writeOut(cmd)
             subprocess.check_call(cmd, env={
                 "CONFDIR": "/etc/%s" % self.name,
@@ -452,7 +452,7 @@ removes all containers based on an image.
 
         args = self._get_args("INSTALL")
         if args:
-            cmd = self.gen_cmd(args)
+            cmd = self.gen_cmd(args + self.args.args)
             self.writeOut(cmd)
 
             return(subprocess.check_call(cmd, env={

--- a/atomic
+++ b/atomic
@@ -82,12 +82,12 @@ if __name__ == '__main__':
                                     epilog="atomic install attempts to read the LABEL INSTALL field in the image, if it does not exist atomic will just pull the image on to your machine.  You could add a LABEL INSTALL command to your Dockerfile like: 'LABEL INSTALL %s'" % atomic.print_install() )
 
     installp.set_defaults(func=atomic.install)
-    installp.add_argument("image", help=_("container image"))
-    installp.add_argument("command", nargs=argparse.REMAINDER,
-                          help=_("execute container image install method"))
     installp.add_argument("-n", "--name", dest="name",
                       default=None,
                       help=_("name of container"))
+    installp.add_argument("image", help=_("container image"))
+    installp.add_argument("args", nargs=argparse.REMAINDER,
+                          help=_("Additional arguments appended to the image uninstall method"))
     stopp = subparser.add_parser("stop",
                                 help=_("execute container image stop method"),
                                  epilog="atomic will just stop the container if it is running, if image does not specify LABEL STOP\n")
@@ -126,6 +126,8 @@ if __name__ == '__main__':
                             action="store_true",
                             help=_("remove all containers based on this image"))
     uninstallp.add_argument("image", help=_("container image"))
+    uninstallp.add_argument("args", nargs=argparse.REMAINDER,
+                          help=_("Additional arguments appended to the image install method"))
 
     updatep = subparser.add_parser("update",help=_("pull latest container image from repository"), epilog="atomic update downloads the latest container image. If a previously container based on this image exists, the container will continue to use the old image.  Use --force to remove the container.")
 

--- a/docs/atomic-install.1.md
+++ b/docs/atomic-install.1.md
@@ -8,7 +8,7 @@ atomic-install - Execute Image Install Method
 **atomic install**
 [**-h**]
 [**--name**[=*NAME*]]
-IMAGE [COMMAND] [ARG...]
+IMAGE [ARG...]
 
 # DESCRIPTION
 **atomic install** attempts to read the `LABEL INSTALL` field in the container
@@ -20,7 +20,8 @@ If the container image has a LABEL INSTALL instruction like the following:
 
 `atomic install` will replace the NAME and IMAGE fields with the name and
 image specified via the command,  NAME will be replaced with IMAGE if it is
-not specified. `atomic install` will also pass in the CONFDIR, LOGDIR and DATADIR environment variables to the container.
+not specified. `atomic install` will also pass in the CONFDIR, LOGDIR and DATADIR environment variables to the container.  Any additional arguments will be
+appended to the command.
 
 # OPTIONS:
 **--help**

--- a/docs/atomic-uninstall.1.md
+++ b/docs/atomic-uninstall.1.md
@@ -8,7 +8,7 @@ atomic-uninstall - Remove/Uninstall container/container image from system
 **atomic uninstall**
 [**-f**][**--force**]
 [**-h**]
-IMAGE
+IMAGE [ARG...]
 
 # DESCRIPTION
 **atomic uninstall** attempts to read the `LABEL UNINSTALL` field in the
@@ -20,8 +20,8 @@ If the container image has a LABEL UNINSTALL instruction like the following:
 ```LABEL UNINSTALL /usr/bin/docker run -t -i --rm --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=NAME -e IMAGE=IMAGE -e CONFDIR=${CONFDIR} -e LOGDIR=${LOGDIR} -e DATADIR=${DATADIR} --name NAME IMAGE /bin/uninstall.sh```
 
 `atomic uninstall` will replace the NAME and IMAGE fields with the name and
-image specified via the command,  `atomic uninstall` will also pass in the CONFDIR, LOGDIR and DATADIR environment variables to the container.
-
+image specified via the command,  `atomic uninstall` will also pass in the CONFDIR, LOGDIR and DATADIR environment variables to the container. Any additional
+arguments will be appended to the command.
 
 # OPTIONS:
 **-f** **--force**


### PR DESCRIPTION
This patch will allow a user to pass additional arguments to the command specified in the INSTALL/UNINSTALL lines