### PR TITLE
Atomic: top: add optional uid,gid,user,group to ps_args

### DIFF
--- a/Atomic/top.py
+++ b/Atomic/top.py
@@ -58,7 +58,15 @@ class Top(Atomic):
             {'shortname': 'STIME', 'column': '(S)TIME', 'character': 's', 'sort': True, 'index': 7,
              'field': '{:10}', 'active': False, 'ps_opt': 'stime', 'sort_order': True},
             {'shortname': 'PPID', 'column': 'PPI(D)', 'character': 'd', 'sort': True, 'index': 8,
-             'field': '{:10}', 'active': False, 'ps_opt': 'ppid', 'sort_order': False}
+             'field': '{:10}', 'active': False, 'ps_opt': 'ppid', 'sort_order': False},
+            {'shortname': 'UID', 'column': '(U)ID', 'character': 'u', 'sort': True, 'index': 9,
+             'field': '{:6}', 'active': True, 'ps_opt': 'uid', 'sort_order': True},
+            {'shortname': 'GID', 'column': '(G)ID', 'character': 'g', 'sort': True, 'index': 10,
+             'field': '{:6}', 'active': True, 'ps_opt': 'gid', 'sort_order': True},
+            {'shortname': 'USER', 'column': 'USER', 'character': None, 'sort': False, 'index': 11,
+             'field': '{:10}', 'active': False, 'ps_opt': 'user'},
+            {'shortname': 'GROUP', 'column': 'GROUP', 'character': None, 'sort': False, 'index': 12,
+             'field': '{:10}', 'active': False, 'ps_opt': 'group'}
         ]
 
     def _activate_optionals(self):

--- a/atomic
+++ b/atomic
@@ -433,7 +433,7 @@ if __name__ == '__main__':
     "top", help=_("Show top-like stastics about processes running in containers"))
     topp.set_defaults(_class=Top, func='atomic_top')
     topp.add_argument("-d", type=int, default=1, help=_("Interval (secs) to refresh process information"))
-    topp.add_argument("-o", "--optional", help=_("Additional fields to display"), nargs='*', choices=['time', 'stime', 'ppid'])
+    topp.add_argument("-o", "--optional", help=_("Additional fields to display"), nargs='*', choices=['time', 'stime', 'ppid', 'uid', 'gid', 'user', 'group'])
     topp.add_argument("-n", help=_("Number of iterations"), type=check_negative)
     topp.add_argument("containers", nargs="*", help=_("list of containers to monitor, leave blank for all"))
 

--- a/docs/atomic-top.1.md
+++ b/docs/atomic-top.1.md
@@ -6,7 +6,7 @@ atomic-top - Run a top-like list of active container processes
 # SYNOPSIS
 **atomic top**
 [**-h**|**--help**]
-[**-d**][**-o, --optional=[time, stime, ppid]**][**-n**]
+[**-d**][**-o, --optional=[time, stime, ppid, uid, gid, user, group]**][**-n**]
 [Containers to monitor]
 
 # DESCRIPTION
@@ -33,7 +33,7 @@ Like top, you can exit the interactive view and return to the command line, use 
 
 **-o** **--optional**
   Add more fields of data to collect for each process.  The fields resemble fields commonly used by
-  ps -o.  They currently are: [time, stime, ppid]
+  ps -o.  They currently are: [time, stime, ppid, uid, gid, user, group]
 
 # EXAMPLES
 Monitor processes with default fields.
@@ -44,9 +44,9 @@ Monitor processes with default fields on a 5 second interval for 3 interations
 
     atomic top -d 5 -n 3
 
-Monitor processes and add in the data for the parent PIDs.
+Monitor processes and add in the data for the parent PIDs and UID.
 
-    atomic top -o ppid
+    atomic top -o ppid uid
 
 # HISTORY
 December 2015, Originally written by Brent Baude (bbaude at redhat dot com)


### PR DESCRIPTION
`docker run -ti -u 1042 fedora /bin/bash` will run `/bin/bash` as user id `1042` for instance
`docker run -ti fedora /bin/bash` instead run as user id `0`

add an option to `ps_args` in `atomic top` which optionally display `UID` for the container

@baude I hope I've covered everything

Signed-off-by: Antonio Murdaca <runcom@redhat.com>