### PR TITLE
Module import (re-)organization [v2]

### DIFF
--- a/Atomic/Export.py
+++ b/Atomic/Export.py
@@ -1,16 +1,18 @@
 """
 export docker images, containers and volumes into a filesystem directory.
 """
-import docker
-import sys
 import os
+import sys
 import subprocess
-import Atomic.util as util
-
 try:
     from subprocess import DEVNULL  # pylint: disable=no-name-in-module
 except ImportError:
     DEVNULL = open(os.devnull, 'wb')
+
+import docker
+
+from . import util
+
 
 DOCKER_CLIENT = docker.Client()
 

--- a/Atomic/Import.py
+++ b/Atomic/Import.py
@@ -1,15 +1,16 @@
 """
 import docker images, containers and volumes from a filesystem directory.
 """
-import sys
 import os
+import sys
 import subprocess
-import Atomic.util as util
-
 try:
     from subprocess import DEVNULL  # pylint: disable=no-name-in-module
 except ImportError:
     DEVNULL = open(os.devnull, 'wb')
+
+from . import util
+
 
 def import_docker(graph, import_location):
     """

--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -1,27 +1,29 @@
-import sys
 import os
-import argparse
-import docker
-import json
-import subprocess
-import getpass
-import requests
-import pipes
+import sys
 import pwd
+import json
 import time
 import math
-import Atomic.mount as mount
-import Atomic.util as util
-import Atomic.satellite as satellite
-import Atomic.pulp as pulp
-import dbus
-from Atomic.Export import export_docker
-from Atomic.Import import import_docker
-
+import pipes
+import getpass
+import argparse
+import subprocess
 try:
     from subprocess import DEVNULL  # pylint: disable=no-name-in-module
 except ImportError:
     DEVNULL = open(os.devnull, 'wb')
+
+import dbus
+import docker
+import requests
+
+from . import mount
+from . import util
+from . import satellite
+from . import pulp
+from .Export import export_docker
+from .Import import import_docker
+
 
 IMAGES = []
 

--- a/Atomic/mount.py
+++ b/Atomic/mount.py
@@ -22,13 +22,13 @@
 
 import os
 import sys
+import json
+from fnmatch import fnmatch as matches
 
 import docker
-import json
 
-from Atomic import util
+from . import util
 
-from fnmatch import fnmatch as matches
 
 """ Module for mounting and unmounting containerized applications. """
 

--- a/Atomic/pulp.py
+++ b/Atomic/pulp.py
@@ -1,12 +1,14 @@
-import sys
-import requests
-import json
 import os
-from Atomic import util
+import sys
+import json
 try:
     import ConfigParser as configparser
 except ImportError:  # py3 compat
     import configparser
+
+import requests
+
+from . import util
 
 
 # On latest Fedora, this is a symlink

--- a/Atomic/pulp.py
+++ b/Atomic/pulp.py
@@ -11,23 +11,7 @@ import requests
 from . import util
 
 
-# On latest Fedora, this is a symlink
-if hasattr(requests, 'packages'):
-    requests.packages.urllib3.disable_warnings()
-else:
-    # But with python-requests-2.4.3-1.el7.noarch, we need
-    # to talk to urllib3 directly
-    have_urllib3 = False
-    try:
-        import urllib3
-        have_urllib3 = True
-    except ImportError as e:
-        pass
-    if have_urllib3:
-        # Except only call disable-warnings if it exists
-        if hasattr(urllib3, 'disable_warnings'):
-            urllib3.disable_warnings()
-
+util.urllib3_disable_warnings()
 
 def push_image_to_pulp(image, server_url, username, password,
                        verify_ssl, docker_client):

--- a/Atomic/satellite.py
+++ b/Atomic/satellite.py
@@ -1,13 +1,15 @@
-import sys
-import requests
-import json
 import os
+import sys
+import json
 import base64
-from Atomic import util
 try:
     import ConfigParser as configparser
 except ImportError:  # py3 compat
     import configparser
+
+import requests
+
+from . import util
 
 # On latest Fedora, this is a symlink
 if hasattr(requests, 'packages'):

--- a/Atomic/satellite.py
+++ b/Atomic/satellite.py
@@ -11,22 +11,8 @@ import requests
 
 from . import util
 
-# On latest Fedora, this is a symlink
-if hasattr(requests, 'packages'):
-    requests.packages.urllib3.disable_warnings()
-else:
-    # But with python-requests-2.4.3-1.el7.noarch, we need
-    # to talk to urllib3 directly
-    have_urllib3 = False
-    try:
-        import urllib3
-        have_urllib3 = True
-    except ImportError as e:
-        pass
-    if have_urllib3:
-        # Except only call disable-warnings if it exists
-        if hasattr(urllib3, 'disable_warnings'):
-            urllib3.disable_warnings()
+
+util.urllib3_disable_warnings()
 
 
 def push_image_to_satellite(image, server_url, username, password,

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -221,3 +221,22 @@ def is_dock_obj_mounted(docker_obj):
     # of devices which comes from mount, safe to assume
     # it is busy.
     return any(docker_obj in x for x in devices)
+
+
+def urllib3_disable_warnings():
+    # On latest Fedora, this is a symlink
+    if hasattr(requests, 'packages'):
+        requests.packages.urllib3.disable_warnings()
+    else:
+        # But with python-requests-2.4.3-1.el7.noarch, we need
+        # to talk to urllib3 directly
+        have_urllib3 = False
+        try:
+            import urllib3
+            have_urllib3 = True
+        except ImportError as e:
+            pass
+        if have_urllib3:
+            # Except only call disable-warnings if it exists
+            if hasattr(urllib3, 'disable_warnings'):
+                urllib3.disable_warnings()

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -224,6 +224,11 @@ def is_dock_obj_mounted(docker_obj):
 
 
 def urllib3_disable_warnings():
+    if not 'requests' in sys.modules:
+        import requests
+    else:
+        requests = sys.modules['requests']
+
     # On latest Fedora, this is a symlink
     if hasattr(requests, 'packages'):
         requests.packages.urllib3.disable_warnings()
@@ -232,8 +237,9 @@ def urllib3_disable_warnings():
         # to talk to urllib3 directly
         have_urllib3 = False
         try:
-            import urllib3
-            have_urllib3 = True
+            if not 'urllib3' in sys.modules:
+                import urllib3
+                have_urllib3 = True
         except ImportError as e:
             pass
         if have_urllib3:

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -1,10 +1,11 @@
+import sys
+import json
+import subprocess
 import collections
+from fnmatch import fnmatch as matches
+
 import docker
 import selinux
-import subprocess
-import sys
-from fnmatch import fnmatch as matches
-import json
 
 """Atomic Utility Module"""
 

--- a/atomic
+++ b/atomic
@@ -21,13 +21,13 @@
 #    02110-1301 USA.
 #
 #
-import sys
 import os
-import argparse
+import sys
 import gettext
-import docker
+import argparse
 import subprocess
 
+import docker
 import Atomic
 
 PROGNAME = "atomic"

--- a/atomic_client.py
+++ b/atomic_client.py
@@ -1,7 +1,5 @@
-import dbus
-import dbus.service
-
 import sys
+
 import dbus
 import dbus.service
 import dbus.mainloop.glib


### PR DESCRIPTION
This PR adds a pattern to the module imports used throughout the code, as suggested by PEPs 008 and 328. PEPs aside, the goal is to make it easier to tell the internal and external dependencies of each module.

Also move the urrlib3 warnings handling to the util module.

---

Change from v1 (PR #212):
 - Rebased to latest master