### PR TITLE
Allow arbitrary files in test images.

### DIFF
--- a/tests/integration/test_info.sh
+++ b/tests/integration/test_info.sh
@@ -6,7 +6,7 @@ EXPECTED_T1="Checksum: $(sha256sum ./tests/test-images/Dockerfile.1)"
 
 validTest1 () {
     for e in ${TEST_1}; do
-        [ "$e" = "${EXPECTED_T1}" ] && return 0;
+        [[ $e = ${EXPECTED_T1}* ]] && return 0;
     done
     return 1
 }

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -18,7 +18,7 @@ class TestAtomicUtil(unittest.TestCase):
                              for m in matches]))
 
     def test_image_by_name_tag_glob(self):
-        matches = util.image_by_name('busybox:*atest*')
+        matches = util.image_by_name('/busybox:*atest*')
         self.assertTrue(len(matches) == 1)
 
     def test_image_by_name_registry_match(self):


### PR DESCRIPTION
This patch will allow arbitrary files to be inserted into the test images.

If you have a file hierarchy that looks like this:
- test-images/
    - Dockerfile.\<id\>
    - Dockerfile.\<id\>.d/
        - foo

Then the directory `Dockerfile.<id>.d` will be available to the image at build time, and can be added to the image, e.g. (with an \<id\> of 'foo') as
`Dockerfile.foo`:
```
FROM rhel7:7.1-9
MAINTAINER "William Temple <wtemple at redhat dot com>"

ADD ./Dockerfile.foo.d/some_script.sh /usr/bin/some_script
RUN "chmod +x /usr/bin/some_script"
```

The script will also now rebuild any test-images whose files have changed.

@rhatdan RFC. I think this is the cleanest way to add arbitrary files to these test images.

@sallyom This should enable you to add scripts/etc. to the test images, and you should then be able to take the "docker build" logic out of your test script.

Signed-off-by: William Temple <wtemple@redhat.com>