### PR TITLE
build-sys: Avoid self-dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 
 # Author: Dan Walsh <dwalsh@redhat.com>
+import sys
+import os
 from setuptools import setup
 import pkg_resources
 
-__version__ = pkg_resources.require('Atomic')[0].version
+sys.path.insert(0, os.path.abspath(os.getcwd()))
+from Atomic import __version__
 
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()


### PR DESCRIPTION
The earlier 58a6e0e4eff379578d497d67002cbef1438f8ab2 and later
455fc8499fee1b970eafd7f80942405ef6bef17f both break if the atomic
package is not actually installed on the system - as will be the case
with `mock/pbuilder` style builds.

It looks like OpenStack uses https://pypi.python.org/pypi/pbr which
presumably solves this problem.  I however am not super interested
right now in diving into that...I just want the thing to build.

So let's just hardcode the version number in two places for now.
Anyone who wants to improve this should probably look at PBR or
something other projects do.