### PR TITLE
atomic: print usage on command line failures

### DIFF
--- a/atomic
+++ b/atomic
@@ -47,8 +47,8 @@ except IOError:
 class HelpByDefaultArgumentParser(argparse.ArgumentParser):
 
     def error(self, message):
-        sys.stderr.write('%s: %s\n' % (sys.argv[0], message))
-        sys.stderr.write("Try '%s --help' for more information.\n" % self.prog)
+        sys.stderr.write('%s: %s\n\n' % (self.prog, message))
+        sys.stderr.write(self.format_help())
         sys.exit(2)
 
 


### PR DESCRIPTION
Instead of telling the user to rerun the tool with `--help`, just
show the usage information at once. Then the subsequent run will
hopefully be a successful one.

Also, IMHO, let's use argparse's program name uniformly, which
may or may not include extra commands (positional arguments).

Signed-off-by: Cleber Rosa <crosa@redhat.com>