### PR TITLE
Removes --name \${NAME} from atomic install and uninstall man pages

### DIFF
--- a/docs/atomic-install.1.md
+++ b/docs/atomic-install.1.md
@@ -20,7 +20,7 @@ IMAGE, if this field does not exist, `atomic install` will install the IMAGE
 
 If the container image has a LABEL INSTALL instruction like the following:
 
-```LABEL INSTALL /usr/bin/docker run -t -i --rm \${OPT1} --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=\${NAME} -e IMAGE=\${IMAGE} -e CONFDIR=\${CONFDIR} -e LOGDIR=\${LOGDIR} -e DATADIR=\${DATADIR} --name \${NAME} \${IMAGE} \${OPT2} /bin/install.sh \${OPT3}```
+```LABEL INSTALL /usr/bin/docker run -t -i --rm \${OPT1} --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=\${NAME} -e IMAGE=\${IMAGE} -e CONFDIR=\${CONFDIR} -e LOGDIR=\${LOGDIR} -e DATADIR=\${DATADIR} \${IMAGE} \${OPT2} /bin/install.sh \${OPT3}```
 
 `atomic install` will set the following environment variables for use in the command:
 

--- a/docs/atomic-uninstall.1.md
+++ b/docs/atomic-uninstall.1.md
@@ -20,7 +20,7 @@ uninstall the image.
 
 If the container image has a LABEL UNINSTALL instruction like the following:
 
-```LABEL UNINSTALL /usr/bin/docker run -t -i --rm \${OPT1} --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=${NAME} -e IMAGE=${IMAGE} -e CONFDIR=${CONFDIR} -e LOGDIR=${LOGDIR} -e DATADIR=${DATADIR} --name ${NAME} ${IMAGE} \${OPT2} /bin/uninstall.sh \${OPT3}```
+```LABEL UNINSTALL /usr/bin/docker run -t -i --rm \${OPT1} --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=${NAME} -e IMAGE=${IMAGE} -e CONFDIR=${CONFDIR} -e LOGDIR=${LOGDIR} -e DATADIR=${DATADIR} ${IMAGE} \${OPT2} /bin/uninstall.sh \${OPT3}```
 
 `atomic uninstall` will set the following environment variables for use in the command:
 


### PR DESCRIPTION
Because it is error prone to use it this way. Using the same NAME in the
environment variable -e NAME=\${NAME} and in container name (--name) for
install and uninstall seems incorrect because both of them serve
different purposes. Also if NAME is being used to create a container in
the install script, which happens most of the time, it leads to failure
because the same NAME is used for the ephemeral container to process
LABEL INSTALL and due to that, the actual container can not be created
and it gives following error:
"Error response from daemon: Conflict. The name "etcd1" is
already in use by container b50ea8bf1d40."

Anyway assigning names (using -name NAME) to ephemeral containers during
install and uninstall does not make much sense in my point of view.