### PR TITLE
atomic.sysconfig: leave default TOOLSIMG undefined

### DIFF
--- a/atomic.sysconfig
+++ b/atomic.sysconfig
@@ -1,5 +1,5 @@
 # Specify the tools package to be used for missing commands
 # A missing command on an atomic host platform will execute
-# atomic run --spc ${TOOLSIMG} COMMAND
+# atomic run ${TOOLSIMG} COMMAND
 # If the TOOLSIMG is defined
-# export TOOLSIMG=rhel7/rhel-tools
+# export TOOLSIMG=


### PR DESCRIPTION
We leave it up to each distro to configure the TOOLSIMG to be used.

Related PR: https://github.com/projectatomic/atomic/pull/91