### PR TITLE
Tell pylint to ignore unexpected-keyword-arg

### DIFF
--- a/atomic
+++ b/atomic
@@ -32,6 +32,7 @@ PROGNAME="atomic"
 gettext.bindtextdomain(PROGNAME, "/usr/share/locale")
 gettext.textdomain(PROGNAME)
 try:
+    #pylint: disable=unexpected-keyword-arg
     gettext.install(PROGNAME,
                     unicode=True,
                     codeset = 'utf-8')


### PR DESCRIPTION
gettext.install() has changed between Python 2 and 3 and no longer has
an argument called unicode. This is handled by a try-except when the code
is executed, but pylint doesn't know that. By adding this comment, it will
stop reporting it as an error.