### PR TITLE
Remove automatic setting of CONFDIR, DATADIR and LOGDIR

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -61,9 +61,9 @@ class Atomic(object):
                     "-v", "${CONFDIR}:/etc/${NAME}",
                     "-v", "${LOGDIR}:/var/log/${NAME}",
                     "-v", "${DATADIR}:/var/lib/${NAME}",
-                    "-e", "CONFDIR=${CONFDIR}",
-                    "-e", "LOGDIR=${LOGDIR}",
-                    "-e", "DATADIR=${DATADIR}",
+                    "-e", "CONFDIR=/etc/${NAME}",
+                    "-e", "LOGDIR=/var/log/${NAME}",
+                    "-e", "DATADIR=/var/lib/${NAME}",
                     "--name", "${NAME}",
                     "${IMAGE}"]
 
@@ -546,10 +546,7 @@ class Atomic(object):
     def cmd_env(self):
         env = dict(os.environ)
         env.update({'NAME': self.name,
-                    'IMAGE': self.image,
-                    'CONFDIR': "/etc/%s" % self.name,
-                    'LOGDIR': "/var/log/%s" % self.name,
-                    'DATADIR': "/var/lib/%s" % self.name})
+                    'IMAGE': self.image})
 
         if hasattr(self.args, 'opt1') and self.args.opt1:
             env['OPT1'] = self.args.opt1

--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ cat Dockerfile
 ```
 # Example Dockerfile for httpd application
 #
-FROM 		fedora
+FROM		fedora
 MAINTAINER	Dan Walsh
 ENV container docker
 RUN yum -y update; yum -y install httpd; yum clean all
 
 LABEL Vendor="Red Hat" License=GPLv2
 LABEL Version=1.0
-LABEL INSTALL="docker run --rm --privileged -v /:/host -e HOST=/host -e LOGDIR=${LOGDIR} -e CONFDIR=${CONFDIR} -e DATADIR=${DATADIR} -e IMAGE=${IMAGE} -e NAME=${NAME} ${IMAGE} /bin/install.sh"
+LABEL INSTALL="docker run --rm --privileged -v /:/host -e HOST=/host -e LOGDIR=/var/log/\${NAME} -e CONFDIR=/etc/\${NAME} -e DATADIR=/var/lib/\${NAME} -e IMAGE=\${IMAGE} -e NAME=\${NAME} \${IMAGE} /bin/install.sh"
 LABEL UNINSTALL="docker run --rm --privileged -v /:/host -e HOST=/host -e IMAGE=${IMAGE} -e NAME=${NAME} ${IMAGE} /bin/uninstall.sh"
 ADD root /
 
@@ -62,14 +62,9 @@ EXPOSE 80
 CMD [ "/usr/sbin/httpd", "-D", "FOREGROUND" ]
 ```
 
-`atomic install` will read the LABEL INSTALL line and substitute `NAME` with
+`atomic install` will read the LABEL INSTALL line and substitute `${NAME}` with
 the name specified with the name option, or use the image name, it will also
-replace`IMAGE` with the image name.  It will also create the following
-directories:
-
-* CONFDIR=/etc/NAME
-* LOGDIR=/var/log/NAME
-* DATADIR=/var/lib/NAME
+replace`${IMAGE}` with the image name.
 
 To be used by the application.  The install script could populate these
 directories if necessary.
@@ -111,7 +106,7 @@ install, and can be used to remove any host system configuration.
 
 Here is the example script we used.
 
-cat root/usr/bin/uninstall.sh 
+cat root/usr/bin/uninstall.sh
 ```
 #!/bin/sh
 chroot ${HOST} /usr/bin/systemctl disable /etc/systemd/system/httpd_${NAME}.service
@@ -120,9 +115,9 @@ rm -f ${HOST}/etc/systemd/system/httpd_${NAME}.service
 
 Finally here is the systemd unit file template I used:
 
-cat root/etc/systemd/system/httpd_template.service 
+cat root/etc/systemd/system/httpd_template.service
 ```
-# cat ./root/etc/systemd/system/httpd_template.service 
+# cat ./root/etc/systemd/system/httpd_template.service
 [Unit]
 Description=The Apache HTTP Server for TEMPLATE
 After=docker.service

--- a/docs/atomic-install.1.md
+++ b/docs/atomic-install.1.md
@@ -20,7 +20,7 @@ IMAGE, if this field does not exist, `atomic install` will install the IMAGE.
 
 If the container image has a LABEL INSTALL instruction like the following:
 
-`LABEL INSTALL /usr/bin/docker run -t -i --rm \${OPT1} --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=\${NAME} -e IMAGE=\${IMAGE} -e CONFDIR=\${CONFDIR} -e LOGDIR=\${LOGDIR} -e DATADIR=\${DATADIR} \${IMAGE} \${OPT2} /bin/install.sh \${OPT3}`
+`LABEL INSTALL /usr/bin/docker run -t -i --rm \${OPT1} --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=\${NAME} -e IMAGE=\${IMAGE} -e CONFDIR=\/etc/${NAME} -e LOGDIR=/var/log/\${NAME} -e DATADIR=/var/lib/\${NAME} \${IMAGE} \${OPT2} /bin/install.sh \${OPT3}`
 
 `atomic install` will set the following environment variables for use in the command:
 
@@ -39,7 +39,7 @@ If the container image has a LABEL INSTALL instruction like the following:
 **SUDO_GID**
   The `SUDO_GID` environment variable.  This is useful with the docker `-u` option for user space tools.  If the environment variable is not available, the default GID of the value for `SUDO_UID` is used.  If this value is not available, the value of `/proc/self/loginuid` is used.
 
-`atomic install` will also pass in the CONFDIR, LOGDIR and DATADIR environment variables to the container.  Any additional arguments will be appended to the command.
+Any additional arguments will be appended to the command.
 
 # OPTIONS:
 **-h** **--help**

--- a/docs/atomic-uninstall.1.md
+++ b/docs/atomic-uninstall.1.md
@@ -21,7 +21,7 @@ uninstall the image.
 
 If the container image has a LABEL UNINSTALL instruction like the following:
 
-`LABEL UNINSTALL /usr/bin/docker run -t -i --rm \${OPT1} --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=${NAME} -e IMAGE=${IMAGE} -e CONFDIR=${CONFDIR} -e LOGDIR=${LOGDIR} -e DATADIR=${DATADIR} ${IMAGE} \${OPT2} /bin/uninstall.sh \${OPT3}`
+`LABEL UNINSTALL /usr/bin/docker run -t -i --rm \${OPT1} --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=${NAME} -e IMAGE=${IMAGE} -e CONFDIR=\/etc/${NAME} -e LOGDIR=/var/log/\${NAME} -e DATADIR=/var/lib/\${NAME} ${IMAGE} \${OPT2} /bin/uninstall.sh \${OPT3}`
 
 `atomic uninstall` will set the following environment variables for use in the command:
 
@@ -40,7 +40,7 @@ If the container image has a LABEL UNINSTALL instruction like the following:
 **SUDO_GID**
   The `SUDO_GID` environment variable.  This is useful with the docker `-u` option for user space tools.  If the environment variable is not available, the default GID of the value for `SUDO_UID` is used.  If this value is not available, the value of `/proc/self/loginuid` is used.
 
-`atomic uninstall` will also pass in the CONFDIR, LOGDIR and DATADIR environment variables to the container. Any additional arguments will be appended to the command.
+Any additional arguments will be appended to the command.
 
 # OPTIONS:
 **-f** **--force**


### PR DESCRIPTION
Users can do this themselves by using the ${NAME} field.

Hard coding behaviour of these three variables was a mistake, and this
is a lot more flexible.  I could add back the variables and don't document them
if people think someone has used them