### PR TITLE
Add IMAGE and NAME as environment variables

### DIFF
--- a/docs/atomic-install.1.md
+++ b/docs/atomic-install.1.md
@@ -16,11 +16,11 @@ IMAGE, if this field does not exist, `atomic install` will install the IMAGE
 
 If the container image has a LABEL INSTALL instruction like the following:
 
-```LABEL INSTALL /usr/bin/docker run -t -i --rm --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=NAME -e IMAGE=IMAGE -e CONFDIR=${CONFDIR} -e LOGDIR=${LOGDIR} -e DATADIR=${DATADIR} --name NAME IMAGE /bin/install.sh```
+```LABEL INSTALL /usr/bin/docker run -t -i --rm --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=${NAME} -e IMAGE=${IMAGE} -e CONFDIR=${CONFDIR} -e LOGDIR=${LOGDIR} -e DATADIR=${DATADIR} --name ${NAME} ${IMAGE} /bin/install.sh```
 
 `atomic install` will replace the NAME and IMAGE fields with the name and
 image specified via the command,  NAME will be replaced with IMAGE if it is
-not specified. `atomic install` will also pass in the CONFDIR, LOGDIR and DATADIR environment variables to the container.  Any additional arguments will be
+not specified. `atomic install` will pass in the CONFDIR, LOGDIR, DATADIR, NAME, and IMAGE environment variables to the container (the NAME variable will be set to IMAGE if not specified).  Any additional arguments will be
 appended to the command.
 
 # OPTIONS:

--- a/docs/atomic-run.1.md
+++ b/docs/atomic-run.1.md
@@ -18,14 +18,14 @@ IMAGE.
 
 If the container image has a LABEL RUN instruction like the following:
 
-```LABEL RUN /usr/bin/docker run -t -i --rm --cap_add=SYS_ADMIN --net=host -v ${LOGDIR}:/var/log -v ${DATADIR}:/var/lib --name NAME IMAGE```
+```LABEL RUN /usr/bin/docker run -t -i --rm --cap_add=SYS_ADMIN --net=host -v ${LOGDIR}:/var/log -v ${DATADIR}:/var/lib --name ${NAME} ${IMAGE}```
 
 If this field does not exist, `atomic run` defaults to the following:
-```/usr/bin/docker run -t -i --rm -v ${LOGDIR}:/var/log -v ${DATADIR}:/var/lib --name NAME IMAGE```
+```/usr/bin/docker run -t -i --rm -v ${LOGDIR}:/var/log -v ${DATADIR}:/var/lib --name ${NAME} ${IMAGE}```
 
 These defaults are suggested values for your container images.
 
-atomic will replace the NAME and IMAGE fields with the name and image specified via the command,  NAME will be replaced with IMAGE if it is not specified.
+atomic will replace the NAME and IMAGE fields with the name and image specified via the command,  NAME will be replaced with IMAGE if it is not specified.  Additionally, atomic will pass in the LOGDIR, DATADIR, CONFDIR, NAME, and IMAGE environment variables (with NAME defaulting to IMAGE if not set).
 
 # OPTIONS:
 **--help**
@@ -40,7 +40,7 @@ NAME will default to the IMAGENAME if it is not specified.
 
   The image will run with the following command:
   
-```/usr/bin/docker run -t -i --rm --privileged -v /:/host -v /run:/run --net=host --ipc=host --pid=host -e HOST=/host -e NAME=NAME -e IMAGE=IMAGE --name NAME IMAGE```
+```/usr/bin/docker run -t -i --rm --privileged -v /:/host -v /run:/run --net=host --ipc=host --pid=host -e HOST=/host -e NAME=${NAME} -e IMAGE=${IMAGE} --name ${NAME} ${IMAGE}```
 
 # HISTORY
 January 2015, Originally compiled by Daniel Walsh (dwalsh at redhat dot com)

--- a/docs/atomic-stop.1.md
+++ b/docs/atomic-stop.1.md
@@ -16,11 +16,11 @@ IMAGE.
 
 If the container image has a `LABEL STOP` instruction like the following:
 
-```CLABEL STOP /usr/bin/docker kill -s HUP --name NAME IMAGE```
+```CLABEL STOP /usr/bin/docker kill -s HUP --name ${NAME} ${IMAGE}```
 
 atomic would execute this command before stoping the container.
 
-atomic will replace the NAME and IMAGE fields with the name and image specified via the command,  NAME will be replaced with IMAGE if it is not specified.
+atomic will replace the NAME and IMAGE fields with the name and image specified via the command,  NAME will be replaced with IMAGE if it is not specified.  Additionally, atomic will pass in NAME and IMAGE as environment variables as well (with NAME defaulting to IMAGE if not set).
 
 If this field does not exist, `atomic stop` will just stop the container, if
 the container is running.

--- a/docs/atomic-uninstall.1.md
+++ b/docs/atomic-uninstall.1.md
@@ -17,10 +17,10 @@ uninstall the image.
 
 If the container image has a LABEL UNINSTALL instruction like the following:
 
-```LABEL UNINSTALL /usr/bin/docker run -t -i --rm --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=NAME -e IMAGE=IMAGE -e CONFDIR=${CONFDIR} -e LOGDIR=${LOGDIR} -e DATADIR=${DATADIR} --name NAME IMAGE /bin/uninstall.sh```
+```LABEL UNINSTALL /usr/bin/docker run -t -i --rm --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=${NAME} -e IMAGE=${IMAGE} -e CONFDIR=${CONFDIR} -e LOGDIR=${LOGDIR} -e DATADIR=${DATADIR} --name ${NAME} ${IMAGE} /bin/uninstall.sh```
 
 `atomic uninstall` will replace the NAME and IMAGE fields with the name and
-image specified via the command,  `atomic uninstall` will also pass in the CONFDIR, LOGDIR and DATADIR environment variables to the container. Any additional
+image specified via the command,  `atomic uninstall` will also pass in the CONFDIR, LOGDIR, DATADIR, IMAGE, and NAME environment variables to the container (with NAME defaulting to IMAGE if not set). Any additional
 arguments will be appended to the command.
 
 # OPTIONS:

--- a/test.sh
+++ b/test.sh
@@ -26,9 +26,9 @@ docker build -t atomic_busybox .
 ./atomic version atomic_busybox
 cat > Dockerfile <<EOF
 FROM busybox
-LABEL RUN /usr/bin/docker run -ti --rm IMAGE /bin/echo RUN
-LABEL INSTALL /usr/bin/docker run -ti --rm IMAGE /bin/echo INSTALL
-LABEL UNINSTALL /usr/bin/docker run -ti --rm IMAGE /bin/echo UNINSTALL
+LABEL RUN /usr/bin/docker run -ti --rm \${IMAGE} /bin/echo RUN
+LABEL INSTALL /usr/bin/docker run -ti --rm \${IMAGE} /bin/echo INSTALL
+LABEL UNINSTALL /usr/bin/docker run -ti --rm \${IMAGE} /bin/echo UNINSTALL
 LABEL Name Atomic Busybox
 LABEL Version 1.0
 LABEL Release 1.0


### PR DESCRIPTION
This commit adds `IMAGE` and `NAME` as environment variables
passed to install, uninstall, stop, and run (similarly to
`CONFDIR`, `DATADIR`, and `LOGDIR`).  This allows users to write
`NAME=${NAME}` instead of `NAME=NAME`, and also enables `${NAME}`
and `${IMAGE}` to be used in arbitrary parts of the commands.

This commit is based off of ideas from #59 