### PR TITLE
Bugfix atomic mount command & incorrect test configuration

### DIFF
--- a/Atomic/mount.py
+++ b/Atomic/mount.py
@@ -418,7 +418,7 @@ class DockerMount(Mount):
         dev = Mount.get_dev_at_mountpoint(self.mountpoint)
 
         dev_name = dev.replace('/dev/mapper/', '')
-        if not dev_name.startswith('docker-'):
+        if not dev_name.startswith(pool.rsplit('-', 1)[0]):
             raise MountError('Device mounted at {} is not a docker container.'
                              ''.format(self.mountpoint))
 

--- a/tests/integration/test_info.sh
+++ b/tests/integration/test_info.sh
@@ -12,8 +12,8 @@ validTest1 () {
 }
 
 TEST_1=`${ATOMIC} info atomic-test-1`
-TEST_RHEL_REMOTE=`${ATOMIC} info --remote rhel7:7.1-9`
-TEST_RHEL=`${ATOMIC} info rhel7:7.1-9`
+TEST_CENTOS_REMOTE=`${ATOMIC} info --remote centos:latest`
+TEST_CENTOS=`${ATOMIC} info centos:latest`
 
 set +e
 
@@ -23,7 +23,7 @@ set -e
 
 echo $TEST_1
 
-if [[ "${TEST_RHEL_REMOTE}" != "${TEST_RHEL}" ]]; then
+if [[ "${TEST_CENTOS_REMOTE}" != "${TEST_CENTOS}" ]]; then
     exit 1
 fi
 


### PR DESCRIPTION
Bugfix for atomic mount not detecting the correct docker thin-pool device prefix and failing to recognize containers mounted as docker containers. Also changed test_info.sh to use CentOS rather than RHEL images, as the test harness was changed to ensure that the test environment contains a CentOS image, but not necessarily a RHEL image.

Signed-off-by: William Temple <wtemple@redhat.com>