### PR TITLE
atomic mount --live (and other improvements)

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -1,0 +1,67 @@
+import collections
+import docker
+import selinux
+import subprocess
+
+from fnmatch import fnmatch as matches
+
+"""Atomic Utility Module"""
+
+ReturnTuple = collections.namedtuple('ReturnTuple',
+                                     ['return_code', 'stdout', 'stderr'])
+
+
+def image_by_name(img_name):
+    """
+    Returns a list of image data for images which match img_name.
+    """
+    def _decompose(compound_name):
+        """ '[reg/]repo[:tag]' -> (reg, repo, tag) """
+        reg, repo, tag = '', compound_name, ''
+        if '/' in repo:
+            reg, repo = repo.split('/', 1)
+        if ':' in repo:
+            repo, tag = repo.rsplit(':', 1)
+        return reg, repo, tag
+
+    c = docker.Client()
+
+    i_reg, i_rep, i_tag = _decompose(img_name)
+    # Correct for bash-style matching expressions.
+    if not i_reg:
+        i_reg = '*'
+    if not i_tag:
+        i_tag = '*'
+
+    images = c.images(all=False)
+    valid_images = []
+    for i in images:
+        for t in i['RepoTags']:
+            reg, rep, tag = _decompose(t)
+            if matches(reg, i_reg) \
+                    and matches(rep, i_rep) \
+                    and matches(tag, i_tag):
+                valid_images.append(i)
+                break
+    return valid_images
+
+
+def subp(cmd):
+    """
+    Run a command as a subprocess.
+    Return a triple of return code, standard out, standard err.
+    """
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
+    out, err = proc.communicate()
+    return ReturnTuple(proc.returncode, stdout=out, stderr=err)
+
+
+def default_container_context():
+    if selinux.is_selinux_enabled() != 0:
+        fd = open(selinux.selinux_lxc_contexts_path())
+        for i in fd.readlines():
+            name, context = i.split("=")
+            if name.strip() == "file":
+                return context.strip("\n\" ")
+    return ""

--- a/atomic
+++ b/atomic
@@ -99,9 +99,18 @@ if __name__ == '__main__':
     mountp.add_argument("-o", "--options", dest="options",
                       default="",
                       help=_("comma-separated list of mount options, "
-                          "defaults are 'ro,nodev,nosuid'"),)
+                          "defaults are 'ro,nodev,nosuid'"))
+    mountp.add_argument("--live", dest="live",
+                      action="store_true",
+                      help=_("mount a running container 'live', allowing "
+                          "modification of the contents."))
+    mountp.add_argument("--no-bind", dest="no_bind",
+                      action="store_true",
+                      help=_("do not bind the container's 'rootfs' directory"
+                          " to the mountpoint."))
     mountp.add_argument("image", help=_("image/container id"))
-    mountp.add_argument("mountpoint", help=_("filesystem location to mount the image/container"))
+    mountp.add_argument("mountpoint", help=_("filesystem location to mount "
+                          "the image/container"))
 
     stopp = subparser.add_parser("stop",
                                 help=_("execute container image stop method"),

--- a/bash/atomic
+++ b/bash/atomic
@@ -260,6 +260,8 @@ _atomic_mount() {
 	"
 	local all_options="$options_with_args
 		--help
+		--live
+		--no-bind
 	"
 
 	local options_with_args_glob=$(__atomic_to_extglob "$options_with_args")

--- a/docs/atomic-mount.1.md
+++ b/docs/atomic-mount.1.md
@@ -6,20 +6,41 @@ atomic-mount - Mount Images/Containers to Filesystem
 
 # SYNOPSIS
 **atomic mount**
-[**-o**|**--options** *OPTIONS*]
-[REGISTRY/]IMAGE[:TAG]|ID
+[**--live** | [**-o**|**--options** *OPTIONS*]]
+[**--no-bind**]
+[REGISTRY/]REPO[:TAG]|UUID|NAME
 DIRECTORY
 
 # DESCRIPTION
-**atomic mount** attempts to mount the filesystem belonging to a given
-container/image ID or IMAGE to the given DIRECTORY. Optionally, provide a
-registry and tag to use a specific version of an image.
+**atomic mount** attempts to mount the underlying filesystem of a container or
+image into the host filesystem. Accepts one of image UUID, container UUID,
+container NAME, or image REPO (optionally with registry and tag information).
+If the given UUID or NAME is a container, and **--live** is not set, then
+*atomic mount* will create a snapshot of the container by commiting it to a
+temporary image and spawning a temporary container from that image. If UUID or
+REPO refers to an image, then *atomic mount* will simply create a temporary
+container from the given image. All temporary artifacts are cleaned upon
+*atomic unmount*.
 
 # OPTIONS
 **-o|--options** *OPTIONS*
-    Specify options to be passed to *mount*. Any options accepted by mount
-are valid. Default settings are: 'ro,nodev,nosuid'. If this flag is specified,
-no defaults are assumed. The 'rw' flag is *illegal* and will cause an error.
+Specify options to be passed to *mount*. All options accepted by the 'mount'
+command are valid. The default mount options (if the **--live** flag is unset)
+are: 'ro,nodev,nosuid'. These flags must be overridden explicitly using 'rw',
+'dev', and 'suid', respectively. Use of the 'rw' flag is discouraged, as writes
+into the atomic temporary containers are never preserved. Use of this option
+conflicts with **--live**, as live containers have predetermined, immutable
+mount options.
+
+**--live**
+Mount a container live, writable, and synchronized. This option allows the user
+to modify the container's contents as it runs or update the container's
+software without rebuilding the container. If live mode is used, no mount
+options may be provided.
+
+**--no-bind**
+By default, atomic mount binds '/rootfs' to '/' within the container. This
+option disables that behavior.
 
 # HISTORY
 June 2015, Originally compiled by William Temple (wtemple at redhat dot com)


### PR DESCRIPTION
Changes:
- Added --live option to mount running containers. Default behavior is to mount *snapshots*, rather than live.
- Refactored to avoid creating new thin devices. Now we just use docker's or create identical ones.
- By default image-mounts create a container tagged with a sentinel environment variable.
- Non-live container mounts commit the container to an image (tagged with a sentinel label) then image-mount it. On cleanup, the container mounted at the mount path and its image are inspected for sentinel values and removed if they are tagged.
- a --no-bind option was added to prevent atomic mount from bind-mounting 'mntpoint/rootfs' to 'mntpoint'. The default behavior is to perform the bind-mount.
- More easily support extension to other backends. e.g. to support the btrfs backend, one only needs to write `DockerMount._mount_btrfs()`, and the mount command will automatically invoke that method when on the btrfs backend. At the moment, only LVM devicemapper is supported.
- If a --live mount is specified, setting any mount option is illegal.
- Setting the 'context' mount option is forbidden. Security context is provided by the container.

**NOTE**: strongly recommended to add '--storage-opt dm.use_deferred_removal=true' to docker daemon command line. It sounds like this setting will become a default in at least the Red Hat distributions if not upstream.

Signed-off-by: William Temple <wtemple@redhat.com>