### PR TITLE
Atomic TOP: Top-like display for container processes

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -1054,12 +1054,12 @@ class Atomic(object):
 
         return self.containers
 
-    def get_active_containers(self):
+    def get_active_containers(self, refresh=False):
         '''
         Wrapper function for obtaining active containers.  Should be used
         instead of direct queries to docker
         '''
-        if not self.active_containers:
+        if not self.active_containers or refresh:
             self.active_containers = self.d.containers(all=False)
 
         return self.active_containers
@@ -1074,3 +1074,22 @@ def SetFunc(function):
         def __call__(self, parser, namespace, values, option_string=None):
             setattr(namespace, self.dest, function)
     return customAction
+
+
+class AtomicDocker(docker.Client):
+    """
+    A class based on the docker client class with custom APIs specifically for
+    atomic
+    """
+    def atomic_top(self, container, ps_args=None):
+        """
+        Same as the docker top API but allows passing of ps args
+        :param container: container ID
+        :param ps_args:  custom ps args
+        :return:
+        """
+        u = self._url("/containers/{0}/top".format(container))
+        params = {}
+        if ps_args is not None:
+            params['ps_args'] = ps_args
+        return self._result(self._get(u, params=params), True)

--- a/Atomic/top.py
+++ b/Atomic/top.py
@@ -1,0 +1,201 @@
+from . import Atomic
+from .atomic import AtomicDocker
+from . import util
+import tty
+import sys
+import termios
+import select
+from operator import itemgetter
+
+
+class Top(Atomic):
+    """
+    Class to support atomic top; based on the Atomic class
+    """
+    # Set to true to output debug information
+    DEBUG = False
+
+    def __init__(self):
+        super(Top, self).__init__()
+        self.input_var = None
+        self._sort = 'CID'
+        self.AD = AtomicDocker()
+        self.name_id = {}
+        self.optional = None
+        self.titles = None
+        # To add a new column to the output, create a new dict inside self.headers
+        # The fields are as follows:
+        # shortname: <str> a unique key used to describe the dict
+        # column: <str> column title, use parans to define a sort character
+        # character: <str> a single character the user presses to sort on that column
+        # sort: <bool> to determine IF the column can be sorted upon
+        # index: <int> order the columns display left to right. Do not change 0-5
+        # _field: <str> If the width of the column needs to be dynamically sized, put
+        #               the formatting in _field, set field to None, and be sure to
+        #               add a key for _min_width
+        # field: <str> the preferred format for the column
+        # active: if the column should be active by default
+        # ps_opt: <str> the descriptor for ps to get the column's data (ps -o)
+        # sort_order: <bool> True reverses the sort order from ascending to descending
+        # _min_width: <int> Minimum field width if you are using dynamic fields
+        self.headers = [
+            {'shortname': '%CPU', 'column': '(C)PU', 'character': 'c', 'sort': True, 'index': 3,
+             'field': '{:6}', 'active': True, 'ps_opt': 'pcpu', 'sort_order': True},
+            {'shortname': 'CID', 'column': 'CONTA(I)NER', 'character': 'i', 'sort': True, 'index': 0,
+             'field': '{:12.12}', 'active': True, 'ps_opt': None, 'sort_order': False},
+            {'shortname': 'NAME', 'column': '(N)AME', 'character': 'n', 'sort': True, 'index': 1,
+             '_field': '{:WIDTH}', 'field': None, 'active': True, 'ps_opt': None, 'sort_order': False,
+             '_min_width': 10},
+            {'shortname': 'PID', 'column': '(P)ID', 'character': 'p', 'sort': True, 'index': 2,
+             'field': '{:<10}', 'active': True, 'ps_opt': 'pid', 'sort_order': False},
+            {'shortname': '%MEM', 'column': '(M)EM', 'character': 'm', 'sort': True, 'index': 4,
+             'field': '{:6}', 'active': True, 'ps_opt': 'pmem', 'sort_order': True},
+            {'shortname': 'CMD', 'column': 'CMD', 'character': None, 'sort': False, 'index': 99,
+             '_field': '{:WIDTH}', 'field': None, 'active': True, 'ps_opt': 'cmd', '_min_width': 10},
+            {'shortname': 'TIME', 'column': '(T)IME', 'character': 't', 'sort': True, 'index': 6,
+             'field': '{:10}', 'active': False, 'ps_opt': 'time', 'sort_order': True},
+            {'shortname': 'STIME', 'column': '(S)TIME', 'character': 's', 'sort': True, 'index': 7,
+             'field': '{:10}', 'active': False, 'ps_opt': 'stime', 'sort_order': True},
+            {'shortname': 'PPID', 'column': 'PPI(D)', 'character': 'd', 'sort': True, 'index': 8,
+             'field': '{:10}', 'active': False, 'ps_opt': 'ppid', 'sort_order': False}
+        ]
+
+    def _activate_optionals(self):
+        """
+        Sets the active bool to True for any optional  ps
+        arguments.
+        :return: None
+        """
+        if self.args.optional:
+            for option in self.args.optional:
+                for header in self.headers:
+                    if header['ps_opt'] == option:
+                        header['active'] = True
+
+    def _set_dynamic_column_widths(self, ps_info):
+        for header in self.headers:
+            if '_field' in header:
+                max_widths = [len(x[header['shortname']]) for x in ps_info]
+                max_width = header['_min_width'] if not max_widths else max(max_widths)
+                header['field'] = header['_field'].replace('WIDTH', str(max_width))
+
+    def atomic_top(self):
+        """
+        Main sub-function for top
+        :return: None
+        """
+        # Activate optional columns
+        self._activate_optionals()
+
+        # Set up terminal, input handling
+        fd = sys.stdin.fileno()
+        old_settings = termios.tcgetattr(fd)
+        sort_vals = [x['character'].upper() for x in self.headers if x['active'] and x['sort']]
+        while True:
+            proc_info = []
+            if len(self.args.containers) < 1:
+                con_ids = [x['Id'] for x in self.get_active_containers(refresh=True)]
+            else:
+                con_ids = self.args.containers
+            for cid in con_ids:
+                proc_info += self.get_pids_by_container(cid)
+            # Reset screen
+            if not self.DEBUG:
+                util.writeOut("\033c")
+            sorted_info = self.reformat_ps_info(proc_info)
+            self._set_dynamic_column_widths(sorted_info)
+            self.output_top(sorted_info)
+            tty.setraw(sys.stdin.fileno())
+            i, ii, iii = select.select([sys.stdin], [], [], self.args.d)
+            if i:
+                ch = sys.stdin.read(1)
+                # Detect 'q' or Cntrl-c
+                if ch.upper() == 'q'.upper() or ord(ch) == 3:
+                    # reset terminal
+                    termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+                    raise SystemExit
+                # Detect of the character pushed is one in self.headers
+                elif ch.upper() in sort_vals:
+                    self._sort = next((header['shortname'] for header in self.headers if header['character'] is not
+                                       None and header['character'].upper() == ch.upper()), False)
+
+            # reset terminal
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+
+    def get_pids_by_container(self, con_id):
+        """
+        Call the custom API for docker python
+        :param con_id: id of the container
+        :return: dict
+        """
+        f_procs = []
+        # Get the name of the container by ID
+        con_name = str(next((l for l in self.active_containers if l['Id'] == con_id), None)['Names'][0])
+        if con_name.startswith("/"):
+            con_name = con_name.replace("/", "")
+        # Assemble the ps args
+        ps_args = [header['ps_opt']for header in sorted(self.headers, key=itemgetter('index')) if header['ps_opt']
+                   is not None and header['active']]
+        con_procs = self.AD.atomic_top(con_id, ps_args="o {}".format(",".join(ps_args)))
+
+        # Set the column header titles one-time
+        if self.titles is None:
+            self.titles = con_procs['Titles']
+
+        # Massage the information into a dict
+        for proc in con_procs['Processes']:
+            t_dict = {'CID': con_id,
+                      'NAME': con_name}
+            for place in range(0, len(proc)):
+                t_dict[self.titles[place]] = proc[place]
+            f_procs.append(t_dict)
+        return f_procs
+
+    def output_top(self, sorted_info):
+        """
+        Primary function for output to stdout
+        :param sorted_info: list of dicts containing process information
+        :return: None
+        """
+        cols = [col for col in sorted(self.headers, key=itemgetter('index')) if col['active']]
+        active_column_names = [x['shortname'] for x in cols]
+        out_format = " ".join([x['field'] for x in cols])
+        col_headers = []
+
+        # Add a '*' to the column header name currently being
+        # sorted on
+        for col in cols:
+            title = col['column']
+            if col['shortname'] == self._sort:
+                title += "*"
+            col_headers.append(title)
+        formatted_col_headers = "\033[7m" + out_format.format(*col_headers) + "\033[0m"
+        # output ATOMIC TOP title
+        almost_center = len(formatted_col_headers)
+        center_col = '{:^%WIDTH%}'.replace("%WIDTH%", str(almost_center))
+        util.writeOut(center_col.format("ATOMIC TOP\n"))
+        # Output the headers
+        util.writeOut(formatted_col_headers)
+        for ps in sorted_info:
+            line_out = []
+            for val in active_column_names:
+                line_out.append(ps[val])
+            # Output the ps information
+            util.writeOut(out_format.format(*line_out))
+
+    def reformat_ps_info(self, proc_info):
+        """
+        Takes a structure of process information and re-organizes it into
+        a list of dictionaries, where each dict is a process.
+        :param proc_info:
+        :return: a list of dicts
+        """
+        # Determine if the sort field needs to reverse the order of the sort
+        _reverse = next((header['sort_order'] for header in self.headers if header['shortname'] == self._sort), False)
+        if self.DEBUG:
+            util.writeOut("sorting on {0} and reverse is {1}".format(self._sort, _reverse))
+        return sorted(proc_info, key=itemgetter(self._sort), reverse=_reverse)
+
+
+
+

--- a/atomic
+++ b/atomic
@@ -30,6 +30,7 @@ import subprocess
 import docker
 import Atomic
 from Atomic.diff import Diff
+from Atomic.top import Top
 
 PROGNAME = "atomic"
 gettext.bindtextdomain(PROGNAME, "/usr/share/locale")
@@ -414,6 +415,14 @@ if __name__ == '__main__':
         default=False,
         action="store_true",
         help=_("preview the command that %s would execute") % sys.argv[0])
+
+    # atomic top
+    topp = subparser.add_parser(
+    "top", help=_("Show top-like stastics about processes running in containers"))
+    topp.set_defaults(_class=Top, func='atomic_top')
+    topp.add_argument("-d", type=int, default=1, help=_("Interval (secs) to refresh process information"))
+    topp.add_argument("-o", "--optional", help=_("Additional fields to display"), nargs='*', choices=['time', 'stime', 'ppid'])
+    topp.add_argument("containers", nargs="*", help=_("list of containers to monitor, leave blank for all"))
 
     # atomic uninstall
     uninstallp = subparser.add_parser(

--- a/bash/atomic
+++ b/bash/atomic
@@ -201,6 +201,37 @@ _atomic_scan() {
 	return 0
 
 }
+
+_atomic_top() {
+    local options_with_args="
+		--optional
+		-o
+		-d
+	"
+    local all_options="$options_with_args"
+    [ "$command" = "top" ] && all_options="$all_options"
+    local options_with_args_glob=$(__atomic_to_extglob "$options_with_args")
+
+    case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "$all_options" -- "$cur" ) )
+			;;
+		*)
+
+			local counter=$( __atomic_pos_first_nonflag $( __atomic_to_alternatives "$options_with_args" ) )
+
+			if [ $cword -eq $counter ]; then
+				__atomic_containers_and_images
+				return 0
+			fi
+
+			COMPREPLY=( $( compgen -d "$cur" ) )
+			return 0
+			;;
+	esac
+	return 0
+}
+
 _atomic_verify() {
 	case "$cur" in
 		*)
@@ -583,9 +614,10 @@ _atomic() {
 		images
 		migrate
 		mount
+		run
 		scan
 		stop
-		run
+		top
 		verify
 		version
 		uninstall

--- a/docs/atomic.1.md
+++ b/docs/atomic.1.md
@@ -44,6 +44,9 @@ scan an image or container for CVEs
 **atomic-stop(1)**
 execute container image stop method
 
+**atomic-top(1)**
+display a top-like list of container processes
+
 **atomic-uninstall(1)**
 uninstall container from system
 


### PR DESCRIPTION
Adding a new atomic sub-command that behaves like GNU top
but for processes being run for containers.  It currently
displays the container id,  container name,
pid, cpu% (as reported by docker
top), mem% (as reported by docker top), and the command.

You can optionally pass in -o ppid, stime, time to collect
more data on the processes themselves.

While in the interactive display, you can also sort on
the columns to re-organize the data as needed.

You can define an interval for refreshing the process
information.

atomic top can be run without any additional
parameters.  If that is the case, it will by default
show processes for all active containers.  You can also
add one or more container_ids for exclusive process
monitoring by container.

Also added an AtomicDocker class to atomic.py which
allows for custom docker, python-api calls without
having to re-invent the wheel.