### PR TITLE
BUGFIX: Atomic throws exception when no scan_targets are passed

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -432,6 +432,9 @@ class Atomic(object):
             subprocess.check_call(cmd, env=self.cmd_env, shell=True)
 
     def scan(self):
+        if (not self.args.images and not self.args.containers and not self.args.all) and len(self.args.scan_targets) == 0:
+            sys.stderr.write("\nYou must provide a list of containers or images to scan\n")
+            sys.exit(1)
         self.ping()
         BUS_NAME = "org.OpenSCAP.daemon"
         OBJECT_PATH = "/OpenSCAP/daemon"

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -121,6 +121,8 @@ def print_scan_summary(json_data, names=None):
 
     if len(names) > 0:
         max_width = _max_width(names)
+    else:
+        max_width = min_width
     template = "{0:" + str(max_width) + "}   {1:5} {2:5} {3:5} {4:5}"
     sevs = ['critical', 'important', 'moderate', 'low']
     writeOut(template.format("Container/Image", "Cri", "Imp", "Med", "Low"))


### PR DESCRIPTION
    Martin Preisle has found a bug that when you run atomic scan
    without any values, it produces an exception.  This small
    patch verifies that if neither --all, --images, --containers
    is passed, then scan_targets must have at least one
    argument.