### PR TITLE
atomic: add missing bytes unit

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -26,7 +26,7 @@ IMAGES = []
 
 def convert_size(size):
     if size > 0:
-        size_name = ("KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
+        size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
         i = int(math.floor(math.log(size, 1000)))
         p = math.pow(1000, i)
         s = round(size/p, 2)
@@ -567,14 +567,14 @@ class Atomic(object):
                 self.d.remove_image(i, force=True)
             return
 
-        self.writeOut(" %-25s %-19s %.12s            %-19s %-10s" %
+        self.writeOut(" %-35s %-19s %.12s            %-19s %-10s" %
                       ("REPOSITORY", "TAG", "IMAGE ID", "CREATED",
                        "VIRTUAL SIZE"))
 
         for image in self.d.images():
             repo, tag = image["RepoTags"][0].split(":")
             self.writeOut(
-                "%s%-25s %-19s %.12s        %-19s %-12s" %
+                "%s%-35s %-19s %.12s        %-19s %-12s" %
                 (self.dangling(repo), repo, tag, image["Id"],
                  time.strftime("%F %H:%M",
                                time.localtime(image["Created"])),


### PR DESCRIPTION
The size_name tuple missed "B" bytes unit option in convert_size(),
and the output of images are not good if the REPOSITORY name is
a little long such as registry.access.redhat.com/rhel7, it looks
like this:
```shell
 REPOSITORY                TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
 docker-dev                master              bffd816efbfe        2015-06-09 18:15    1.58 TB
*<none>                    <none>              3439600f6aa8        2015-06-09 17:39    188.31 GB
*<none>                    <none>              8df315cf193a        2015-06-09 17:24    188.31 GB
 docker.io/ubuntu          14.04               fa81ed084842        2015-06-01 08:00    188.28 GB
 docker.io/busybox         latest              8c2e06607696        2015-04-18 06:01    2.43 GB
 registry.access.redhat.com/rhel7 latest              10acc31def5d        2015-02-05 23:04    154.11 GB
```
With the patch, the output of atomic images looks like this:
```shell
 REPOSITORY                          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
 docker-dev                          master              bffd816efbfe        2015-06-09 18:15    1.58 GB
*<none>                              <none>              3439600f6aa8        2015-06-09 17:39    188.31 MB
*<none>                              <none>              8df315cf193a        2015-06-09 17:24    188.31 MB
 docker.io/ubuntu                    latest              fa81ed084842        2015-06-01 08:00    188.28 MB
 docker.io/busybox                   latest              8c2e06607696        2015-04-18 06:01    2.43 MB
 registry.access.redhat.com/rhel7    latest              10acc31def5d        2015-02-05 23:04    154.11 MB
```
Signed-off-by: Alex Jia <ajia@redhat.com>