### PR TITLE
FIX test failures

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -595,8 +595,9 @@ class Atomic(object):
             # Some images may not have a 'Labels' key.
             raise ValueError('{} has no label information.'
                              ''.format(self.args.image))
-        for label in labels:
-            self.writeOut('{0}: {1}'.format(label, labels[label]))
+        if labels is not None: 
+            for label in labels:
+                self.writeOut('{0}: {1}'.format(label, labels[label]))
 
     def dangling(self, image):
         if image == "<none>":

--- a/tests/integration/test_display.sh
+++ b/tests/integration/test_display.sh
@@ -23,8 +23,10 @@ trap teardown EXIT
 
 setup
 
-OUTPUT=`${ATOMIC} run --display -n TEST1 atomic-test-1` 
-if [[ ${OUTPUT} != "/usr/bin/docker run -t --user 1000:1000  -v /var/log/TEST1:/var/log -v /var/lib/TEST1:/var/lib  --name TEST1 atomic-test-1  echo I am the run label." ]]; then
+# Remove the --user UID:GID
+OUTPUT=`${ATOMIC} run --display -n TEST1 atomic-test-1 | sed 's/ --user [0-9]*:[0-9]* //'`
+OUTPUT2="/usr/bin/docker run -t -v /var/log/TEST1:/var/log -v /var/lib/TEST1:/var/lib  --name TEST1 atomic-test-1  echo I am the run label."
+if [[ ${OUTPUT} != ${OUTPUT2} ]]; then
     exit 1
 fi
 

--- a/tests/integration/test_info.sh
+++ b/tests/integration/test_info.sh
@@ -11,20 +11,24 @@ validTest1 () {
     return 1
 }
 
+
 TEST_1=`${ATOMIC} info atomic-test-1`
-TEST_CENTOS_REMOTE=`${ATOMIC} info --remote centos:latest`
 TEST_CENTOS=`${ATOMIC} info centos:latest`
 
 set +e
 
+TEST_CENTOS_REMOTE=`${ATOMIC} info --remote centos:latest`
+HAS_REMOTE=$?
 TEST_DOES_NOT_EXIST=`${ATOMIC} info this-is-not-a-real-image`
 
 set -e
 
 echo $TEST_1
 
-if [[ "${TEST_CENTOS_REMOTE}" != "${TEST_CENTOS}" ]]; then
-    exit 1
+if [[ "${HAS_REMOTE}" -eq 0 ]]; then
+    if [[ "${TEST_CENTOS_REMOTE}" != "${TEST_CENTOS}" ]]; then
+        exit 1
+    fi
 fi
 
 if [[ "${TEST_DOES_NOT_EXIST}" != "" ]]; then


### PR DESCRIPTION
    Fix test failures that have crept into the atomic master.

tests/integration/test_display.sh
    Fix failure related to defined UID/GID's in the test itself.  I now
    use sed to remove the --user UID:GID to make the comparison equal
    and remove potential for dynamic failures.

    I also had to add a conditional if the labels (in python) are of
    type None to prevent a traceback.

tests/integration/test_info.sh
    There seemed to be two related failures in the test case that relate to
    running 'atomic info --remote'.  If that command is run with a docker
    daemon that is not capable of --remote, the test will failure.  I added
    a variable based on the return of that command and put it under the
    set +e section.

    I then added a conditional for that test (based on the return of above),
    to only run the test if the docker daemon is capable of the --remote
    function.