### PR TITLE
Pass integer to dmsetup

### DIFF
--- a/Atomic/mount.py
+++ b/Atomic/mount.py
@@ -83,7 +83,7 @@ class Mount:
         Provisions an LVM device-mapper thin device reflecting,
         DM device id 'dm_id' in the docker pool.
         """
-        table = '0 %d thin /dev/mapper/%s %s' %  (int(size)/512, pool, dm_id)
+        table = '0 %d thin /dev/mapper/%s %s' %  (int(size)//512, pool, dm_id)
 
         cmd = ['dmsetup', 'create', name, '--table', table]
         r = util.subp(cmd)


### PR DESCRIPTION
oscap-docker on Fedora 23 failed with a MountError exception.  strace-ing the process produced the following output:

[pid 17354] execve("/sbin/dmsetup", ["dmsetup", "create", "docker-253:1-791413-c135d4b9e1cd9f68485765ed681cf80b8fe1e91559fc8a3101ecf59e35a05501", "--table", "0 20971520.0 thin /dev/mapper/vg_air-docker--pool 445"], [/* 38 vars */]) = 0
[pid 17354] +++ exited with 1 +++
--- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=17354, si_uid=0, si_status=1, si_utime=0, si_stime=0} ---
Traceback (most recent call last):
  File "/bin/oscap-docker", line 108, in <module>
    args.func()
  File "/bin/oscap-docker", line 44, in cve_scan
    result = OS.scan_cve(self.args.scan_target, self.unknown_args)
  File "/usr/lib/python3.4/site-packages/oscap_docker_python/oscap_docker_util.py", line 193, in scan_cve
    _tmp_mnt_dir = DM.mount(image)
  File "/usr/lib/python3.4/site-packages/Atomic/mount.py", line 294, in mount
    driver_mount_fn(identifier, options)
  File "/usr/lib/python3.4/site-packages/Atomic/mount.py", line 372, in _mount_devicemapper
    dm_pool)
  File "/usr/lib/python3.4/site-packages/Atomic/mount.py", line 91, in _activate_thin_device
    raise MountError('Failed to create thin device: ' + r.stderr.decode('utf-8'))
Atomic.mount.MountError: Failed to create thin device: device-mapper: reload ioctl on docker-253:1-791413-c135d4b9e1cd9f68485765ed681cf80b8fe1e91559fc8a3101ecf59e35a05501 failed: Invalid argument
Command failed

"dmsetup create" is passed decimal 20971520.0 when an integer is needed.

---
Is size always an integer?  Then int(size/512) would be sufficient.

This is untested, but a similar change worked on Fedora's atomic-1.6-5.git09ac479.fc23.x86_64 package.