### PR TITLE
In docker-1.10 the device/imageIDs are not == to container ID

### DIFF
--- a/atomic
+++ b/atomic
@@ -447,7 +447,7 @@ if __name__ == '__main__':
 
     # atomic unmount
     unmountp = subparser.add_parser(
-        "unmount", help=_("unmount container image"),
+        "unmount", aliases=["umount"],help=_("unmount container image"),
         epilog="atomic unmount will unmount a container image previously "
         "mounted with atomic mount")
     unmountp.set_defaults(func='unmount')


### PR DESCRIPTION
This is causing atomic unmount to fail. This searches for the DeviceName
in the list of containers to umount.