### PR TITLE
use docker.AutoVersionClient to avoid API version mismatch

### DIFF
--- a/Atomic/Export.py
+++ b/Atomic/Export.py
@@ -11,7 +11,7 @@ from . import util
 from docker.utils import kwargs_from_env
 
 
-DOCKER_CLIENT = docker.Client(**kwargs_from_env())
+DOCKER_CLIENT = docker.AutoVersionClient(**kwargs_from_env())
 
 ATOMIC_LIBEXEC = os.environ.get('ATOMIC_LIBEXEC', '/usr/libexec/atomic')
 

--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -1011,7 +1011,7 @@ def SetFunc(function):
     return customAction
 
 
-class AtomicDocker(docker.Client):
+class AtomicDocker(docker.AutoVersionClient):
     """
     A class based on the docker client class with custom APIs specifically for
     atomic

--- a/Atomic/mount.py
+++ b/Atomic/mount.py
@@ -190,7 +190,7 @@ class DockerMount(Mount):
 
     def __init__(self, mountpoint, live=False, mnt_mkdir=False):
         Mount.__init__(self, mountpoint, live)
-        self.client = docker.Client(**kwargs_from_env())
+        self.client = docker.AutoVersionClient(**kwargs_from_env())
         self.mnt_mkdir = mnt_mkdir
         self.tmp_image = None
 

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -44,7 +44,7 @@ def image_by_name(img_name, images=None):
 
     # If the images were not passed in, go get them.
     if images is None:
-        c = docker.Client(**kwargs_from_env())
+        c = docker.AutoVersionClient(**kwargs_from_env())
         images = c.images(all=False)
 
     valid_images = []


### PR DESCRIPTION
400 Client Error: Bad Request ("client is newer than server (client API version: 1.21, server API version: 1.20)")