### PR TITLE
Make test_display.sh pass again

### DIFF
--- a/tests/integration/test_display.sh
+++ b/tests/integration/test_display.sh
@@ -30,8 +30,9 @@ if [[ ${OUTPUT} != ${OUTPUT2} ]]; then
     exit 1
 fi
 
-OUTPUT=`${ATOMIC} install --display -n TEST2 atomic-test-1` 
-if [[ ${OUTPUT} != "docker  run -v /etc/TEST2:/etc/ -v /var/log/TEST2:/var/log/ -v /var/lib/TEST2:/var/lib/  --name TEST2 atomic-test-1  echo I am the install label." ]]; then
+OUTPUT=`${ATOMIC} install --display -n TEST2 atomic-test-1`
+OUTPUT2="/usr/bin/docker  run -v /etc/TEST2:/etc -v /var/log/TEST2:/var/log -v /var/lib/TEST2:/var/lib  --name TEST2 atomic-test-1  echo I am the install label."
+if [[ ${OUTPUT} != ${OUTPUT2} ]]; then
     exit 1
 fi
 
@@ -48,6 +49,7 @@ if [[ ${OUTPUT} != "I am the run label." ]]; then
 fi
 
 OUTPUT=`${ATOMIC} install --display -n TEST5 centos`
-if [[ ${OUTPUT} != "/usr/bin/docker run -t -i --rm --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=TEST5 -e IMAGE=centos -v /etc/TEST5:/etc/TEST5 -v /var/log/TEST5:/var/log/TEST5 -v /var/lib/TEST5:/var/lib/TEST5 -e CONFDIR=/etc/TEST5 -e LOGDIR=/var/log/TEST5 -e DATADIR=/var/lib/TEST5 --name TEST5 centos" ]]; then
+OUTPUT2='/usr/bin/docker run -t -i --rm --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=TEST5 -e IMAGE=centos -e CONFDIR=/host/etc/TEST5 -e LOGDIR=/host/var/log/TEST5 -e DATADIR=/host/var/lib/TEST5 --name TEST5 centos'
+if [[ ${OUTPUT} != ${OUTPUT2} ]]; then
     exit 1
 fi

--- a/tests/test-images/Dockerfile.1
+++ b/tests/test-images/Dockerfile.1
@@ -4,6 +4,6 @@ ENV container docker
 
 LABEL "Name"="atomic-test-1"
 
-LABEL RUN "/usr/bin/docker run -t --user \${SUDO_UID}:\${SUDO_GID} \${OPT1}  -v \${LOGDIR}:/var/log -v \${DATADIR}:/var/lib \$OPT2 --name \${NAME} \${IMAGE} \$OPT3 echo I am the run label." 
+LABEL RUN "/usr/bin/docker run -t --user \${SUDO_UID}:\${SUDO_GID} \${OPT1}  -v /var/log/\${NAME}:/var/log -v /var/lib/\${NAME}:/var/lib \$OPT2 --name \${NAME} \${IMAGE} \$OPT3 echo I am the run label."
 
-LABEL INSTALL "docker \${OPT1} run  -v \${CONFDIR}:/etc/${NAME} -v \${LOGDIR}:/var/log/${NAME} -v \${DATADIR}:/var/lib/${NAME} \$OPT2 --name \${NAME} \${IMAGE} \$OPT3 echo I am the install label."
+LABEL INSTALL "/usr/bin/docker \${OPT1} run  -v /etc/\${NAME}:/etc -v /var/log/\${NAME}:/var/log -v /var/lib/\${NAME}:/var/lib \$OPT2 --name \${NAME} \${IMAGE} \$OPT3 echo I am the install label."


### PR DESCRIPTION
This patch makes test_display.sh pass. They are mostly tweaks to account
for the following:
- Account for commit 7858957, which removes {CONF,LOG,DATA}DIR from the
  target environment.
- Account for commit ae931d0, which removes those default bind mounts.
- Fix a few mismatches between the labels in the Dockerfile vs the
  expected output in the test script.

And with that, all tests (should) pass!