### PR TITLE
Allow GO_MD2MAN path to be configurable via env variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SYSCONFDIR ?= $(DESTDIR)/etc/sysconfig
 PROFILEDIR ?= $(DESTDIR)/etc/profile.d
 PYTHON ?= /usr/bin/python
 PYLINT ?= /usr/bin/pylint
+GO_MD2MAN ?= /usr/bin/go-md2man
 
 .PHONY: all
 all: python-build docs
@@ -20,7 +21,7 @@ python-build:
 MANPAGES_MD = $(wildcard docs/*.md)
 
 docs/%.1: docs/%.1.md
-	go-md2man -in $< -out $@.tmp && mv $@.tmp $@
+	$(GO_MD2MAN) -in $< -out $@.tmp && touch $@.tmp && mv $@.tmp $@
 
 .PHONY: docs
 docs: $(MANPAGES_MD:%.md=%)


### PR DESCRIPTION
Also added a touch invocation to allow users to do:
`GO_MD2MAN=/bin/true make`
This skips building the manuals which helps on systems where getting
the go-md2man tool is difficult. This is similar to the trick that can be
used for PYLINT:
`PYLINT=/bin/true GO_MD2MAN=/bin/true make` now works.