### PR TITLE
Support OPT1, OPT2 in install/run command

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -418,6 +418,15 @@ removes all containers based on an image.
                'LOGDIR': "/var/log/%s" % self.name,
                'DATADIR':"/var/lib/%s" % self.name}
 
+        if self.args.opt1:
+            env['OPT1'] = self.args.opt1
+
+        if self.args.opt2:
+            env['OPT2'] = self.args.opt2
+
+        if self.args.opt3:
+            env['OPT3'] = self.args.opt3
+
         with open("/proc/self/loginuid") as f:
             default_uid = f.readline()
 
@@ -430,7 +439,7 @@ removes all containers based on an image.
             env['SUDO_GID'] = os.environ['SUDO_GID']
         else:
             try:
-                env['SUDO_GID'] = pwd.getpwuid(int(env["SUDO_UID"]))[3]
+                env['SUDO_GID'] = str(pwd.getpwuid(int(env["SUDO_UID"]))[3])
             except:
                 env["SUDO_GID"] = self.default_uid
 

--- a/atomic
+++ b/atomic
@@ -82,6 +82,9 @@ if __name__ == '__main__':
                                     epilog="atomic install attempts to read the LABEL INSTALL field in the image, if it does not exist atomic will just pull the image on to your machine.  You could add a LABEL INSTALL command to your Dockerfile like: 'LABEL INSTALL %s'" % atomic.print_install() )
 
     installp.set_defaults(func=atomic.install)
+    installp.add_argument("--opt1", dest="opt1", help="additional arguments to be passed as ${OPT1} for install command.")
+    installp.add_argument("--opt2", dest="opt2", help="additional arguments to be passed as ${OPT2} for install command.")
+    installp.add_argument("--opt3", dest="opt3", help="additional arguments to be passed as ${OPT3} for install command.")
     installp.add_argument("-n", "--name", dest="name",
                       default=None,
                       help=_("name of container"))
@@ -125,6 +128,9 @@ if __name__ == '__main__':
                                 help=_("execute container image run method"),
                                 epilog="atomic run defaults to the following command, if image does not specify LABEL run\n'%s'" % atomic.print_run() )
     runp.set_defaults(func=atomic.run)
+    runp.add_argument("--opt1", dest="opt1", help="additional arguments to be passed as ${OPT1} for run command.")
+    runp.add_argument("--opt2", dest="opt2", help="additional arguments to be passed as ${OPT2} for run command.")
+    runp.add_argument("--opt3", dest="opt3", help="additional arguments to be passed as ${OPT3} for run command.")
     runp.add_argument("-n", "--name", dest="name",
                       default=None,
                       help=_("name of container"))
@@ -141,6 +147,9 @@ if __name__ == '__main__':
                                                                           epilog="atomic uninstall attempts to read the LABEL UNINSTALL field in the image, if it does not exist atomic will remove the image from your machine.  You could add a LABEL UNINSTALL command to your Dockerfile like: 'LABEL UNINSTALL %s'" % atomic.print_uninstall() )
 
     uninstallp.set_defaults(func=atomic.uninstall)
+    uninstallp.add_argument("--opt1", dest="opt1", help="additional arguments to be passed as ${OPT1} for uninstall command.")
+    uninstallp.add_argument("--opt2", dest="opt2", help="additional arguments to be passed as ${OPT2} for uninstall command.")
+    uninstallp.add_argument("--opt3", dest="opt3", help="additional arguments to be passed as ${OPT3} for uninstall command.")
     uninstallp.add_argument("-n", "--name", dest="name",
                             default=None,
                             help=_("name of container"))

--- a/docs/atomic-install.1.md
+++ b/docs/atomic-install.1.md
@@ -16,7 +16,7 @@ IMAGE, if this field does not exist, `atomic install` will install the IMAGE
 
 If the container image has a LABEL INSTALL instruction like the following:
 
-```LABEL INSTALL /usr/bin/docker run -t -i --rm --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=${NAME} -e IMAGE=${IMAGE} -e CONFDIR=${CONFDIR} -e LOGDIR=${LOGDIR} -e DATADIR=${DATADIR} --name ${NAME} ${IMAGE} /bin/install.sh```
+```LABEL INSTALL /usr/bin/docker run -t -i --rm \${OPT1} --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=${NAME} -e IMAGE=${IMAGE} -e CONFDIR=${CONFDIR} -e LOGDIR=${LOGDIR} -e DATADIR=${DATADIR} --name ${NAME} ${IMAGE} \${OPT2} /bin/install.sh \${OPT3}```
 
 `atomic install` will set the following environment variables for use in the command:
 
@@ -25,6 +25,9 @@ If the container image has a LABEL INSTALL instruction like the following:
 
 **IMAGE**
   The name and image specified via the command.
+
+**OPT1, OPT2, OPT3**
+  Additional options which can be specified via the command.
 
 **SUDO_UID**
   The `SUDO_UID` environment variable.  This is useful with the docker `-u` option for user space tools.  If the environment variable is not available, the value of `/proc/self/loginuid` is used.

--- a/docs/atomic-run.1.md
+++ b/docs/atomic-run.1.md
@@ -18,7 +18,7 @@ IMAGE.
 
 If the container image has a LABEL RUN instruction like the following:
 
-```LABEL RUN /usr/bin/docker run -t -i --rm --cap_add=SYS_ADMIN --net=host -v ${LOGDIR}:/var/log -v ${DATADIR}:/var/lib --name ${NAME} ${IMAGE}```
+```LABEL RUN /usr/bin/docker run -t -i --rm \${OPT1} --cap_add=SYS_ADMIN --net=host -v ${LOGDIR}:/var/log -v ${DATADIR}:/var/lib --name ${NAME} ${IMAGE} \${OPT2} run.sh \${OPT3}```
 
 If this field does not exist, `atomic run` defaults to the following:
 ```/usr/bin/docker run -t -i --rm -v ${LOGDIR}:/var/log -v ${DATADIR}:/var/lib --name ${NAME} ${IMAGE}```
@@ -32,6 +32,9 @@ These defaults are suggested values for your container images.
 
 **IMAGE**
   The name and image specified via the command.
+
+**OPT1, OPT2, OPT3**
+  Additional options which can be specified via the command.
 
 **SUDO_UID**
   The `SUDO_UID` environment variable.  This is useful with the docker `-u` option for user space tools.  If the environment variable is not available, the value of `/proc/self/loginuid` is used.

--- a/docs/atomic-uninstall.1.md
+++ b/docs/atomic-uninstall.1.md
@@ -17,7 +17,7 @@ uninstall the image.
 
 If the container image has a LABEL UNINSTALL instruction like the following:
 
-```LABEL UNINSTALL /usr/bin/docker run -t -i --rm --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=${NAME} -e IMAGE=${IMAGE} -e CONFDIR=${CONFDIR} -e LOGDIR=${LOGDIR} -e DATADIR=${DATADIR} --name ${NAME} ${IMAGE} /bin/uninstall.sh```
+```LABEL UNINSTALL /usr/bin/docker run -t -i --rm \${OPT1} --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=${NAME} -e IMAGE=${IMAGE} -e CONFDIR=${CONFDIR} -e LOGDIR=${LOGDIR} -e DATADIR=${DATADIR} --name ${NAME} ${IMAGE} \${OPT2} /bin/uninstall.sh \${OPT3}```
 
 `atomic uninstall` will set the following environment variables for use in the command:
 
@@ -26,6 +26,9 @@ If the container image has a LABEL UNINSTALL instruction like the following:
 
 **IMAGE**
   The name and image specified via the command.
+
+**OPT1, OPT2, OPT3**
+  Additional options which can be specified via the command.
 
 **SUDO_UID**
   The `SUDO_UID` environment variable.  This is useful with the docker `-u` option for user space tools.  If the environment variable is not available, the value of `/proc/self/loginuid` is used.


### PR DESCRIPTION
@rhatdan 


The Labels look like below.
LABEL RUN  docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} run \${OPT3} /atomicapp

LABEL STOP docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} stop \${OPT3} /atomicapp

LABEL INSTALL docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run  --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} install \${OPT3} --destination /atomicapp /application-entity


Usage:
atomic --opt1="-p :5000" --opt2="-d" install submod/guestbookphp-app