### PR TITLE
Atomic should print error message only not usage on error

### DIFF
--- a/atomic
+++ b/atomic
@@ -45,8 +45,8 @@ except IOError:
 
 class HelpByDefaultArgumentParser(argparse.ArgumentParser):
     def error(self, message):
-        self.print_help()
-        sys.stderr.write('\nerror: %s\n' % message)
+        sys.stderr.write('%s: %s\n' % (sys.argv[0], message))
+        sys.stderr.write("Try '%s --help' for more information.\n" % self.prog)
         sys.exit(2)
 
 if __name__ == '__main__':


### PR DESCRIPTION
I got docker to merge a similar request to this.   We should follow suit.

Problem with printing usage message is it can cause confusion to the user.

ls --foobar 
ls: unrecognized option '--foobar'
Try 'ls --help' for more information.
