### PR TITLE
Append command to container run method when container is not running.

### DIFF
--- a/atomic
+++ b/atomic
@@ -194,7 +194,10 @@ if __name__ == '__main__':
                              atomic.print_spc()))
     runp.add_argument("image", help=_("container image"))
     runp.add_argument("command", nargs=argparse.REMAINDER,
-                      help=_("command to execute within the container"))
+                      help=_("command to execute within the container. "
+                             "If container is not running, command is appended"
+                             "to the image run method"))
+
     runp.add_argument("--display",
                       default=False,
                       action="store_true",


### PR DESCRIPTION
We have two cases when calling atomic run, In one case the container
exists and we will just execute the COMMAND into the container.

If the container is not running, we want to append the COMMAND onto the
container RUN method, to allow more complex interaction.

For example if i had container image TEST that had the run label:

LABEL RUN="docker run -ti \${IMAGE} command"

atomic run TEST -h

Would execute

docker run -ti \${IMAGE} command -h

Displaying help information about the container.