### PR TITLE
Atomic Diff: RPMS arent being collected

### DIFF
--- a/Atomic/diff.py
+++ b/Atomic/diff.py
@@ -31,6 +31,7 @@ class Diff(Atomic):
                     if not rpmimage.is_rpm:
                         helpers._cleanup(image_list)
                         raise ValueError("{0} is not RPM based.".format(rpmimage.name))
+                    rpmimage._get_rpm_content()
                     rpm_image_list.append(rpmimage)
 
             if not self.args.no_files:


### PR DESCRIPTION
Due to very small bug, the function that collects the
operating system version and RPMs was not being called.