### PR TITLE
Make pylint scan all the python files and fix pylint issues

### DIFF
--- a/Atomic/__init__.py
+++ b/Atomic/__init__.py
@@ -6,4 +6,6 @@ from .satellite import SatelliteServer, SatelliteConfig
 from .atomic import Atomic
 from .util import writeOut
 
+#https://bitbucket.org/logilab/pylint/issues/36/
+#pylint: disable=no-member
 __version__ = get_distribution('atomic').version

--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -622,6 +622,9 @@ class Atomic(object):
                 pass
         if inspection is None:
             try:
+                # Shut up pylint in case we're on a machine with upstream
+                # docker-py, which lacks the remote keyword arg.
+                #pylint: disable=unexpected-keyword-arg
                 inspection = self.d.inspect_image(self.args.image, remote=True)
             except docker.errors.APIError:
                 # image does not exist on any configured registry

--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -95,7 +95,7 @@ class Atomic(object):
         self.force = False
         self._images = []
         self.containers = False
-        self.images = False
+        self.images_cache = None
 
     def writeOut(self, output, lf="\n"):
         sys.stdout.flush()
@@ -965,9 +965,9 @@ class Atomic(object):
         Wrapper function that should be used instead of querying docker
         multiple times for a list of images.
         '''
-        if not self.images:
-            self.images = self.d.images()
-        return self.images
+        if not self.images_cache:
+            self.images_cache = self.d.images()
+        return self.images_cache
 
     def get_containers(self):
         '''

--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -491,17 +491,17 @@ class Atomic(object):
         except KeyError:
             pass
 
-    def _rpmostree(self, *args):
+    def _rpmostree(self, args):
         aargs = self.args.args
-        if aargs == "--":
-            aargs = args[1:]
-        os.execl("/usr/bin/rpm-ostree", "rpm-ostree", *args + aargs)
+        if len(aargs) > 0 and aargs[0] == "--":
+            aargs = aargs[1:]
+        os.execl("/usr/bin/rpm-ostree", "rpm-ostree", *(args + aargs))
 
     def host_status(self):
         argv = ["status"]
         if self.args.pretty:
             argv.append("--pretty")
-        self._rpmostree(*argv)
+        self._rpmostree(argv)
 
     def host_upgrade(self):
         argv = ["upgrade"]
@@ -513,19 +513,19 @@ class Atomic(object):
             argv.append("--check-diff")
         if self.args.downgrade:
             argv.append("--allow-downgrade")
-        self._rpmostree(*argv)
+        self._rpmostree(argv)
 
     def host_rollback(self):
         argv = ["rollback"]
         if self.args.reboot:
             argv.append("--reboot")
-        self._rpmostree(*argv)
+        self._rpmostree(argv)
 
     def host_rebase(self):
         argv = ["rebase", self.args.refspec]
         if self.args.os:
             argv.append("--os=" % self.args.os )
-        self._rpmostree(*argv)
+        self._rpmostree(argv)
 
     def uninstall(self):
         self.inspect = self._inspect_container()

--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -453,7 +453,7 @@ class Atomic(object):
             oscap_i = dbus.Interface(oscap_d, INTERFACE)
             scan_return = json.loads(oscap_i.scan_list(scan_list, 4))
         except dbus.exceptions.DBusException:
-            error = "Unable to find the openscap-daemon dbus service."\
+            error = "Unable to find the openscap-daemon dbus service. "\
                     "Either start the openscap-daemon service or pull and run"\
                     " the openscap-daemon image"
             sys.stderr.write("\n{0}\n\n".format(error))

--- a/Atomic/satellite_new.py
+++ b/Atomic/satellite_new.py
@@ -65,8 +65,7 @@ def push_image_to_satellite(image, server_url, username, password,
 typed the name correctly, or create the repository
 """.format(repo_name).replace('\n', ' '))
     try:
-        activation_key = sat.getActivationKey(activation_key_name,
-                                              organization_id)
+        activation_key = sat.getActivationKey(activation_key_name, org_id)
     except Exception as e:
         raise IOError("""Invalid Activation Key Name:
             {0}""".format(activation_key_name).replace('\n', ' '))
@@ -179,14 +178,14 @@ class SatelliteServer(object):
                                                       task['_href']))
         return r_json
 
-    def getOrgID(organization_name):
+    def getOrgID(self, organization_name):
         url = '{0}/katello/api/v2/organizations'.format(self._server_url)
         r_json = self._call_satellite(url)
         org_id = r_json.get(organization_name).get("id")
         return org_id
 
     # no idea if this works
-    def getActivationKey(activation_key_name, org_id):
+    def getActivationKey(self, activation_key_name, org_id):
         url = '{0}/katello/api/v2/organizations/{1}/activation_keys'.format(
             self._server_url, org_id)
         r_json = self._call_satellite(url)
@@ -194,9 +193,9 @@ class SatelliteServer(object):
         return org_id
 
     # no idea if this works
-    def getRepoId(repo_name, org_id):
-        url = '{0}/katello/api/v2/repositories'.format(self._server_url,
-                                                       org_id)
+    def getRepoId(self, repo_name, org_id):
+        url = '{0}/katello/api/v2/repositories/{1}'.format(self._server_url,
+                                                           org_id)
         payload = {"organization_id": org_id}
         r_json = self._call_satellite(url, payload)
         repo_id = r_json.get(repo_name).get('id')

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -119,6 +119,7 @@ def print_detail_scan_summary(json_data):
     Print a detailed summary of the data returned from
     a CVE scan.
     '''
+    clean = True
     sevs = ['Critical', 'Important', 'Moderate', 'Low']
     cve_summary = json_data['host_results']
     image_template = "  {0:10}: {1}"
@@ -137,6 +138,7 @@ def print_detail_scan_summary(json_data):
 
         for sev in sevs:
             if sev in scan_results:
+                clean = False
                 writeOut(image_template.format(sev,
                                             str(scan_results[sev]['num'])))
                 for cve in scan_results[sev]['cves']:
@@ -148,3 +150,4 @@ def print_detail_scan_summary(json_data):
                         writeOut(cve_template.format("RHSA URL",
                                                   cve['rhsa_ref_url']))
                         writeOut("")
+    return clean

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test:
 
 python-build: atomic
 	$(PYTHON) setup.py build
-	$(PYLINT) -E --additional-builtins _ atomic
+	$(PYLINT) -E --additional-builtins=_ *.py atomic Atomic tests/unit/*.py
 
 MANPAGES_MD = $(wildcard docs/*.md)
 

--- a/atomic
+++ b/atomic
@@ -108,7 +108,9 @@ if __name__ == '__main__':
                                       "prepared"))
         rollbackp.add_argument("args", nargs=argparse.REMAINDER,
                                help=_("Additional arguments appended to the "
-                                      "rollback method.  Use `-- --OPTION=VAL` if you want to pass additional unsupported arguments to ostree."))
+                                      "rollback method.  Use `-- --OPTION=VAL` "
+                                      "if you want to pass additional "
+                                      "unsupported arguments to rpm-ostree."))
 
 
         # atomic host status
@@ -119,7 +121,9 @@ if __name__ == '__main__':
                               help=_("Display status in formatted rows"))
         statusp.add_argument("args", nargs=argparse.REMAINDER,
                              help=_("Additional arguments appended to the "
-                                    "status method.  Use `-- --OPTION=VAL` if you want to pass additional unsupported arguments to ostree."))
+                                    "status method.  Use `-- --OPTION=VAL` "
+                                    "if you want to pass additional "
+                                    "unsupported arguments to rpm-ostree."))
 
         statusp.set_defaults(func=atomic.host_status)
 
@@ -142,7 +146,9 @@ if __name__ == '__main__':
                               help=_("Check for upgrades and print package diff only"))
         upgradep.add_argument("args", nargs=argparse.REMAINDER,
                               help=_("Additional arguments appended to the "
-                                     "upgrade method.  Use `-- --OPTION=VAL` if you want to pass additional unsupported arguments to ostree."))
+                                     "upgrade method.  Use `-- --OPTION=VAL` "
+                                     "if you want to pass additional "
+                                     "unsupported arguments to rpm-ostree."))
 
         # atomic host rebase
         rebasep = host_subparser.add_parser(
@@ -154,7 +160,9 @@ if __name__ == '__main__':
                              help=_("Origin refspec for new deployment"))
         rebasep.add_argument("args", nargs=argparse.REMAINDER,
                              help=_("Additional arguments appended to the "
-                                    "rebase method.  Use `-- --OPTION=VAL` if you want to pass additional unsupported arguments to ostree."))
+                                    "rebase method.  Use `-- --OPTION=VAL` "
+                                    "if you want to pass additional "
+                                    "unsupported arguments to rpm-ostree."))
 
     # atomic info
     infop = subparser.add_parser(


### PR DESCRIPTION
The `pylint` invocation in the `Makefile` was only scanning the `atomic` file. We now make it scan all the python files. The following commits fix all the new issues that `pylint` detected.

The final commit fixes the way `rpm-ostree` args are passed to avoid a TypeError during runtime.