### PR TITLE
Atomic/util.py: Hush benign pylint error

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -231,7 +231,7 @@ def urllib3_disable_warnings():
 
     # On latest Fedora, this is a symlink
     if hasattr(requests, 'packages'):
-        requests.packages.urllib3.disable_warnings()
+        requests.packages.urllib3.disable_warnings() #pylint: disable=maybe-no-member
     else:
         # But with python-requests-2.4.3-1.el7.noarch, we need
         # to talk to urllib3 directly


### PR DESCRIPTION
With CentOS and Debian, 'makes' were failing due to a
maybe-no-member pylint error.  The error is a false
positive.  Added #pylint: disable=maybe-no-member to hush
it.