### PR TITLE
atomic: add '--env' option

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -511,6 +511,16 @@ class Atomic(object):
                'LOGDIR': "/var/log/%s" % self.name,
                'DATADIR': "/var/lib/%s" % self.name}
 
+        if hasattr(self.args, 'env') and self.args.env:
+            for i in self.args.env:
+                pair = i.split('=', 1)
+                name = pair[0]
+                env[name] = ""
+                if len(pair) > 1:
+                    env[name] = pair[1]
+                elif name in os.environ:
+                    env[name] = os.environ[name]
+
         if hasattr(self.args, 'opt1') and self.args.opt1:
             env['OPT1'] = self.args.opt1
 

--- a/atomic
+++ b/atomic
@@ -44,6 +44,15 @@ except IOError:
     builtins.__dict__['_'] = str
 
 
+def add_generic_subparsers(parser, command):
+    parser.add_argument("--env", "-e", dest="env", type=str, action='append',
+                        metavar="ENV[=VALUE]",
+                        help=_("set additional environment variable ENV "
+                               "for '{0}' command; value of $ENV from actual "
+                               "environment is inherited when no VALUE "
+                               "is specified".format(command)))
+
+
 class HelpByDefaultArgumentParser(argparse.ArgumentParser):
 
     def error(self, message):
@@ -149,6 +158,9 @@ if __name__ == '__main__':
         "INSTALL command to your Dockerfile like: 'LABEL INSTALL "
         "%s'" % atomic.print_install())
     installp.set_defaults(func=atomic.install)
+
+    add_generic_subparsers(installp, 'install')
+
     installp.add_argument("--opt1", dest="opt1",
                           help="additional arguments to be passed as ${OPT1} "
                                "for install command.")
@@ -280,6 +292,9 @@ if __name__ == '__main__':
         epilog="atomic run defaults to the following command, if image "
         "does not specify LABEL run\n'%s'" % atomic.print_run())
     runp.set_defaults(func=atomic.run)
+
+    add_generic_subparsers(runp, 'run')
+
     runp.add_argument("--opt1", dest="opt1",
                       help="additional arguments to be passed as ${OPT1} for "
                       "run command.")
@@ -315,6 +330,9 @@ if __name__ == '__main__':
         "LABEL UNINSTALL command to your Dockerfile like: 'LABEL "
         "UNINSTALL %s'" % atomic.print_uninstall())
     uninstallp.set_defaults(func=atomic.uninstall)
+
+    add_generic_subparsers(uninstallp, 'uninstall')
+
     uninstallp.add_argument("--opt1", dest="opt1",
                             help="additional arguments to be passed as "
                                  "${OPT1} for uninstall command.")

--- a/docs/atomic-install.1.md
+++ b/docs/atomic-install.1.md
@@ -12,6 +12,7 @@ atomic-install - Execute Image Install Method
 [**--opt1**[=*OPT*]]
 [**--opt2**[=*OPT*]]
 [**--opt3**[=*OPT*]]
+[**-e**][**--env**[=*VAR[=NAME]*]]
 IMAGE [ARG...]
 
 # DESCRIPTION
@@ -65,6 +66,10 @@ in the LABEL.
 **--opt3**=""
    Substitute options specified as opt3 for all instances of ${OPT3} specified
 in the LABEL.
+
+**-e** **--env**=""
+   Set additional environment variable ENV for 'install' command; value of $ENV
+from actual environment is inherited when no VALUE is specified.
 
 # HISTORY
 January 2015, Originally compiled by Daniel Walsh (dwalsh at redhat dot com)

--- a/docs/atomic-run.1.md
+++ b/docs/atomic-run.1.md
@@ -12,6 +12,7 @@ atomic-run - Execute container image run method
 [**--opt1**[=*OPT*]]
 [**--opt2**[=*OPT*]]
 [**--opt3**[=*OPT*]]
+[**-e**][**--env**[=*VAR[=NAME]*]]
 [**--spc**]
 IMAGE [COMMAND] [ARG...]
 
@@ -75,6 +76,10 @@ in the LABEL.
 **--opt3**=""
    Substitute options specified as opt3 for all instances of ${OPT3} specified
 in the LABEL.
+
+**-e** **--env**=""
+   Set additional environment variable ENV for 'run' command; value of $ENV
+from actual environment is inherited when no VALUE is specified.
 
 **--spc**
   Run container in super privileged container mode.  The image will run with the following command:

--- a/docs/atomic-uninstall.1.md
+++ b/docs/atomic-uninstall.1.md
@@ -12,6 +12,7 @@ atomic-uninstall - Remove/Uninstall container/container image from system
 [**--opt1**[=*OPT*]]
 [**--opt2**[=*OPT*]]
 [**--opt3**[=*OPT*]]
+[**-e**][**--env**[=*VAR[=NAME]*]]
 IMAGE [ARG...]
 
 # DESCRIPTION
@@ -63,6 +64,10 @@ in the LABEL.
 **--opt3**=""
    Substitute options specified as opt3 for all instances of ${OPT3} specified
 in the LABEL.
+
+**-e** **--env**=""
+   Set additional environment variable ENV for 'uninstall' command; value of $ENV
+from actual environment is inherited when no VALUE is specified.
 
 # HISTORY
 January 2015, Originally compiled by Daniel Walsh (dwalsh at redhat dot com)


### PR DESCRIPTION
.. to 'install', 'uninstall' and 'run' commands.  This way we can
now do stuff like this:

    sudo atomic install -e CONFIG='some value' ...

Or:

    sudo CONFIG="some value" atomic install -e CONFIG ...

While INSTALL script can do simply:

    'docker run ... -e CONFIG ... SCRIPT'.

So far we could use only --opt2 or 'args' for this to specify
CONFIG for underlying command (running in container).  The --opt2,
however, can't be used to specify '--opt2 "-e VAR=\"some val\""',
because resulting ${OPT2} variable is split based on spaces before
used as 'docker run' arguments.
Although specifying CONFIG='some value' via 'args' is treated by
pipes.quote() correctly, it requires additional parsing on the
script side.