### PR TITLE
Make pylint check optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PYLINT ?= /usr/bin/pylint
 GO_MD2MAN ?= /usr/bin/go-md2man
 
 .PHONY: all
-all: python-build docs
+all: python-build docs pylint-check
 
 .PHONY: test
 test:
@@ -16,6 +16,8 @@ test:
 .PHONY: python-build
 python-build:
 	$(PYTHON) setup.py build
+
+pylint-check:
 	$(PYLINT) -E --additional-builtins=_ *.py atomic Atomic tests/unit/*.py
 
 MANPAGES_MD = $(wildcard docs/*.md)

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ test:
 python-build:
 	$(PYTHON) setup.py build
 
+.PHONY: pylint-check
 pylint-check:
 	$(PYLINT) -E --additional-builtins=_ *.py atomic Atomic tests/unit/*.py
 
@@ -33,8 +34,8 @@ clean:
 	$(PYTHON) setup.py clean
 	-rm -rf build *~ \#* *pyc .#* docs/*.1
 
-.PHONY: install
-install: all 
+.PHONY: install-only
+install-only:
 	$(PYTHON) setup.py install --install-scripts /usr/share/atomic `test -n "$(DESTDIR)" && echo --root $(DESTDIR)`
 
 	install -d -m 0755 $(DESTDIR)/usr/bin
@@ -50,3 +51,6 @@ install: all
 	install -m 644 $(basename $(MANPAGES_MD)) $(PREFIX)/share/man/man1
 
 	echo ".so man1/atomic-push.1" > $(PREFIX)/share/man/man1/atomic-upload.1
+
+.PHONY: install
+install: all install-only


### PR DESCRIPTION
Currently it is not possible to build atomic via
make without pylint. We therefore move pylint check
to separate make target