### PR TITLE
Let test.sh decide if bash, not Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: python-build docs pylint-check
 
 .PHONY: test
 test:
-	sh ./test.sh
+	./test.sh
 
 .PHONY: python-build
 python-build:


### PR DESCRIPTION
We should let `test.sh` decide whether to use bash or not, rather than `Makefile`.

Errors if not in sh / bash.

```
dropbox/dev/atomic  master ✔                                                                                                                                                                                                                              1d  
▶ sudo make test
sh ./test.sh
./test.sh: 2: set: Illegal option -o pipefail
Makefile:14: recipe for target 'test' failed
make: *** [test] Error 2
```

after PR:
```
dropbox/dev/atomic  fix-makefile ✔                                                                                                                                                                                                                        1m  
▶ sudo make test
./test.sh
Pulling standard images from Docker Hub...
```