### PR TITLE
Atomic/run.py: Add security implications messages based on RUN label

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -387,59 +387,7 @@ class Atomic(object):
         command += self.image
         return command
 
-    def run(self):
-        missing_RUN = False
-        self.inspect = self._inspect_container()
-
-        if self.inspect:
-            self._check_latest()
-            # Container exists
-            if self.inspect["State"]["Running"]:
-                return self._running()
-            elif not self.args.display:
-                return self._start()
-
-        # Container does not exist
-        self.inspect = self._inspect_image()
-        if not self.inspect:
-            if self.args.display:
-                return self.display("Need to pull %s" % self.image)
-
-            self.update()
-            self.inspect = self._inspect_image()
-
-        if self.spc:
-            if self.command:
-                args = self.SPC_ARGS + self.command
-            else:
-                args = self.SPC_ARGS + self._get_cmd()
-
-            cmd = self.gen_cmd(args)
-        else:
-            args = self._get_args("RUN")
-            if args:
-                args += self.command
-            else:
-                missing_RUN = True
-                if self.command:
-                    args = self.RUN_ARGS + self.command
-                else:
-                    args = self.RUN_ARGS + self._get_cmd()
-
-            cmd = self.gen_cmd(args)
-            self.display(cmd)
-            if self.args.display:
-                return
-
-            if missing_RUN:
-                subprocess.check_call(cmd, env=self.cmd_env,
-                                      shell=True, stderr=DEVNULL,
-                                      stdout=DEVNULL)
-                return self._start()
-
-        self.display(cmd)
-        if not self.args.display:
-            subprocess.check_call(cmd, env=self.cmd_env, shell=True)
+    #def run -> Atomic/run.py
 
     def scan(self):
         if (not self.args.images and not self.args.containers and not self.args.all) and len(self.args.scan_targets) == 0:

--- a/Atomic/run.py
+++ b/Atomic/run.py
@@ -1,0 +1,115 @@
+import subprocess
+import os
+from . import util
+
+try:
+    from . import Atomic
+except ImportError:
+    from atomic import Atomic
+
+try:
+    from subprocess import DEVNULL  # pylint: disable=no-name-in-module
+except ImportError:
+    DEVNULL = open(os.devnull, 'wb')
+
+
+class Run(Atomic):
+    def run(self):
+        missing_RUN = False
+        self.inspect = self._inspect_container()
+
+        if self.inspect:
+            self._check_latest()
+            # Container exists
+            if self.inspect["State"]["Running"]:
+                return self._running()
+            elif not self.args.display:
+                return self._start()
+
+        # Container does not exist
+        self.inspect = self._inspect_image()
+        if not self.inspect:
+            if self.args.display:
+                return self.display("Need to pull %s" % self.image)
+
+            self.update()
+            self.inspect = self._inspect_image()
+
+        if self.spc:
+            if self.command:
+                args = self.SPC_ARGS + self.command
+            else:
+                args = self.SPC_ARGS + self._get_cmd()
+
+            cmd = self.gen_cmd(args)
+        else:
+            args = self._get_args("RUN")
+            if args:
+                args += self.command
+            else:
+                missing_RUN = True
+                if self.command:
+                    args = self.RUN_ARGS + self.command
+                else:
+                    args = self.RUN_ARGS + self._get_cmd()
+
+            cmd = self.gen_cmd(args)
+            self.display(cmd)
+            if self.args.display:
+                return
+
+            if missing_RUN:
+                subprocess.check_call(cmd, env=self.cmd_env,
+                                      shell=True, stderr=DEVNULL,
+                                      stdout=DEVNULL)
+                return self._start()
+
+        if self.args.quiet:
+            self.check_args(cmd)
+        if not self.args.display:
+            subprocess.check_call(cmd, env=self.cmd_env, shell=True)
+
+    @staticmethod
+    def check_args(cmd):
+        found_sec_arg = False
+        security_args = { '--privileged': 'This container runs without '
+                                          'separation and should be considered'
+                                          ' the same as root on your system.',
+                          '--cap-add': 'Adding capabilities to your container'
+                                       ' could allow processes from the'
+                                       ' container to break out onto'
+                                       ' your host system.',
+                          '--security-opt '
+                          'label:disable': 'Disabling label separation turns'
+                                           ' off tools like SELinux and could'
+                                           ' allow processes from the '
+                                           'container to break out onto'
+                                           ' your host system.',
+                          '--net=host': 'Processes in this container can'
+                                        ' listen to ports (and possibly'
+                                        ' rawip traffic) on the hosts '
+                                        'network.',
+                          '--pid=host': 'Processes in this container can see'
+                                        ' and interact with all processes on '
+                                        'the host and disables SELinux within'
+                                        'the container.',
+                          '--ipc=host': 'Processes in this container can see '
+                                        'and possibly interact with all '
+                                        'semaphores and shared memory segments'
+                                        ' on the host as well as disables '
+                                        'SELinux within the container.'
+                          }
+
+        for sec_arg in security_args:
+            if sec_arg in cmd:
+                if not found_sec_arg:
+                    util.writeOut("\nThis container uses privileged "
+                                  "security switches:")
+                util.writeOut("\n\033[1mINFO: {}\033[0m "
+                              "\n{}{}".format(sec_arg, " " * 6,
+                                              security_args[sec_arg]))
+                found_sec_arg = True
+        if found_sec_arg:
+            util.writeOut("\nFor more information on these switches and their "
+                          "security implications, consult the manpage for "
+                          "'docker run'.\n")

--- a/atomic
+++ b/atomic
@@ -33,6 +33,7 @@ from Atomic.diff import Diff
 from Atomic.top import Top
 from Atomic.verify import Verify
 from Atomic.help import AtomicHelp
+from Atomic.run import Run
 
 PROGNAME = "atomic"
 gettext.bindtextdomain(PROGNAME, "/usr/share/locale")
@@ -417,7 +418,8 @@ if __name__ == '__main__':
         "run", help=_("execute container image run method"),
         epilog="atomic run defaults to the following command, if image "
         "does not specify LABEL run\n'%s'" % atomic.print_run())
-    runp.set_defaults(func='run')
+    runp.set_defaults(_class=Run, func='run')
+    run_group = runp.add_mutually_exclusive_group()
     add_opt(runp)
     runp.add_argument("-n", "--name", dest="name", default=None,
                       help=_("name of container"))
@@ -429,8 +431,10 @@ if __name__ == '__main__':
                       help=_("command to execute within the container. "
                              "If container is not running, command is appended"
                              "to the image run method"))
+    run_group.add_argument("--quiet", "-q", default=True, action="store_false",
+                      help=_("Be less verbose."))
 
-    runp.add_argument(
+    run_group.add_argument(
         "--display",
         default=False,
         action="store_true",

--- a/bash/atomic
+++ b/bash/atomic
@@ -296,6 +296,7 @@ _atomic_run() {
 		--help
 		--spc
                --display
+        --quiet
 	"
 
 	[ "$command" = "run" ] && all_options="$all_options"

--- a/docs/atomic-run.1.md
+++ b/docs/atomic-run.1.md
@@ -10,6 +10,7 @@ atomic-run - Execute container image run method
 [**--display**]
 [**-n**][**--name**[=*NAME*]]
 [**--spc**]
+[**--quiet**]
 IMAGE [COMMAND] [ARG...]
 
 # DESCRIPTION
@@ -65,6 +66,9 @@ NAME will default to the IMAGENAME if it is not specified.
   Run container in super privileged container mode.  The image will run with the following command:
 
 `/usr/bin/docker run -t -i --rm --privileged -v /:/host -v /run:/run --net=host --ipc=host --pid=host -e HOST=/host -e NAME=${NAME} -e IMAGE=${IMAGE} --name ${NAME} ${IMAGE}`
+
+**--quiet**
+  Run without verbose messaging (i.e. security warnings).
 
 # HISTORY
 January 2015, Originally compiled by Daniel Walsh (dwalsh at redhat dot com)

--- a/tests/integration/test_help.sh
+++ b/tests/integration/test_help.sh
@@ -17,7 +17,7 @@ IFS=$'\n\t'
 OUTPUT=$(/bin/true)
 
 # Test standard help in man format
-${ATOMIC} help --no_pager atomic-test-1 1>/dev/null
+${ATOMIC} help atomic-test-1 1>/dev/null
 
 # Test override label
 ${ATOMIC} help atomic-test-3 1>/dev/null


### PR DESCRIPTION
Laymen users who are told to run a image may not understand
the docker run switches that have security implications.  We
now look for the following switches:

* --privileged
* --cap-add
* --security-opt label:disable
* --net=host
* --pid=host
* --ipc=host

and output an appropriate security message.

Also, moved def run() from Atomic/atomic.py to Atomic/run.py
to reduce the size and the number of definitions in
Atomic/atomic.py.