### PR TITLE
Add support for listing images for atomic

### DIFF
--- a/atomic
+++ b/atomic
@@ -86,6 +86,12 @@ if __name__ == '__main__':
                                     help=_("execute container image install method"),
                                     epilog="atomic install attempts to read the LABEL INSTALL field in the image, if it does not exist atomic will just pull the image on to your machine.  You could add a LABEL INSTALL command to your Dockerfile like: 'LABEL INSTALL %s'" % atomic.print_install() )
 
+    imagesp = subparser.add_parser("images",
+                                   help=_("list container images on your system"), 
+                                   epilog="atomic images by default will list all installed container images on your system.  Using the --prune option, will free up disk space deleting unused 'dangling' images")
+    imagesp.set_defaults(func=atomic.images)
+    imagesp.add_argument("--prune", action="store_true", help="prune dangling images")
+
     installp.set_defaults(func=atomic.install)
     installp.add_argument("--opt1", dest="opt1", help="additional arguments to be passed as ${OPT1} for install command.")
     installp.add_argument("--opt2", dest="opt2", help="additional arguments to be passed as ${OPT2} for install command.")

--- a/docs/atomic-images.1.md
+++ b/docs/atomic-images.1.md
@@ -1,0 +1,33 @@
+% ATOMIC(1) Atomic Man Pages
+% Dan Walsh
+% July 2015
+# NAME
+atomic-images - list locally installed container images
+
+# SYNOPSIS
+**atomic images**
+[**-h**]
+IMAGE
+
+# DESCRIPTION
+**atomic images** by default will list all installed container images on your
+system.
+
+Using the ```--prune``` option, will free up disk space deleting unused
+`dangling` images.
+
+`Dangling` images are images with no name/tag which are not used by other images.
+Since they are not used, they waste system space.  They are usually caused
+by doing docker builds to update a container wither newer layered images.
+
+A `*` in the first column indicates a dangling image.
+
+# OPTIONS:
+**--help**
+  Print usage statement
+
+**--prune**
+  Prune dangling images
+
+# HISTORY
+July 2015, Originally compiled by Daniel Walsh (dwalsh at redhat dot com)


### PR DESCRIPTION
This patch set adds the images keyword.  This will list all local
images by default.

You can also use the --prune option to delete any dangling images,
freeing up disk space.

In the future we would like to expand to support other frameworks
besides docker to list any other local container images.