### PR TITLE
Drop use of setuptools as it injects a runtime dependency

### DIFF
--- a/Atomic/__init__.py
+++ b/Atomic/__init__.py
@@ -1,11 +1,8 @@
 import sys
 import os
-from pkg_resources import get_distribution
 from .pulp import PulpServer, PulpConfig
 from .satellite import SatelliteServer, SatelliteConfig
 from .atomic import Atomic
 from .util import writeOut
 
-#https://bitbucket.org/logilab/pylint/issues/36/
-#pylint: disable=no-member
-__version__ = get_distribution('atomic').version
+__version__ = '1.5'

--- a/setup.py
+++ b/setup.py
@@ -3,18 +3,17 @@
 # Author: Dan Walsh <dwalsh@redhat.com>
 import sys
 import os
-from setuptools import setup
+from distutils.core import setup
 
-with open('requirements.txt') as f:
-    requirements = f.read().splitlines()
+sys.path.insert(0, os.path.abspath(os.getcwd()))
+from Atomic import __version__
 
 setup(
     name="atomic", scripts=["atomic", "atomic_dbus.py"],
-    version='1.5',
+    version=__version__,
     description="Atomic Management Tool",
     author="Daniel Walsh", author_email="dwalsh@redhat.com",
     packages=["Atomic"],
-    install_requires=requirements,
     data_files=[('/etc/dbus-1/system.d/', ["org.atomic.conf"]),
                 ('/usr/share/dbus-1/system-services', ["org.atomic.service"]),
                 ('/usr/share/polkit-1/actions/', ["org.atomic.policy"]),


### PR DESCRIPTION
This is a re-commit of 106878815f5a5dd61b0e527c502fb6eeaf0c9c67
because the later fix in #112 added a *runtime* dependency on
setuptools, which we don't want.

It looks like OpenStack uses https://pypi.python.org/pypi/pbr which
presumably solves this problem.  I however am not super interested
right now in diving into that...I just want the thing to build.

Ansible just inserts the current dir in `sys.path`, which seems like a
simple hack, so let's do that.

Conflicts:
	setup.py