### PR TITLE
mount,overlay: fix tback when mount fails

### DIFF
--- a/Atomic/mount.py
+++ b/Atomic/mount.py
@@ -21,6 +21,7 @@
 #
 
 import os
+import sys
 
 import docker
 import json
@@ -388,7 +389,7 @@ class DockerMount(Mount):
         if status.return_code != 0:
             self._cleanup_container(cinfo)
             raise MountError('Failed to mount OverlayFS device.\n' +
-                             status.stderr)
+                             status.stderr.decode(sys.getdefaultencoding()))
 
     def _cleanup_container(self, cinfo):
         """


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/bin/atomic", line 306, in <module>
    sys.exit(args.func())
  File "/usr/lib/python3.4/site-packages/Atomic/atomic.py", line 705, in mount
    self.args.live).mount(self.args.image, options)
  File "/usr/lib/python3.4/site-packages/Atomic/mount.py", line 268, in mount
    driver_mount_fn(identifier, options)
  File "/usr/lib/python3.4/site-packages/Atomic/mount.py", line 384, in _mount_overlay
    status.stderr)
TypeError: Can't convert 'bytes' object to str implicitly
```