### PR TITLE
BindTo docker in example systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ cat root/etc/systemd/system/httpd_template.service
 [Unit]
 Description=The Apache HTTP Server for TEMPLATE
 After=docker.service
+BindTo=docker.service
 
 [Service]
 ExecStart=/usr/bin/docker start TEMPLATE


### PR DESCRIPTION
BindTo=docker.service ensures, that the service is stopped or restarted
whenever docker is. This is more sane behavior if no docker restart policy is
given (i.e. --restart=always).