### PR TITLE
Makefile: remove atomic target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,15 @@ PROFILEDIR ?= $(DESTDIR)/etc/profile.d
 PYTHON ?= /usr/bin/python
 PYLINT ?= /usr/bin/pylint
 
+.PHONY: all
 all: python-build docs
 
+.PHONY: test
 test:
 	sh ./test.sh
 
-python-build: atomic
+.PHONY: python-build
+python-build:
 	$(PYTHON) setup.py build
 	$(PYLINT) -E --additional-builtins=_ *.py atomic Atomic tests/unit/*.py
 
@@ -19,12 +22,15 @@ MANPAGES_MD = $(wildcard docs/*.md)
 docs/%.1: docs/%.1.md
 	go-md2man -in $< -out $@.tmp && mv $@.tmp $@
 
+.PHONY: docs
 docs: $(MANPAGES_MD:%.md=%)
 
+.PHONY: clean
 clean:
 	$(PYTHON) setup.py clean
 	-rm -rf build *~ \#* *pyc .#* docs/*.1
 
+.PHONY: install
 install: all 
 	$(PYTHON) setup.py install --install-scripts /usr/share/atomic `test -n "$(DESTDIR)" && echo --root $(DESTDIR)`
 


### PR DESCRIPTION
The `python-build` target lists `atomic` as a prerequisite target.
However, there is no explicit target named 'atomic', so `make` tries to
find any implicit rules that apply. One of the rules that it tries is
whether the unprocessed file is called `atomic.sh`. Since that file
exists, it proceeds by copying `atomic.sh` to `atomic` if e.g.
`atomic.sh` is newer than `atomic`:

      Considering target file 'python-build'.
       File 'python-build' does not exist.
        Considering target file 'atomic'.
         <snip>
         Found an implicit rule for 'atomic'.
          Considering target file 'atomic.sh'.
           <snip>
           Finished prerequisites of target file 'atomic.sh'.
          No need to remake target 'atomic.sh'.
         Finished prerequisites of target file 'atomic'.
         Prerequisite 'atomic.sh' is newer than target 'atomic'.
        Must remake target 'atomic'.
    cat atomic.sh >atomic

This patch removes the `atomic` target which does not exist, and also
explicitly makes all the other non-file targets phonies to make sure no
name collisions will happen again (and as a plus, improve performance).