### PR TITLE
make echo cross-distro

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -799,7 +799,7 @@ class Atomic(object):
 
     def display(self, cmd):
         subprocess.check_call(
-            "/usr/bin/echo \"" + cmd + "\"", env=self.cmd_env, shell=True)
+            "/bin/echo \"" + cmd + "\"", env=self.cmd_env, shell=True)
 
 
 def SetFunc(function):


### PR DESCRIPTION
changes echo location from `/usr/bin/echo` to `/bin/echo`

fixes issue #139 

