### PR TITLE
Bugfix for docker create_container API change.

### DIFF
--- a/Atomic/mount.py
+++ b/Atomic/mount.py
@@ -174,8 +174,7 @@ class DockerMount(Mount):
             return self.client.create_container(
                                  image=iid, command='/bin/true',
                                  environment=['_ATOMIC_TEMP_CONTAINER'],
-                                 detach=True, mem_limit='4m',
-                                 network_disabled=True)['Id']
+                                 detach=True, network_disabled=True)['Id']
         except docker.errors.APIError as ex:
             raise MountError('Error creating temporary container:\n' + str(ex))
 


### PR DESCRIPTION
In docker API version 1.19, mem_limit was moved to the host_config section of the container metadata. This changed the docker-py api and attempts to mount an image or non-live container would result in the following error:

`mem_limit has been moved to host_config in API version 1.19`

This patch addresses the problem by removing the memory limit, which was probably unnecessary in the first place, as these containers are only temporary for the purposes of mounting the internal filesystems.

Signed-off-by: William Temple <wtemple@redhat.com>