### PR TITLE
Fix setup py (fixes #112)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+requests
+setuptools
+docker-py
+websocket-client>=0.11.0
+six>=1.3.0

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 
 # Author: Dan Walsh <dwalsh@redhat.com>
-import os
 from setuptools import setup
 import pkg_resources
 
 __version__ = pkg_resources.require('Atomic')[0].version
 
 setup(
-    name = "atomic", scripts=["atomic", "atomic_dbus.py"], version=__version__,
+    name="atomic", scripts=["atomic", "atomic_dbus.py"], version=__version__,
     description="Atomic Management Tool",
     author="Daniel Walsh", author_email="dwalsh@redhat.com",
     packages=["Atomic"],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,9 @@
 # Author: Dan Walsh <dwalsh@redhat.com>
 import os
 from distutils.core import setup
-from Atomic import __version__
+import pkg_resources
+
+__version__ = pkg_resources.require('Atomic')[0].version
 
 setup(
     name = "atomic", scripts=["atomic", "atomic_dbus.py"], version=__version__,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 # Author: Dan Walsh <dwalsh@redhat.com>
 import os
-from distutils.core import setup
+from setuptools import setup
 import pkg_resources
 
 __version__ = pkg_resources.require('Atomic')[0].version

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,15 @@ import pkg_resources
 
 __version__ = pkg_resources.require('Atomic')[0].version
 
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+
 setup(
     name="atomic", scripts=["atomic", "atomic_dbus.py"], version=__version__,
     description="Atomic Management Tool",
     author="Daniel Walsh", author_email="dwalsh@redhat.com",
     packages=["Atomic"],
+    install_requires=requirements,
     data_files=[('/etc/dbus-1/system.d/', ["org.atomic.conf"]),
                 ('/usr/share/dbus-1/system-services', ["org.atomic.service"]),
                 ('/usr/share/polkit-1/actions/', ["org.atomic.policy"]),


### PR DESCRIPTION
Fixes #112 
- Access ``setup.py`` without installing dependencies
- Make ``python setup.py`` develop work.
- Install python dependencies from ``requirements.txt`` on running ``setup.py {develop,install}``
- Fix linting errors