### PR TITLE
 In docker-1.10 the device/imageIDs are not == to container ID

### DIFF
--- a/Atomic/verify.py
+++ b/Atomic/verify.py
@@ -3,8 +3,6 @@ from . import Atomic
 import os
 from docker.errors import NotFound
 from operator import itemgetter
-from exceptions import StopIteration
-
 
 class Verify(Atomic):
     DEBUG = False

--- a/atomic
+++ b/atomic
@@ -448,7 +448,7 @@ if __name__ == '__main__':
 
     # atomic unmount
     unmountp = subparser.add_parser(
-        "unmount", help=_("unmount container image"),
+        "unmount", aliases=["umount"],help=_("unmount container image"),
         epilog="atomic unmount will unmount a container image previously "
         "mounted with atomic mount")
     unmountp.set_defaults(func='unmount')


### PR DESCRIPTION
This is causing atomic unmount to fail. This searches for the DeviceName
in the list of containers to umount.

Since I was constantly typing `atomic umount` rather then `atomic unmount`,
I thought we should add an alias.