### PR TITLE
Remove opt documentation, but continue support

### DIFF
--- a/atomic
+++ b/atomic
@@ -85,6 +85,11 @@ class AliasedSubParsersAction(argparse._SubParsersAction):
 
         return parser
 
+def add_opt(sub):
+    sub.add_argument("--opt1", dest="opt1",help=argparse.SUPPRESS)
+    sub.add_argument("--opt2", dest="opt2",help=argparse.SUPPRESS)
+    sub.add_argument("--opt3", dest="opt3",help=argparse.SUPPRESS)
+
 if __name__ == '__main__':
     atomic = Atomic.Atomic()
     parser = HelpByDefaultArgumentParser(description=atomic.help())
@@ -149,15 +154,7 @@ if __name__ == '__main__':
         "INSTALL command to your Dockerfile like: 'LABEL INSTALL "
         "%s'" % atomic.print_install())
     installp.set_defaults(func=atomic.install)
-    installp.add_argument("--opt1", dest="opt1",
-                          help="additional arguments to be passed as ${OPT1} "
-                               "for install command.")
-    installp.add_argument("--opt2", dest="opt2",
-                          help="additional arguments to be passed as ${OPT2} "
-                               "for install command.")
-    installp.add_argument("--opt3", dest="opt3",
-                          help="additional arguments to be passed as ${OPT3} "
-                               "for install command.")
+    add_opt(installp)
     installp.add_argument("-n", "--name", dest="name", default=None,
                           help=_("name of container"))
     installp.add_argument(
@@ -285,6 +282,7 @@ if __name__ == '__main__':
         epilog="atomic will just stop the container if it is running, if "
         "image does not specify LABEL STOP")
     stopp.set_defaults(func=atomic.stop)
+    add_opt(stopp)
     stopp.add_argument("-n", "--name", dest="name", default=None,
                        help=_("name of container"))
     stopp.add_argument("image", help=_("container image"))
@@ -295,15 +293,7 @@ if __name__ == '__main__':
         epilog="atomic run defaults to the following command, if image "
         "does not specify LABEL run\n'%s'" % atomic.print_run())
     runp.set_defaults(func=atomic.run)
-    runp.add_argument("--opt1", dest="opt1",
-                      help="additional arguments to be passed as ${OPT1} for "
-                      "run command.")
-    runp.add_argument("--opt2", dest="opt2",
-                      help="additional arguments to be passed as ${OPT2} for "
-                           "run command.")
-    runp.add_argument("--opt3", dest="opt3",
-                      help="additional arguments to be passed as ${OPT3} for "
-                           "run command.")
+    add_opt(runp)
     runp.add_argument("-n", "--name", dest="name", default=None,
                       help=_("name of container"))
     runp.add_argument("--spc", default=False, action="store_true",
@@ -330,15 +320,7 @@ if __name__ == '__main__':
         "LABEL UNINSTALL command to your Dockerfile like: 'LABEL "
         "UNINSTALL %s'" % atomic.print_uninstall())
     uninstallp.set_defaults(func=atomic.uninstall)
-    uninstallp.add_argument("--opt1", dest="opt1",
-                            help="additional arguments to be passed as "
-                                 "${OPT1} for uninstall command.")
-    uninstallp.add_argument("--opt2", dest="opt2",
-                            help="additional arguments to be passed as "
-                                 "${OPT2} for uninstall command.")
-    uninstallp.add_argument("--opt3", dest="opt3",
-                            help="additional arguments to be passed as "
-                                 "${OPT3} for uninstall command.")
+    add_opt(uninstallp)
     uninstallp.add_argument("-n", "--name", dest="name", default=None,
                             help=_("name of container"))
     uninstallp.add_argument("-f", "--force", default=False, dest="force",

--- a/docs/atomic-install.1.md
+++ b/docs/atomic-install.1.md
@@ -9,9 +9,6 @@ atomic-install - Execute Image Install Method
 [**-h**|**--help**]
 [**--display**]
 [**-n**][**--name**[=*NAME*]]
-[**--opt1**[=*OPT*]]
-[**--opt2**[=*OPT*]]
-[**--opt3**[=*OPT*]]
 IMAGE [ARG...]
 
 # DESCRIPTION
@@ -53,18 +50,6 @@ If --display is not specified the install command will execute.
 **-n** **--name**=""
    Use this name for creating installed content for the container.
 NAME will default to the IMAGENAME if it is not specified.
-
-**--opt1**=""
-   Substitute options specified as opt1 for all instances of ${OPT1} specified
-in the LABEL.
-
-**--opt2**=""
-   Substitute options specified as opt2 for all instances of ${OPT2} specified
-in the LABEL.
-
-**--opt3**=""
-   Substitute options specified as opt3 for all instances of ${OPT3} specified
-in the LABEL.
 
 # HISTORY
 January 2015, Originally compiled by Daniel Walsh (dwalsh at redhat dot com)

--- a/docs/atomic-run.1.md
+++ b/docs/atomic-run.1.md
@@ -9,9 +9,6 @@ atomic-run - Execute container image run method
 [**-h**|**--help**]
 [**--display**]
 [**-n**][**--name**[=*NAME*]]
-[**--opt1**[=*OPT*]]
-[**--opt2**[=*OPT*]]
-[**--opt3**[=*OPT*]]
 [**--spc**]
 IMAGE [COMMAND] [ARG...]
 
@@ -63,18 +60,6 @@ If --display is not specified the run command will execute.
 **--n** **--name**=""
    Use this name for creating run content for the container.
 NAME will default to the IMAGENAME if it is not specified.
-
-**--opt1**=""
-   Substitute options specified as opt1 for all instances of ${OPT1} specified
-in the LABEL.
-
-**--opt2**=""
-   Substitute options specified as opt2 for all instances of ${OPT2} specified
-in the LABEL.
-
-**--opt3**=""
-   Substitute options specified as opt3 for all instances of ${OPT3} specified
-in the LABEL.
 
 **--spc**
   Run container in super privileged container mode.  The image will run with the following command:

--- a/docs/atomic-uninstall.1.md
+++ b/docs/atomic-uninstall.1.md
@@ -9,9 +9,6 @@ atomic-uninstall - Remove/Uninstall container/container image from system
 [**-f**][**--force**]
 [**-h**|**--help**]
 [**-n**][**--name**[=*NAME*]]
-[**--opt1**[=*OPT*]]
-[**--opt2**[=*OPT*]]
-[**--opt3**[=*OPT*]]
 IMAGE [ARG...]
 
 # DESCRIPTION
@@ -51,18 +48,6 @@ Any additional arguments will be appended to the command.
 
 **-n** **--name**=""
    If name is specified `atomic uninstall` will uninstall the named container from the system, otherwise it will uninstall the container images.
-
-**--opt1**=""
-   Substitute options specified as opt1 for all instances of ${OPT1} specified
-in the LABEL.
-
-**--opt2**=""
-   Substitute options specified as opt2 for all instances of ${OPT2} specified
-in the LABEL.
-
-**--opt3**=""
-   Substitute options specified as opt3 for all instances of ${OPT3} specified
-in the LABEL.
 
 # HISTORY
 January 2015, Originally compiled by Daniel Walsh (dwalsh at redhat dot com)


### PR DESCRIPTION
opt1, opt2 and opt3 can be specified as environment variables.

OPT1=--debug atomic install foobar

No reason to have options.