### PR TITLE
Add --only-cache option for atomic scan

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -437,7 +437,6 @@ class Atomic(object):
         OBJECT_PATH = "/OpenSCAP/daemon"
         INTERFACE = "org.OpenSCAP.daemon.Interface"
         input_resolve = {}
-
         if self.args.images:
             scan_list = self._get_all_image_ids()
         elif self.args.containers:
@@ -457,7 +456,18 @@ class Atomic(object):
         try:
             oscap_d = bus.get_object(BUS_NAME, OBJECT_PATH)
             oscap_i = dbus.Interface(oscap_d, INTERFACE)
-            scan_return = json.loads(oscap_i.scan_list(scan_list, 4, self.args.only_cache))
+            # Check if the user has asked to override the behaviour of fetching the
+            # latest CVE input data, as defined in the openscap-daemon conf file
+            # oscap-daemon a byte of 0 (False), 1 (True), and 2 (no change)
+
+            if self.args.fetch_cves is None:
+                fetch = 2
+            elif self.args.fetch_cves:
+                fetch = 1
+            else:
+                fetch = 0
+            scan_return = json.loads(oscap_i.scan_list(scan_list, 4, fetch, timeout=99999))
+
         except dbus.exceptions.DBusException, e:
             message = "The openscap-daemon returned: {0}".format(e.get_dbus_message())
             if e.get_dbus_name() == 'org.freedesktop.DBus.Error.ServiceUnknown':

--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -457,12 +457,14 @@ class Atomic(object):
         try:
             oscap_d = bus.get_object(BUS_NAME, OBJECT_PATH)
             oscap_i = dbus.Interface(oscap_d, INTERFACE)
-            scan_return = json.loads(oscap_i.scan_list(scan_list, 4))
-        except dbus.exceptions.DBusException:
-            error = "Unable to find the openscap-daemon dbus service. "\
-                    "Either start the openscap-daemon service or pull and run"\
-                    " the openscap-daemon image"
-            sys.stderr.write("\n{0}\n\n".format(error))
+            scan_return = json.loads(oscap_i.scan_list(scan_list, 4, self.args.only_cache))
+        except dbus.exceptions.DBusException, e:
+            message = "The openscap-daemon returned: {0}".format(e.get_dbus_message())
+            if e.get_dbus_name() == 'org.freedesktop.DBus.Error.ServiceUnknown':
+                message = "Unable to find the openscap-daemon dbus service. "\
+                          "Either start the openscap-daemon service or pull " \
+                          "and run the openscap-daemon image"
+            sys.stderr.write("\n{0}\n\n".format(message))
             sys.exit(1)
 
         if self.args.json:

--- a/atomic
+++ b/atomic
@@ -297,6 +297,9 @@ if __name__ == '__main__':
     #                      help=_("Organization Name"))
 
     # atomic scan
+    def bool_detect(myarg):
+        return True if myarg.lower() in \
+            ('yes', 'true', 't', 'y', '1') else False
 
     scanp = subparser.add_parser(
         "scan", help=_("scan an image or container for CVEs"),
@@ -307,7 +310,7 @@ if __name__ == '__main__':
     scan_out.add_argument("--json", default=False, action='store_true', help=_("output json"))
     scan_out.add_argument("--detail", default=False, action='store_true', help=_("output more detail"))
     scanp.add_argument("scan_targets", nargs='*', help=_("container image"))
-    scanp.add_argument("--only-cache", default=False, action='store_true', help=_("only use the OVAL input files cached in the openscap-daemon image"))
+    scanp.add_argument("--fetch_cves", type=bool_detect, default=None,  help=_("override the behavior defined in /etc/oscapd/config.ini as to whether to download the most recent CVE data. Values can be True of False"))
     scan_group.add_argument("--all", default=False, action='store_true', help=_("scan all images (excluding intermediate layers) and containers"))
     scan_group.add_argument("--images", default=False, action='store_true', help=_("scan all images (excluding intermediate layers)"))
     scan_group.add_argument("--containers", default=False, action='store_true', help=_("scan all containers"))

--- a/atomic
+++ b/atomic
@@ -307,6 +307,7 @@ if __name__ == '__main__':
     scan_out.add_argument("--json", default=False, action='store_true', help=_("output json"))
     scan_out.add_argument("--detail", default=False, action='store_true', help=_("output more detail"))
     scanp.add_argument("scan_targets", nargs='*', help=_("container image"))
+    scanp.add_argument("--only-cache", default=False, action='store_true', help=_("only use the OVAL input files cached in the openscap-daemon image"))
     scan_group.add_argument("--all", default=False, action='store_true', help=_("scan all images (excluding intermediate layers) and containers"))
     scan_group.add_argument("--images", default=False, action='store_true', help=_("scan all images (excluding intermediate layers)"))
     scan_group.add_argument("--containers", default=False, action='store_true', help=_("scan all containers"))

--- a/docs/atomic-scan.1.md
+++ b/docs/atomic-scan.1.md
@@ -6,7 +6,7 @@ atomic-scan - Scan for CVEs in a container or image
 # SYNOPSIS
 **atomic scan**
 [**-h**|**--help**]
-[**--json** | **--detail**] [**--all** | **--images** | **--containers** |
+[**--only-cache**][**--json** | **--detail**] [**--all** | **--images** | **--containers** |
 IMAGE or CONTAINER name ...]
 
 # DESCRIPTION
@@ -15,6 +15,9 @@ IMAGE or CONTAINER name ...]
 # OPTIONS
 **-h** **--help**
   Print usage statement
+
+**--only-cache**
+  Only use the OVAL input files present in the openscap-daemon image. Do not attempt to download the latest OVAL files.
 
 **--json**
   Output in the form of JSON.
@@ -35,6 +38,10 @@ IMAGE or CONTAINER name ...]
 Scan an image named 'foo1'.
 
     atomic scan foo1
+
+Scan an image named 'foo1' with only the files in the openscap-daemon.
+
+    atomic scan --only-cache foo1
 
 Scan images named 'foo1' and 'foo2' and produce a detailed report.
 

--- a/docs/atomic-scan.1.md
+++ b/docs/atomic-scan.1.md
@@ -6,7 +6,7 @@ atomic-scan - Scan for CVEs in a container or image
 # SYNOPSIS
 **atomic scan**
 [**-h**|**--help**]
-[**--only-cache**][**--json** | **--detail**] [**--all** | **--images** | **--containers** |
+[**--fetch-cves=True|False**][**--json** | **--detail**] [**--all** | **--images** | **--containers** |
 IMAGE or CONTAINER name ...]
 
 # DESCRIPTION
@@ -16,8 +16,8 @@ IMAGE or CONTAINER name ...]
 **-h** **--help**
   Print usage statement
 
-**--only-cache**
-  Only use the OVAL input files present in the openscap-daemon image. Do not attempt to download the latest OVAL files.
+**--fetch-cves=True|False**
+  Override the fetch-cve (fetch the latest CVE input data from Red Hat over the network) setting in /etc/oscapd/config.ini. Values can  be True or False.
 
 **--json**
   Output in the form of JSON.


### PR DESCRIPTION
  * For customers who cannot or do not want to fetch the latest OVAL
    CVE input files for atomic scan, they can now pass the --only-cache
    option which disables the ability to fetch new.