### PR TITLE
Atomic_scan: add option to override fetching of new CVE data

### DIFF
--- a/atomic
+++ b/atomic
@@ -297,6 +297,9 @@ if __name__ == '__main__':
     #                      help=_("Organization Name"))
 
     # atomic scan
+    def bool_detect(myarg):
+        return True if myarg.lower() in \
+            ('yes', 'true', 't', 'y', '1') else False
 
     scanp = subparser.add_parser(
         "scan", help=_("scan an image or container for CVEs"),
@@ -307,6 +310,7 @@ if __name__ == '__main__':
     scan_out.add_argument("--json", default=False, action='store_true', help=_("output json"))
     scan_out.add_argument("--detail", default=False, action='store_true', help=_("output more detail"))
     scanp.add_argument("scan_targets", nargs='*', help=_("container image"))
+    scanp.add_argument("--fetch_cves", type=bool_detect, default=None,  help=_("override the behavior defined in /etc/oscapd/config.ini as to whether to download the most recent CVE data. Values can be True of False"))
     scan_group.add_argument("--all", default=False, action='store_true', help=_("scan all images (excluding intermediate layers) and containers"))
     scan_group.add_argument("--images", default=False, action='store_true', help=_("scan all images (excluding intermediate layers)"))
     scan_group.add_argument("--containers", default=False, action='store_true', help=_("scan all containers"))

--- a/docs/atomic-scan.1.md
+++ b/docs/atomic-scan.1.md
@@ -6,7 +6,7 @@ atomic-scan - Scan for CVEs in a container or image
 # SYNOPSIS
 **atomic scan**
 [**-h**|**--help**]
-[**--json** | **--detail**] [**--all** | **--images** | **--containers** |
+[**--fetch-cves=True|False**][**--json** | **--detail**] [**--all** | **--images** | **--containers** |
 IMAGE or CONTAINER name ...]
 
 # DESCRIPTION
@@ -15,6 +15,9 @@ IMAGE or CONTAINER name ...]
 # OPTIONS
 **-h** **--help**
   Print usage statement
+
+**--fetch-cves=True|False**
+  Override the fetch-cve (fetch the latest CVE input data from Red Hat over the network) setting in /etc/oscapd/config.ini. Values can  be True or False.
 
 **--json**
   Output in the form of JSON.
@@ -35,6 +38,10 @@ IMAGE or CONTAINER name ...]
 Scan an image named 'foo1'.
 
     atomic scan foo1
+
+Scan an image named 'foo1' with only the files in the openscap-daemon.
+
+    atomic scan --only-cache foo1
 
 Scan images named 'foo1' and 'foo2' and produce a detailed report.
 


### PR DESCRIPTION
    * The openscap-daemon can now optionally take a switch
      to override the behavior defined in its configuration
      file as to whether to fetch new CVE input data or
      not.

        --fetch_cves is now a bool (True|False) where true
            means to pull new, false means do not attempt
            to pull aka "phone home"

    * Added timeout value of 99999 to override the default dbus
      connection timeout of 25 seconds.  This allows longer
      scans to complete and not throw an Exception.

    * Added a small def to detect a bool value based on True,
      true, yes, y, 1 and so on