### PR TITLE
Proxy new `rpm-ostree deploy` command

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -549,6 +549,16 @@ class Atomic(object):
             argv.append("--os=" % self.args.os )
         self._rpmostree(argv)
 
+    def host_deploy(self):
+        argv = ["deploy", self.args.revision]
+        if self.args.reboot:
+            argv.append("--reboot")
+        if self.args.os:
+            argv.append("--os=" % self.args.os)
+        if self.args.preview:
+            argv.append("--preview")
+        self._rpmostree(argv)
+
     def uninstall(self):
         self.inspect = self._inspect_container()
         if self.inspect and self.force:

--- a/atomic
+++ b/atomic
@@ -169,6 +169,25 @@ if __name__ == '__main__':
                                     "if you want to pass additional "
                                     "unsupported arguments to rpm-ostree."))
 
+        # atomic host deploy
+        deployp = host_subparser.add_parser(
+            "deploy", help=_("deploy a specific commit"))
+        deployp.set_defaults(func=atomic.host_deploy)
+        deployp.add_argument("revision", help=_("Checksum or version to deploy"));
+        deployp.add_argument("-r", "--reboot", dest="reboot",
+                             action="store_true",
+                             help=_("Reboot after deployment is complete"))
+        deployp.add_argument("--os", dest="os",
+                             help=_("Operate on provided OSNAME"))
+        deployp.add_argument("--preview", dest="preview",
+                             action="store_true",
+                             help=_("Just preview package differences"))
+        deployp.add_argument("args", nargs=argparse.REMAINDER,
+                             help=_("Additional arguments appended to the "
+                                    "deploy method.  Use `-- --OPTION=VAL` "
+                                    "if you want to pass additional "
+                                    "unsupported arguments to rpm-ostree."))
+
     # atomic info
     infop = subparser.add_parser(
         "info", help=_("display label information about an image"),

--- a/bash/atomic
+++ b/bash/atomic
@@ -385,7 +385,7 @@ _atomic_host_deploy() {
 _atomic_host_rollback() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--reboot -h --help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "-r --reboot -h --help" -- "$cur" ) )
 			;;
 		*)
 			;;
@@ -395,7 +395,7 @@ _atomic_host_rollback() {
 _atomic_host_status() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "-h --help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "-p --pretty -h --help" -- "$cur" ) )
 			;;
 		*)
 			;;
@@ -405,7 +405,7 @@ _atomic_host_status() {
 _atomic_host_upgrade() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--reboot -h --help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "-r --reboot --os --allow-downgrade --check-diff -h --help" -- "$cur" ) )
 			;;
 		*)
 			;;

--- a/bash/atomic
+++ b/bash/atomic
@@ -372,6 +372,16 @@ _atomic_stop() {
 	esac
 }
 
+_atomic_host_deploy() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "-r --reboot --os --preview -h --help" -- "$cur" ) )
+			;;
+		*)
+			;;
+	esac
+}
+
 _atomic_host_rollback() {
 	case "$cur" in
 		-*)
@@ -424,6 +434,7 @@ _atomic_host_host() {
 
 _atomic_host() {
 	local commands=(
+		deploy
 	        rollback
 		status
 		upgrade

--- a/docs/atomic-host.1.md
+++ b/docs/atomic-host.1.md
@@ -31,6 +31,9 @@ Switch to alternate installed tree at next boot
 **upgrade**
 Upgrade to the latest Atomic tree if one is available
 
+**deploy**
+Download and deploy a specific Atomic tree
+
 # SEE ALSO
     man rpm-ostree 
 


### PR DESCRIPTION
I just added a new `deploy` command to `rpm-ostree` in https://github.com/projectatomic/rpm-ostree/pull/178.

Here's the changes necessary to proxy it through `atomic host`.