### PR TITLE
Re-enable execution of the container image stop label

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -511,12 +511,13 @@ class Atomic(object):
                 sys.exit(1)
 
     def stop(self):
-        try:
-            cid = self._is_container(self.name, active=True)
-            self.name = cid
-        except AtomicError as error:
-            util.writeOut(error)
-            sys.exit(1)
+        self.inspect = self._inspect_container()
+        if self.inspect is None:
+            self.inspect = self._inspect_image()
+            if self.inspect is None:
+                util.writeOut("Container/Image '%s' does not exists" %
+                              self.name)
+                sys.exit(1)
 
         args = self._get_args("STOP")
         if args:

--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -520,7 +520,7 @@ class Atomic(object):
 
         args = self._get_args("STOP")
         if args:
-            cmd = self.gen_cmd(args)
+            cmd = self.gen_cmd(args + list(map(pipes.quote, self.args.args)))
             self.display(cmd)
             subprocess.check_call(cmd, env=self.cmd_env, shell=True)
 

--- a/atomic
+++ b/atomic
@@ -392,6 +392,9 @@ if __name__ == '__main__':
     stopp.add_argument("-n", "--name", dest="name", default=None,
                        help=_("name of container"))
     stopp.add_argument("image", help=_("container image"))
+    stopp.add_argument("args", nargs=argparse.REMAINDER,
+                          help=_("Additional arguments appended to the image "
+                                 "stop method"))
 
     # atomic run
     runp = subparser.add_parser(

--- a/docs/atomic-stop.1.md
+++ b/docs/atomic-stop.1.md
@@ -8,7 +8,7 @@ atomic-stop - Execute container image stop method
 **atomic stop**
 [**-h**|**--help**]
 [**-n**][**--name**[=*NAME*]]
-IMAGE
+IMAGE [ARG...]
 
 # DESCRIPTION
 **atomic stop** attempts to read the `LABEL STOP` field in the container
@@ -27,6 +27,8 @@ atomic would execute this command before stopping the container.
 
 If this field does not exist, `atomic stop` will just stop the container, if
 the container is running.
+
+Any additional arguments will be appended to the command.
 
 # OPTIONS:
 **-h** **--help**


### PR DESCRIPTION
Also allow for trailing arguments to be passed to the command in the stop label.