### PR TITLE
Add SUDO_UID and SUDO_GID variable substitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ directories if necessary.
 In my example the INSTALL method will execute the install.sh which we add to
 the image.  The root sub directory contains the following scripts:
 
+The `atomic install` will set the following environment variables for use in the command:
+
+**SUDO_UID**
+  The `SUDO_UID` environment variable.  This is useful with the docker `-u` option for user space tools.  If the environment variable is not available, the value of `/proc/self/loginuid` is used.
+
+**SUDO_GID**
+  The `SUDO_GID` environment variable.  This is useful with the docker `-u` option for user space tools.  If the environment variable is not available, the default GID of the value for `SUDO_UID` is used.  If this value is not available, the value of `/proc/self/loginuid` is used.
+
 cat root/usr/bin/install.sh
 ```
 #!/bin/sh

--- a/docs/atomic-install.1.md
+++ b/docs/atomic-install.1.md
@@ -18,10 +18,21 @@ If the container image has a LABEL INSTALL instruction like the following:
 
 ```LABEL INSTALL /usr/bin/docker run -t -i --rm --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=${NAME} -e IMAGE=${IMAGE} -e CONFDIR=${CONFDIR} -e LOGDIR=${LOGDIR} -e DATADIR=${DATADIR} --name ${NAME} ${IMAGE} /bin/install.sh```
 
-`atomic install` will replace the NAME and IMAGE fields with the name and
-image specified via the command,  NAME will be replaced with IMAGE if it is
-not specified. `atomic install` will pass in the CONFDIR, LOGDIR, DATADIR, NAME, and IMAGE environment variables to the container (the NAME variable will be set to IMAGE if not specified).  Any additional arguments will be
-appended to the command.
+`atomic install` will set the following environment variables for use in the command:
+
+**NAME**
+  The name specified via the command.  NAME will be replaced with IMAGE if it is not specified.
+
+**IMAGE**
+  The name and image specified via the command.
+
+**SUDO_UID**
+  The `SUDO_UID` environment variable.  This is useful with the docker `-u` option for user space tools.  If the environment variable is not available, the value of `/proc/self/loginuid` is used.
+
+**SUDO_GID**
+  The `SUDO_GID` environment variable.  This is useful with the docker `-u` option for user space tools.  If the environment variable is not available, the default GID of the value for `SUDO_UID` is used.  If this value is not available, the value of `/proc/self/loginuid` is used.
+
+`atomic install` will also pass in the CONFDIR, LOGDIR and DATADIR environment variables to the container.  Any additional arguments will be appended to the command.
 
 # OPTIONS:
 **--help**

--- a/docs/atomic-run.1.md
+++ b/docs/atomic-run.1.md
@@ -25,7 +25,19 @@ If this field does not exist, `atomic run` defaults to the following:
 
 These defaults are suggested values for your container images.
 
-atomic will replace the NAME and IMAGE fields with the name and image specified via the command,  NAME will be replaced with IMAGE if it is not specified.  Additionally, atomic will pass in the LOGDIR, DATADIR, CONFDIR, NAME, and IMAGE environment variables (with NAME defaulting to IMAGE if not set).
+`atomic run` will set the following environment variables for use in the command:
+
+**NAME**
+  The name specified via the command.  NAME will be replaced with IMAGE if it is not specified.
+
+**IMAGE**
+  The name and image specified via the command.
+
+**SUDO_UID**
+  The `SUDO_UID` environment variable.  This is useful with the docker `-u` option for user space tools.  If the environment variable is not available, the value of `/proc/self/loginuid` is used.
+
+**SUDO_GID**
+  The `SUDO_GID` environment variable.  This is useful with the docker `-u` option for user space tools.  If the environment variable is not available, the default GID of the value for `SUDO_UID` is used.  If this value is not available, the value of `/proc/self/loginuid` is used.
 
 # OPTIONS:
 **--help**

--- a/docs/atomic-stop.1.md
+++ b/docs/atomic-stop.1.md
@@ -20,7 +20,19 @@ If the container image has a `LABEL STOP` instruction like the following:
 
 atomic would execute this command before stoping the container.
 
-atomic will replace the NAME and IMAGE fields with the name and image specified via the command,  NAME will be replaced with IMAGE if it is not specified.  Additionally, atomic will pass in NAME and IMAGE as environment variables as well (with NAME defaulting to IMAGE if not set).
+`atomic stop` will set the following environment variables for use in the command:
+
+**NAME**
+  The name specified via the command.  NAME will be replaced with IMAGE if it is not specified.
+
+**IMAGE**
+  The name and image specified via the command.
+
+**SUDO_UID**
+  The `SUDO_UID` environment variable.  This is useful with the docker `-u` option for user space tools.  If the environment variable is not available, the value of `/proc/self/loginuid` is used.
+
+**SUDO_GID**
+  The `SUDO_GID` environment variable.  This is useful with the docker `-u` option for user space tools.  If the environment variable is not available, the default GID of the value for `SUDO_UID` is used.  If this value is not available, the value of `/proc/self/loginuid` is used.
 
 If this field does not exist, `atomic stop` will just stop the container, if
 the container is running.

--- a/docs/atomic-uninstall.1.md
+++ b/docs/atomic-uninstall.1.md
@@ -19,9 +19,21 @@ If the container image has a LABEL UNINSTALL instruction like the following:
 
 ```LABEL UNINSTALL /usr/bin/docker run -t -i --rm --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=${NAME} -e IMAGE=${IMAGE} -e CONFDIR=${CONFDIR} -e LOGDIR=${LOGDIR} -e DATADIR=${DATADIR} --name ${NAME} ${IMAGE} /bin/uninstall.sh```
 
-`atomic uninstall` will replace the NAME and IMAGE fields with the name and
-image specified via the command,  `atomic uninstall` will also pass in the CONFDIR, LOGDIR, DATADIR, IMAGE, and NAME environment variables to the container (with NAME defaulting to IMAGE if not set). Any additional
-arguments will be appended to the command.
+`atomic uninstall` will set the following environment variables for use in the command:
+
+**NAME**
+  The name specified via the command.  NAME will be replaced with IMAGE if it is not specified.
+
+**IMAGE**
+  The name and image specified via the command.
+
+**SUDO_UID**
+  The `SUDO_UID` environment variable.  This is useful with the docker `-u` option for user space tools.  If the environment variable is not available, the value of `/proc/self/loginuid` is used.
+
+**SUDO_GID**
+  The `SUDO_GID` environment variable.  This is useful with the docker `-u` option for user space tools.  If the environment variable is not available, the default GID of the value for `SUDO_UID` is used.  If this value is not available, the value of `/proc/self/loginuid` is used.
+
+`atomic uninstall` will also pass in the CONFDIR, LOGDIR and DATADIR environment variables to the container. Any additional arguments will be appended to the command.
 
 # OPTIONS:
 **-f** **--force**


### PR DESCRIPTION
These substitutions are useful with docker -u SUDO_UID:SUDO_GID ...
for userspace tools such as format translators