### PR TITLE
Make the tests pass

### DIFF
--- a/Atomic/Export.py
+++ b/Atomic/Export.py
@@ -28,7 +28,7 @@ def export_docker(graph, export_location):
         os.makedirs(export_location)
 
     try:
-	#Save the docker storage driver
+    #Save the docker storage driver
         storage_driver = DOCKER_CLIENT.info()["Driver"]
         filed = open(export_location+"/info.txt", "w")
         filed.write(storage_driver)
@@ -56,32 +56,23 @@ def export_images(export_location):
     split_images, split_ids = ([] for i in range(2))
     for j in DOCKER_CLIENT.images():
         split_images.append(j["RepoTags"])
-    for k in DOCKER_CLIENT.images():
-        split_ids.append(k["Id"])
+        split_ids.append(j["Id"])
 
     dic = {}
 
     for i in range(0, len(split_ids)):
-        if split_images[i] == '<none>:<none>':
+        if '<none>:<none>' in split_images[i]:
             continue
-        if split_ids[i] in dic:
-            dic[split_ids[i]] = [dic[split_ids[i]], split_images[i]]
-        else:
-            dic[split_ids[i]] = split_images[i]
+        if split_ids[i] not in dic:
+            dic[split_ids[i]] = []
+        dic[split_ids[i]].extend(split_images[i])
 
     for ids, images in dic.iteritems():
-        util.writeOut("Exporting image with id: {0}".format(ids[:12]))
-        if isinstance(images, list):
-            img = ""
-            for i, val in enumerate(images):
-                img = img+" "+val
-            subprocess.check_call(
-                "docker save {0} > {1}/images/{2}.tar".format(
-                    img.lstrip(), export_location, ids[:12]), shell=True)
-        else:
-            subprocess.check_call(
-                "docker save {0} > {1}/images/{2}.tar".format(
-                    images, export_location, ids[:12]), shell=True)
+        util.writeOut("Exporting image: {0}".format(ids[:12]))
+        img = " ".join(images)
+        subprocess.check_call(
+            "docker save {0} > {1}/images/{2}.tar".format(
+                img, export_location, ids[:12]), shell=True)
 
 def export_containers(graph, export_location):
     """
@@ -108,7 +99,7 @@ def export_volumes(graph, export_location):
     """
     if not os.path.isdir(export_location + "/volumes"):
         os.makedirs(export_location + "/volumes")
-    util.writeOut("Exporting Volumes")
+    util.writeOut("Exporting volumes")
     subprocess.check_call("/usr/bin/tar --selinux -zcvf {0}/volumes/volumeData.tar.gz"
                           " -C {1}/volumes ."
                           .format(export_location, graph), stdout=DEVNULL, shell=True)

--- a/Atomic/Export.py
+++ b/Atomic/Export.py
@@ -16,6 +16,8 @@ from . import util
 
 DOCKER_CLIENT = docker.Client()
 
+ATOMIC_LIBEXEC = os.environ.get('ATOMIC_LIBEXEC', '/usr/libexec/atomic')
+
 def export_docker(graph, export_location):
     """
     This is a wrapper function for exporting docker images, containers
@@ -93,10 +95,11 @@ def export_containers(graph, export_location):
         split_containers.append(j["Id"])
 
     for i in range(0, len(split_containers)):
-        util.writeOut("Exporting container ID:{0}".format(split_containers[i][:12]))
-        subprocess.check_call("/usr/libexec/atomic/migrate.sh export --container-id={0}"
-                              " --graph={1} --export-location={2}"
-                              .format(split_containers[i][:12], graph, export_location),
+        util.writeOut("Exporting container: {0}".format(split_containers[i][:12]))
+        subprocess.check_call("{0}/migrate.sh export --container-id={1}"
+                              " --graph={2} --export-location={3}"
+                              .format(ATOMIC_LIBEXEC, split_containers[i],
+                                      graph, export_location),
                               shell=True)
 
 def export_volumes(graph, export_location):

--- a/Atomic/Import.py
+++ b/Atomic/Import.py
@@ -12,6 +12,8 @@ except ImportError:
 from . import util
 
 
+ATOMIC_LIBEXEC = os.environ.get('ATOMIC_LIBEXEC', '/usr/libexec/atomic')
+
 def import_docker(graph, import_location):
     """
     This is a wrapper function for importing docker images, containers
@@ -64,10 +66,11 @@ def import_containers(graph, import_location):
     containers = subprocess.check_output("ls {0}/containers".format(import_location), shell=True)
     split_containers = containers.split()
     for i in split_containers:
-        util.writeOut("Importing container ID:{0}".format(i[8:]))
-        subprocess.check_call("/usr/libexec/atomic/migrate.sh import --container-id={0}"
-                              " --graph={1} --import-location={2}"
-                              .format(i[8:], graph, import_location), shell=True)
+        i = i[8:] # strip off the "migrate-"
+        util.writeOut("Importing container: {0}".format(i[:12]))
+        subprocess.check_call("{0}/migrate.sh import --container-id={1}"
+                              " --graph={2} --import-location={3}"
+                              .format(ATOMIC_LIBEXEC, i, graph, import_location), shell=True)
 
 def import_volumes(graph, import_location):
     """

--- a/Atomic/Import.py
+++ b/Atomic/Import.py
@@ -52,7 +52,7 @@ def import_images(import_location):
     tarballs = subprocess.check_output("ls {0}/images".format(import_location), shell=True)
     split_tarballs = tarballs.split()
     for i in split_tarballs:
-        util.writeOut("Importing image with id: {0}".format(i[:-4]))
+        util.writeOut("Importing image: {0}".format(i[:12]))
         subprocess.check_call("docker load < {0}/images/{1}".format(import_location, i), shell=True)
 
 def import_containers(graph, import_location):
@@ -76,7 +76,7 @@ def import_volumes(graph, import_location):
     """
     Method for importing docker volumes from a filesystem directory.
     """
-    util.writeOut("Importing Volumes")
+    util.writeOut("Importing volumes")
     subprocess.check_call("/usr/bin/tar --selinux -xzvf {0}/volumes/volumeData.tar.gz"
                           " -C {1}/volumes"
                           .format(import_location, graph), stdout=DEVNULL, shell=True)

--- a/Atomic/Import.py
+++ b/Atomic/Import.py
@@ -4,10 +4,6 @@ import docker images, containers and volumes from a filesystem directory.
 import os
 import sys
 import subprocess
-try:
-    from subprocess import DEVNULL  # pylint: disable=no-name-in-module
-except ImportError:
-    DEVNULL = open(os.devnull, 'wb')
 
 from . import util
 
@@ -39,7 +35,7 @@ def import_docker(graph, import_location):
     choice = sys.stdin.read(1)
     if (choice == 'y') or (choice == 'Y'):
         util.writeOut("Deleting {0}".format(import_location))
-        subprocess.check_call("rm -rf {0}".format(import_location), shell=True)
+        subprocess.check_call(['/usr/bin/rm', '-rf', import_location])
     else:
         util.writeOut("Cleanup operation aborted")
     util.writeOut("Please restart docker daemon for the changes to take effect")
@@ -49,38 +45,44 @@ def import_images(import_location):
     """
     Method for importing docker images from a filesystem directory.
     """
-    tarballs = subprocess.check_output("ls {0}/images".format(import_location), shell=True)
-    split_tarballs = tarballs.split()
-    for i in split_tarballs:
-        util.writeOut("Importing image: {0}".format(i[:12]))
-        subprocess.check_call("docker load < {0}/images/{1}".format(import_location, i), shell=True)
+    subdir = import_location + '/images'
+    images = os.listdir(subdir)
+    for image in images:
+        util.writeOut("Importing image: {0}".format(image[:12]))
+        with open(subdir + '/' + image) as f:
+            subprocess.check_call(["/usr/bin/docker", "load"], stdin=f)
 
 def import_containers(graph, import_location):
     """
     Method for importing docker containers from a filesystem directory.
     """
-    if not os.path.isdir(import_location + "/containers"):
-        sys.exit("{0} does not exist. No containers to import."
-                 .format(import_location+"/containers"))
+    subdir = import_location + '/containers'
+    containers = os.listdir(subdir)
+    for cnt in containers:
+        cnt = cnt[8:] # strip off the "migrate-" prefix
+        util.writeOut("Importing container: {0}".format(cnt[:12]))
+        subprocess.check_call([ATOMIC_LIBEXEC + '/migrate.sh',
+                               'import',
+                               '--container-id=' + cnt,
+                               '--graph=' + graph,
+                               '--import-location=' + import_location])
 
-    containers = subprocess.check_output("ls {0}/containers".format(import_location), shell=True)
-    split_containers = containers.split()
-    for i in split_containers:
-        i = i[8:] # strip off the "migrate-"
-        util.writeOut("Importing container: {0}".format(i[:12]))
-        subprocess.check_call("{0}/migrate.sh import --container-id={1}"
-                              " --graph={2} --import-location={3}"
-                              .format(ATOMIC_LIBEXEC, i, graph, import_location), shell=True)
+def tar_extract(srcfile, destdir):
+    subprocess.check_call(['/usr/bin/tar', '--extract', '--gzip', '--selinux',
+                           '--file', srcfile, '--directory', destdir])
 
 def import_volumes(graph, import_location):
     """
     Method for importing docker volumes from a filesystem directory.
     """
-    util.writeOut("Importing volumes")
-    subprocess.check_call("/usr/bin/tar --selinux -xzvf {0}/volumes/volumeData.tar.gz"
-                          " -C {1}/volumes"
-                          .format(import_location, graph), stdout=DEVNULL, shell=True)
-    if os.path.isdir(graph + "/vfs"):
-        subprocess.check_call("/usr/bin/tar --selinux -xzvf {0}/volumes/vfsData.tar.gz"
-                              " -C {1}/vfs"
-                              .format(import_location, graph), stdout=DEVNULL,  shell=True)
+
+    volfile = import_location + '/volumes/volumeData.tar.gz'
+    if os.path.isfile(volfile):
+        util.writeOut("Importing volumes")
+        tar_extract(srcfile=volfile,
+                    destdir = graph + '/volumes')
+
+    vfsfile = import_location + '/volumes/vfsData.tar.gz'
+    if os.path.isfile(vfsfile) and os.path.isdir(graph + "/vfs"):
+        tar_extract(srcfile=vfsfile,
+                    destdir = graph + '/vfs')

--- a/migrate.sh
+++ b/migrate.sh
@@ -73,6 +73,16 @@ fi
 
 }
 
+get_docker_pid() {
+	if ! systemctl is-active docker >/dev/null; then
+		echo "Docker daemon is not running"
+		exit 1
+	fi
+
+	pid=$(systemctl show -p MainPID docker.service)
+	echo ${pid#*=}
+}
+
 container_export(){
 	for arg in "$@"
 	do 
@@ -100,7 +110,7 @@ container_export(){
 		exportPath="/var/lib/atomic/migrate"
 	fi
 
-        dockerPid=$(ps aux|grep [d]ocker|awk 'NR==1{print $2}')
+        dockerPid=$(get_docker_pid)
         dockerCmdline=$(cat /proc/$dockerPid/cmdline)||exit 1
         if [[ $dockerCmdline =~ "-g=" ]] || [[ $dockerCmdline =~ "-g/" ]] || [[ $dockerCmdline =~ "--graph" ]];then
                 if [ -z "$dockerRootDir" ] || [ $dockerRootDir = "/var/lib/docker" ];then
@@ -158,7 +168,7 @@ container_import(){
                 importPath="/var/lib/atomic/migrate"
         fi
 
-	dockerPid=$(ps aux|grep [d]ocker|awk 'NR==1{print $2}')
+        dockerPid=$(get_docker_pid)
         dockerCmdline=$(cat /proc/$dockerPid/cmdline)||exit 1
         if [[ $dockerCmdline =~ "-g=" ]] || [[ $dockerCmdline =~ "-g/" ]] || [[ $dockerCmdline =~ "--graph" ]];then
                 if [ -z "$dockerRootDir" ] || [ $dockerRootDir = "/var/lib/docker" ];then

--- a/migrate.sh
+++ b/migrate.sh
@@ -2,6 +2,9 @@
 # bash script to migrate containers from one backend storage to another.
 set -e
 
+ATOMIC_LIBEXEC="${ATOMIC_LIBEXEC-/usr/libexec/atomic}"
+GOTAR="$ATOMIC_LIBEXEC/gotar"
+
 main() {
 if [ $(id -u) != 0 ];then
 	echo "Run 'migrate' as root user"
@@ -116,11 +119,11 @@ container_export(){
 	echo $dockerRootDir>containerInfo.txt
 	echo $containerBaseImageID>>containerInfo.txt
 	echo $notruncContainerID>>containerInfo.txt
-        /usr/libexec/atomic/gotar -cf container-metadata.tar $dockerRootDir/containers/$notruncContainerID 2> /dev/null
+        "$GOTAR" -cf container-metadata.tar $dockerRootDir/containers/$notruncContainerID 2> /dev/null
         imageID=$(docker commit $containerID)||exit 1
         mkdir -p $tmpDir/temp
         docker save $imageID > $tmpDir/temp/image.tar||exit 1
-	$(cd $tmpDir/temp; /usr/libexec/atomic/gotar -xf image.tar)
+	$(cd $tmpDir/temp; "$GOTAR" -xf image.tar)
         cd $tmpDir/temp/$imageID
         cp layer.tar $tmpDir/container-diff.tar
         cd $tmpDir
@@ -169,14 +172,14 @@ container_import(){
 
 	cd $importPath/containers/migrate-$containerID
 	dockerBaseImageID=$(sed -n '2p' containerInfo.txt)||exit 1	
-	cat container-diff.tar|docker run -i -v /usr/libexec/atomic/gotar:/dev/shm/gotar $dockerBaseImageID /dev/shm/gotar -xf -
+	cat container-diff.tar|docker run -i -v "$GOTAR:/dev/shm/gotar" $dockerBaseImageID /dev/shm/gotar -xf -
 	newContainerID=$(docker ps -lq)||exit 1
 	newContainerName=$(docker inspect -f '{{.Name}}' $newContainerID)||exit 1
 	newNotruncContainerID=$(docker ps -aq --no-trunc|grep $newContainerID)||exit 1					
 	cd $dockerRootDir/containers/$newNotruncContainerID
 	rm -rf *
 	cp $importPath/containers/migrate-$containerID/container-metadata.tar .
-	/usr/libexec/atomic/gotar -xf container-metadata.tar	
+	"$GOTAR" -xf container-metadata.tar	
 	rm container-metadata.tar
 	oldDockerRootDir=$(sed -n '1p' $importPath/containers/migrate-$containerID/containerInfo.txt)||exit 1
 	oldNotruncContainerID=$(sed -n '3p' $importPath/containers/migrate-$containerID/containerInfo.txt)||exit 1

--- a/test.sh
+++ b/test.sh
@@ -9,6 +9,7 @@ export PYTHONPATH=${PYTHONPATH:-$(pwd)}
 export WORK_DIR=$(mktemp -p $(pwd) -d -t .tmp.XXXXXXXXXX)
 export DOCKER=${DOCKER:-"/usr/bin/docker"}
 export SECRET=`dd if=/dev/urandom bs=4096 count=1 2> /dev/null | sha256sum`
+export ATOMIC_LIBEXEC="$(pwd)"
 
 # This image contains the secret, so it needs to be rebuilt each time.
 cat > tests/test-images/Dockerfile.secret <<EOF

--- a/tests/integration/test_display.sh
+++ b/tests/integration/test_display.sh
@@ -39,8 +39,9 @@ if [[ ${OUTPUT} != "I am the run label." ]]; then
     exit 1
 fi
 
+# The centos image does not have an INSTALL label, so `atomic install` should be
+# a noop.
 OUTPUT=`${ATOMIC} install --display -n TEST5 centos | xargs`
-OUTPUT2='/usr/bin/docker run -t -i --rm --privileged -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=TEST5 -e IMAGE=centos -e CONFDIR=/host/etc/TEST5 -e LOGDIR=/host/var/log/TEST5 -e DATADIR=/host/var/lib/TEST5 --name TEST5 centos'
-if [[ ${OUTPUT} != ${OUTPUT2} ]]; then
+if [[ -n ${OUTPUT} ]]; then
     exit 1
 fi


### PR DESCRIPTION
This patch series makes some fixes so that the tests pass again.

PR #198 was merged with the tests failing. This caused the PRs that followed to also be marked as failures, thus potentially hiding any new failures. On the plus side, these failures have also helped uncover a few issues with the testing infrastructure, which should now all be resolved.

Hopefully, the auto-tester will like this PR. Once master passes again, PRs that are rebased should get a clearer picture of whether things passed or failed and why.