### PR TITLE
XFS needs 'nouuid' set

### DIFF
--- a/Atomic/mount.py
+++ b/Atomic/mount.py
@@ -371,11 +371,11 @@ class DockerMount(Mount):
             Mount._activate_thin_device(dm_dev_name, dm_dev_id, dm_dev_size,
                                         dm_pool)
 
-        # XFS should get nosuid
+        # XFS should get nouuid
         fstype = Mount._get_fs(dm_dev_path)
-        if fstype.upper() == 'XFS' and 'suid' not in options:
-            if 'nosuid' not in options:
-                options.append('nosuid')
+        if fstype.upper() == 'XFS' and 'nouuid' not in options:
+            if 'nouuid' not in options:
+                options.append('nouuid')
         try:
             Mount.mount_path(dm_dev_path, self.mountpoint,
                              optstring=(','.join(options)))


### PR DESCRIPTION
    For systems that use XFS as the docker FS, 'nouuid' needs to
    be set to avoid duplicate UUID warnings when mounting
    the same container or image multiple times.  XFS is the default
    for RHEL7.

    This also fixes the test_mount.sh failure commonly
    observed on RHEL 7.