### PR TITLE
Install Check:

### DIFF
--- a/atomic
+++ b/atomic
@@ -405,6 +405,9 @@ if __name__ == '__main__':
     runp.add_argument("--spc", default=False, action="store_true",
                       help=_("use super privileged container mode: '%s'" %
                              atomic.print_spc()))
+    runp.add_argument("--nocheck", default=False, action="store_true",
+                      help=_("disables checking if atomic install has "
+                             "been run"))
     runp.add_argument("image", help=_("container image"))
     runp.add_argument("command", nargs=argparse.REMAINDER,
                       help=_("command to execute within the container. "


### PR DESCRIPTION
At present, when 'atomic run' is called, there is no check to see
if an atomic install has occurred (if needed).  This could result
in the an imaging faling to run or running incorrectly.

We introduce a file (/var/lib/atomic/install) that keeps a record
of which images have been installed.

The file looks something like:

```
{
    "install-test": {
        "image_name": "install_test",
        "installed": true,
        "instances": [
            {
                "date": "2015-12-11 14:09:27.957807",
                "iid": "56c6bd1160a15dbb2905779173cb3df7a0b1445f24378dc039fc7b76f08a0077"
            }
        ]
    }
}

```

atomic run will now check if the image in question has an INSTALL
label, and if so, it will see if the image has been installed.  The
check now is simply looking for the presence of the image name.  In
the future, the checking can be more complex, for example, by
combining the image name and image id.

atomic run also has a --nocheck option which allows users to override
the install check.