### PR TITLE
Resolve version info from setup.py using pkg_resources.

### DIFF
--- a/Atomic/__init__.py
+++ b/Atomic/__init__.py
@@ -1,8 +1,9 @@
 import sys
 import os
+from pkg_resources import get_distribution
 from .pulp import PulpServer, PulpConfig
 from .satellite import SatelliteServer, SatelliteConfig
 from .atomic import Atomic
 from .util import writeOut
 
-__version__ = "1.2"
+__version__ = get_distribution('atomic').version

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,12 @@ import sys
 import os
 from setuptools import setup
 
-sys.path.insert(0, os.path.abspath(os.getcwd()))
-from Atomic import __version__
-
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()
 
 setup(
-    name="atomic", scripts=["atomic", "atomic_dbus.py"], version=__version__,
+    name="atomic", scripts=["atomic", "atomic_dbus.py"],
+    version='1.2',
     description="Atomic Management Tool",
     author="Daniel Walsh", author_email="dwalsh@redhat.com",
     packages=["Atomic"],


### PR DESCRIPTION
This fixes version info resolution during using setup.py with deps installed and version resolution from ``Atomic/__init__.py`` too. This is in response to https://github.com/projectatomic/atomic/issues/112#issuecomment-134492154