### PR TITLE
test.sh: add TEST_INTEGRATION support

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -134,6 +134,15 @@ export ATOMIC="${COVERAGE}
 atomic"
 
 for tf in `find ./tests/integration/ -name test_*.sh`; do
+
+    if [ -n "${TEST_INTEGRATION+ }" ]; then
+        tfbn=$(basename "$tf" .sh)
+        tfbn="${tfbn#test_}"
+        if [[ " $TEST_INTEGRATION " != *" $tfbn "* ]]; then
+            continue
+        fi
+    fi
+
     printf "Running test $(basename ${tf})...\t\t"
     printf "\n==== ${tf} ====\n" >> ${LOG}
     if ${tf} &>> ${LOG}; then


### PR DESCRIPTION
This allows users to skip all/certain tests.

```
$ sudo make test
	tests all integration tests

$ sudo make test TEST_INTEGRATION=
	skip all integration tests

$ sudo make test TEST_INTEGRATION='display pass'
	test only the 'display' and 'pass' integration tests
```

Resolves: #259

---

This is a first step at least for integration tests, which take the longest. A `TEST_UNIT` variable could be added at a later time for similarly filtering unit tests.