### PR TITLE
atomic: harden shell invocations (1248038)

### DIFF
--- a/Atomic/help.py
+++ b/Atomic/help.py
@@ -91,5 +91,5 @@ class AtomicHelp(Atomic):
         """
         cmd = self.gen_cmd(self.alt_help_cmd.split(" "))
         self.display(cmd)
-        subprocess.check_call(cmd, env=self.cmd_env, shell=True)
+        util.check_call(cmd, env=self.cmd_env)
 

--- a/Atomic/run.py
+++ b/Atomic/run.py
@@ -54,20 +54,22 @@ class Run(Atomic):
                     args = self.RUN_ARGS + self._get_cmd()
 
             cmd = self.gen_cmd(args)
+            cmd = self.sub_env_strings(cmd)
             self.display(cmd)
             if self.args.display:
                 return
 
             if missing_RUN:
-                subprocess.check_call(cmd, env=self.cmd_env,
-                                      shell=True, stderr=DEVNULL,
-                                      stdout=DEVNULL)
+                util.check_call(cmd,
+                                env=self.cmd_env,
+                                stderr=DEVNULL,
+                                stdout=DEVNULL)
                 return self._start()
 
         if self.args.quiet:
             self.check_args(cmd)
         if not self.args.display:
-            subprocess.check_call(cmd, env=self.cmd_env, shell=True)
+            util.check_call(self.sub_env_strings(cmd), env=self.cmd_env)
 
     @staticmethod
     def check_args(cmd):

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -4,6 +4,7 @@ import subprocess
 import collections
 from fnmatch import fnmatch as matches
 from docker.utils import kwargs_from_env
+import os
 
 import docker
 import selinux
@@ -74,6 +75,12 @@ def subp(cmd):
     out, err = proc.communicate()
     return ReturnTuple(proc.returncode, stdout=out, stderr=err)
 
+
+def check_call(cmd, env=os.environ, stderr=None, stdout=None):
+    # Make sure cmd is a list
+    if not isinstance(cmd, list):
+        cmd = cmd.split(" ")
+    return subprocess.check_call(cmd, env=env, stderr=stderr, stdout=stdout)
 
 def default_container_context():
     if selinux.is_selinux_enabled() != 0:

--- a/tests/integration/test_display.sh
+++ b/tests/integration/test_display.sh
@@ -8,6 +8,7 @@ IFS=$'\n\t'
 #
 ATOMIC=${ATOMIC:="/usr/bin/atomic"}
 DOCKER=${DOCKER:="/usr/bin/docker"}
+TNAME="test_display"
 
 teardown () {
     ${DOCKER} rm TEST3 TEST4 2> /dev/null
@@ -15,27 +16,31 @@ teardown () {
 trap teardown EXIT
 
 # Remove the --user UID:GID
-OUTPUT=`${ATOMIC} run --display -n TEST1 atomic-test-1 | sed 's/ --user [0-9]*:[0-9]* //' | xargs`
+OUTPUT=`${ATOMIC} run --display -n TEST1 atomic-test-1 | sed 's/ --user [0-9]*:[0-9]* / /' | xargs`
 OUTPUT2="/usr/bin/docker run -t -v /var/log/TEST1:/var/log -v /var/lib/TEST1:/var/lib --name TEST1 atomic-test-1 echo I am the run label."
 if [[ ${OUTPUT} != ${OUTPUT2} ]]; then
+    echo "Failed ${TNAME} 1"
     exit 1
 fi
 
 OUTPUT=`${ATOMIC} install --display -n TEST2 atomic-test-1 | xargs`
 OUTPUT2="/usr/bin/docker run -v /etc/TEST2:/etc -v /var/log/TEST2:/var/log -v /var/lib/TEST2:/var/lib --name TEST2 atomic-test-1 echo I am the install label."
 if [[ ${OUTPUT} != ${OUTPUT2} ]]; then
+    echo "Failed ${TNAME} 2"
     exit 1
 fi
 
 ${ATOMIC} install -n TEST3 atomic-test-1
 OUTPUT=`${DOCKER} logs TEST3 | tr -d '\r'`
 if [[ ${OUTPUT} != "I am the install label." ]]; then
+    echo "Failed ${TNAME} 3"
     exit 1
 fi
 
 ${ATOMIC} run -n TEST4 atomic-test-1
 OUTPUT=`${DOCKER} logs TEST4 | tr -d '\r'`
 if [[ ${OUTPUT} != "I am the run label." ]]; then
+    echo "Failed ${TNAME} 4"
     exit 1
 fi
 
@@ -43,5 +48,6 @@ fi
 # a noop.
 OUTPUT=`${ATOMIC} install --display -n TEST5 centos | xargs`
 if [[ -n ${OUTPUT} ]]; then
+    echo "Failed ${TNAME} 5"
     exit 1
 fi


### PR DESCRIPTION
Remove instances where shell=True on subprocess calls to
avoid possible exploitation.  Added def chk_call in util.py
which is similar to subp for re-use.

This addresses bugzilla 1248038.