### PR TITLE
Integrate remote inspection with Atomic info.

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -52,7 +52,7 @@ def image_by_name(img_name):
     return valid_images
 
 
-def subp(cmd): # pragma: no cover
+def subp(cmd):
     """
     Run a command as a subprocess.
     Return a triple of return code, standard out, standard err.
@@ -63,7 +63,7 @@ def subp(cmd): # pragma: no cover
     return ReturnTuple(proc.returncode, stdout=out, stderr=err)
 
 
-def default_container_context(): # pragma: no cover
+def default_container_context():
     if selinux.is_selinux_enabled() != 0:
         fd = open(selinux.selinux_lxc_contexts_path())
         for i in fd.readlines():

--- a/atomic
+++ b/atomic
@@ -81,6 +81,9 @@ if __name__ == '__main__':
                                  help=_("display label information about an image"),
                                  epilog="atomic info attempts to read and display the LABEL information about an image")
     infop.set_defaults(func=atomic.info)
+    infop.add_argument("--remote", dest="force_remote_info",
+                       action='store_true', default=False,
+                       help=_('ignore local images and only scan registries'))
     infop.add_argument("image", help=_("container image"))
 
     installp = subparser.add_parser("install",

--- a/docs/atomic-info.1.md
+++ b/docs/atomic-info.1.md
@@ -7,14 +7,19 @@ atomic-info - Display LABEL information about an image
 # SYNOPSIS
 **atomic info**
 [**-h**]
+[**--remote**]
 IMAGE
 
 # DESCRIPTION
-**atomic info** displays the LABEL fields within an image
+**atomic info** displays the LABEL fields within an image. By default, it
+will check first for a local image and then all configured registries.
 
 # OPTIONS:
 **--help**
   Print usage statement
+
+**--remote**
+  Ignore all local images, only search configured registries.
 
 # HISTORY
 January 2015, Originally compiled by Daniel Walsh (dwalsh at redhat dot com)

--- a/test.sh
+++ b/test.sh
@@ -68,28 +68,31 @@ make_docker_images
 # Python unit tests.
 echo "UNIT TESTS:"
 
-COVERAGE="/usr/bin/coverage"
-if [[ ! -x "${COVERAGE}" ]]; then
+COVERAGE_BIN="/usr/bin/coverage"
+if [[ ! -x "${COVERAGE_BIN}" ]]; then
     # The executable is "coverage2" on systems with default python3 and no
     # python3 install.
-    COVERAGE="/usr/bin/coverage2"
+    COVERAGE_BIN="/usr/bin/coverage2"
 fi
 
 set +e
+COVERAGE="${COVERAGE_BIN}
+run
+--source=./Atomic/
+--branch"
 
-${COVERAGE} run --source=./Atomic/ --branch  -m unittest discover \
-	./tests/unit | tee -a ${LOG}
+${COVERAGE} -m unittest discover ./tests/unit/ | tee -a ${LOG}
 _UNIT_FAIL="$?"
+
 set -e
 
-echo "Coverage report:" | tee -a ${LOG}
-
-${COVERAGE} report | tee -a ${LOG}
-
 # CLI integration tests.
-# TODO: I would like to be able to include CLI tests in the coverage report.
 let failures=0 || true
 printf "\nINTEGRATION TESTS:\n" | tee -a ${LOG}
+
+export ATOMIC="${COVERAGE}
+--append
+atomic"
 
 for tf in `find ./tests/integration/ -name test_*.sh`; do
     printf "Running test $(basename ${tf})...\t\t"
@@ -101,6 +104,10 @@ for tf in `find ./tests/integration/ -name test_*.sh`; do
         let "failures += 1"
     fi
 done
+
+echo "Coverage report:" | tee -a ${LOG}
+
+${COVERAGE_BIN} report | tee -a ${LOG}
 
 if [[ "${failures}" -eq "0" ]]; then
     if [[ $_UNIT_FAIL -eq 0 ]]; then

--- a/tests/integration/test_info.sh
+++ b/tests/integration/test_info.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -x
+set -euo pipefail
+IFS=$'\n\t'
+
+EXPECTED_T1="Checksum: $(sha256sum ./tests/test-images/Dockerfile.1)"
+
+validTest1 () {
+    for e in ${TEST_1}; do
+        [ "$e" = "${EXPECTED_T1}" ] && return 0;
+    done
+    return 1
+}
+
+TEST_1=`${ATOMIC} info atomic-test-1`
+TEST_RHEL_REMOTE=`${ATOMIC} info --remote rhel7:7.1-9`
+TEST_RHEL=`${ATOMIC} info rhel7:7.1-9`
+
+set +e
+
+TEST_DOES_NOT_EXIST=`${ATOMIC} info this-is-not-a-real-image`
+
+set -e
+
+echo $TEST_1
+
+if [[ "${TEST_RHEL_REMOTE}" != "${TEST_RHEL}" ]]; then
+    exit 1
+fi
+
+if [[ "${TEST_DOES_NOT_EXIST}" != "" ]]; then
+    exit 1
+fi
+
+validTest1
+
+if [[ $? -ne 0 ]]; then
+    exit 1
+fi

--- a/tests/integration/test_mount.sh
+++ b/tests/integration/test_mount.sh
@@ -36,24 +36,24 @@ cleanup_container () {
 }
 trap cleanup_container EXIT
 
-./atomic mount ${id} ${MNT_WORK}/container
-./atomic mount ${INAME} ${MNT_WORK}/image
+${ATOMIC} mount ${id} ${MNT_WORK}/container
+${ATOMIC} mount ${INAME} ${MNT_WORK}/image
 
 # Expect failure
 set +e
-./atomic mount ${id} --live ${MNT_WORK}/container
+${ATOMIC} mount ${id} --live ${MNT_WORK}/container
 if [ "$?" -eq "0" ]; then
     exit 1
 fi
-./atomic mount ${INAME} --live ${MNT_WORK}/image
+${ATOMIC} mount ${INAME} --live ${MNT_WORK}/image
 if [ "$?" -eq "0" ]; then
     exit 1
 fi
 set -e
 
 cleanup_mount () {
-    ./atomic unmount ${MNT_WORK}/container
-    ./atomic unmount ${MNT_WORK}/image
+    ${ATOMIC} unmount ${MNT_WORK}/container
+    ${ATOMIC} unmount ${MNT_WORK}/image
     cleanup_container
 }
 trap cleanup_mount EXIT

--- a/tests/integration_template.sh
+++ b/tests/integration_template.sh
@@ -8,8 +8,8 @@ IFS = $'\n\t'
 # testing: PYTHONPATH (python module import path
 #          WORK_DIR   (a directory that is safe to modify)
 #          DOCKER     (the docker executable location)
-#          SECRET     (a generated sha256 hash inserted into test
-#                      containers)
+#          ATOMIC     (an invocation of 'atomic' which measures code coverage)
+#          SECRET     (a generated sha256 hash inserted into test containers)
 
 # In addition, the test harness creates some images for use in testing.
 #   See tests/test-images/


### PR DESCRIPTION
Rather than pull a repository when it isn't found locally, with this patch the `atomic info` command will now use remote inspection. It will first attempt to find the image locally, and then will query configured registries.

Additionally, a `--remote` flag will force `atomic info` to use only remote repositories.

While writing tests for this feature, I also changed the invocation of `atomic` in the test harness. As a result, the test harness is now capable of including the CLI integration tests in the coverage report.

Tested against `rhatdan/docker:fedora-1.7`

Signed-off-by: William Temple <wtemple@redhat.com>