### PR TITLE
Check if coverage is in local bin first

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -117,10 +117,16 @@ make_docker_images
 echo "UNIT TESTS:"
 
 COVERAGE_BIN="/usr/bin/coverage"
+
 if [[ ! -x "${COVERAGE_BIN}" ]]; then
-    # The executable is "coverage2" on systems with default python3 and no
-    # python3 install.
-    COVERAGE_BIN="/usr/bin/coverage2"
+  # Check to see if it is in local instead.
+  COVERAGE_BIN="/usr/local/bin/coverage"
+fi
+
+if [[ ! -x "${COVERAGE_BIN}" ]]; then
+  # The executable is "coverage2" on systems with default python3 and no
+  # python3 install.
+  COVERAGE_BIN="/usr/bin/coverage2"
 fi
 
 set +e


### PR DESCRIPTION
Tests do not check to see if coverage is located in /usr/local/bin instead (standard on debian/ubuntu distros).

Fixes:
```
▶ sudo make test
./test.sh
Pulling standard images from Docker Hub...
Building images from tests/test-images...
        Built   : atomic-test-secret
        Skipped : atomic-test-3
        Skipped : atomic-test-1
        Skipped : atomic-test-2
UNIT TESTS:
./test.sh: line 132: /usr/bin/coverage2: No such file or directory
```