### PR TITLE
Bugfix atomic CLI for users without GraphDriver API exposure, simpler mount options

### DIFF
--- a/docs/atomic-mount.1.md
+++ b/docs/atomic-mount.1.md
@@ -26,11 +26,11 @@ container from the given image. All temporary artifacts are cleaned upon
 **-o|--options** *OPTIONS*
 Specify options to be passed to *mount*. All options accepted by the 'mount'
 command are valid. The default mount options (if the **--live** flag is unset)
-are: 'ro,nodev,nosuid'. These flags must be overridden explicitly using 'rw',
-'dev', and 'suid', respectively. Use of the 'rw' flag is discouraged, as writes
-into the atomic temporary containers are never preserved. Use of this option
-conflicts with **--live**, as live containers have predetermined, immutable
-mount options.
+are: 'ro,nodev,nosuid'. If the **-o** flag is specified, then no default
+options are assumed. Use of the 'rw' flag is discouraged, as writes into the
+atomic temporary containers are never preserved. Use of this option conflicts
+with **--live**, as live containers have predetermined, immutable mount
+options.
 
 **--live**
 Mount a container live, writable, and synchronized. This option allows the user


### PR DESCRIPTION
There is a bug in the atomic cli which prevents users who do not have the GraphDriver API exposure patch from mounting containers. This patch fixes that issue.

In addition, it also fixes a but in mount options in such a way that default options will be honored only if no mount options are provided. The old logic was cumbersome, and would have been prohibitive of any other Graphdriver backend having its own set of default options. The man pages have been updated to reflect the simpler behavior.

Signed-off-by: William Temple <wtemple@redhat.com>