### PR TITLE
added debian install support and doc

### DIFF
--- a/docs/install/Debian.md
+++ b/docs/install/Debian.md
@@ -1,0 +1,38 @@
+#INSTALL
+`atomic` can be installed through below methods
+
+##Make
+On Debian, You will need to install the required build dependencies to build `atomic`
+
+Install the selinux python bindings in order to build `atomic`
+```
+apt-get install python-selinux
+
+```
+
+Pip the required python depencies and `ln` to the /usr/bin dir
+```
+pip install pylint go-m2dman
+ln /usr/local/bin/pylint /usr/bin/pylint
+```
+
+
+Get the code
+```
+git clone https://github.com/projectatomic/atomic
+cd atomic
+```
+
+Build and install it.
+```
+pip install -r requirements.txt
+make all
+make install
+```
+
+Your install will now be complete!
+
+```
+▶ atomic --version
+1.2
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests
+requests>=2.4.3
 setuptools
 docker-py
 websocket-client>=0.11.0


### PR DESCRIPTION
fixes #135 

* changes requirements to fit default python pip install of `requests`
* added tutorial doc on how to install atomic to debian (tested environment debian 8)