### PR TITLE
BUGFIXES: fix critical atomic scan bugs related to Mount

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -454,6 +454,15 @@ class Atomic(object):
                 docker_id = self.get_input_id(scan_input)
                 input_resolve[docker_id] = scan_input
                 scan_list.append(docker_id)
+
+        # Check to make sure none of the docker objects we need to
+        # scan are already mounted.
+        for docker_obj in scan_list:
+            if util.is_dock_obj_mounted(docker_obj):
+                sys.stderr.write("\nThe object {0} is already mounted (in  "
+                                 "use) and therefore cannot be scanned.\n"
+                                 .format(docker_obj))
+                sys.exit(1)
         util.writeOut("\nScanning...\n")
         bus = dbus.SystemBus()
         try:

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -189,3 +189,34 @@ def print_detail_scan_summary(json_data, names=None):
                                                      cve['rhsa_ref_url']))
                         writeOut("")
     return clean
+
+def get_mounts_by_path():
+    '''
+    Gets all mounted devices and paths
+    :return: dict of mounted devices and related information by path
+    '''
+    mount_info = []
+    f = open('/proc/mounts', 'r')
+    for line in f:
+        _tmp = line.split(" ")
+        mount_info.append({'path': _tmp[1],
+                           'device': _tmp[0],
+                           'type': _tmp[2],
+                           'options': _tmp[3]
+                           }
+                          )
+    return mount_info
+
+def is_dock_obj_mounted(docker_obj):
+    '''
+    Check if the provided docker object, which needs to be an ID,
+    is currently mounted and should be considered "busy"
+    :param docker_obj: str, must be in ID format
+    :return: bool True or False
+    '''
+    mount_info = get_mounts_by_path()
+    devices = [x['device'] for x in mount_info]
+    # If we can find the ID of the object in the list
+    # of devices which comes from mount, safe to assume
+    # it is busy.
+    return any(docker_obj in x for x in devices)


### PR DESCRIPTION
    During QE of 'atomic scan', they discovered that when scanning
    of containers occurred, we frequently were left with <none>
    type images.  This was because when containers are mounted, the
    docker mount code actually copies (_clone, docker commit) into
    a new image from which a temporary container is then made.
    However, the temporary image was never removed post-processing.

    While fixing this bug, I discovered two addition bugs that
    needed attention.  When doing a scan, the docker mount backend
    would throw an exception when trying to make a temporary
    directory that already existed.

    And finally, the docker mount backend would throw an exception
    when it tried to work with containers that were already
    mounted.  After speaking with vgoyal and given the inability to
    guess what might be going on there programatically, I have
    injected a quick check prior to handing off to the openscap-
    daemon where if we find that one of the docker objected to be
    scanned is already mounted, we error out there and display
    a nice message to the user explaining that we cannot work
    with busy docker objects.  Per vgoyal, this also follows
    one of docker's golden rules.