### PR TITLE
Removal of remote inspection from docker

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -92,7 +92,7 @@ class Atomic(object):
                 "${IMAGE}"]
 
     def __init__(self):
-        self.d = AtomicDocker(**kwargs_from_env())
+        self.d = docker.Client(**kwargs_from_env())
         self.name = None
         self.image = None
         self.spc = False
@@ -644,7 +644,7 @@ class Atomic(object):
                 # Shut up pylint in case we're on a machine with upstream
                 # docker-py, which lacks the remote keyword arg.
                 #pylint: disable=unexpected-keyword-arg
-                inspection = self.d.remote_inspect(self.args.image)
+                inspection = util.skopeo(self.args.image)
             except docker.errors.APIError:
                 # image does not exist on any configured registry
                 _no_such_image()
@@ -1015,6 +1015,7 @@ class Atomic(object):
 
         return self.active_containers
 
+
 class AtomicError(Exception):
     pass
 
@@ -1024,13 +1025,3 @@ def SetFunc(function):
         def __call__(self, parser, namespace, values, option_string=None):
             setattr(namespace, self.dest, function)
     return customAction
-
-
-class AtomicDocker(docker.AutoVersionClient):
-    """
-    A class based on the docker client class with custom APIs specifically for
-    atomic
-    """
-    def remote_inspect(self, image_id):
-        return self._result(self._get(self._url("/images/{0}/json?remote=1".
-                                                format(image_id))), True)

--- a/Atomic/top.py
+++ b/Atomic/top.py
@@ -1,7 +1,7 @@
 from . import Atomic
-from .atomic import AtomicDocker
 from . import util
 import tty
+import docker
 import sys
 import termios
 import select
@@ -21,7 +21,7 @@ class Top(Atomic):
         super(Top, self).__init__()
         self.input_var = None
         self._sort = 'CID'
-        self.AD = AtomicDocker(**kwargs_from_env())
+        self.AD = docker.Client(**kwargs_from_env())
         self.name_id = {}
         self.optional = None
         self.titles = None

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -5,7 +5,6 @@ import collections
 from fnmatch import fnmatch as matches
 from docker.utils import kwargs_from_env
 import os
-
 import docker
 import selinux
 
@@ -254,3 +253,19 @@ def urllib3_disable_warnings():
             # Except only call disable-warnings if it exists
             if hasattr(urllib3, 'disable_warnings'):
                 urllib3.disable_warnings()
+
+
+def skopeo(image):
+    """
+    Performs remote inspection of an image on a registry
+    :param image:  fully qualified name
+    :return: Returns json formatted data
+    """
+
+    cmd = ['/usr/bin/skopeo', image]
+    results = subp(cmd)
+    if results.return_code is not 0:
+        raise ValueError(results.stderr)
+    else:
+        return json.loads(results.stdout)
+

--- a/Atomic/verify.py
+++ b/Atomic/verify.py
@@ -251,7 +251,7 @@ class Verify(Atomic):
         return "Version unavailable"
 
     def get_latest_remote_version(self, tag):
-        r_inspect = self.d.remote_inspect(tag)
+        r_inspect = util.skopeo(tag)
         if 'Labels' in r_inspect['Config'] \
                 and r_inspect['Config']['Labels'] is not None:
             latest_version = self.assemble_nvr(r_inspect['Config'])


### PR DESCRIPTION
We stopped carrying a patch in docker that allows for a RESTFUL
probe of remote registries.  This function is being replaced
by a new package called skopeo.

The remote_inspection def was removed from the Docker.Client
class extension in atomic.py and is replaced by a def called
util.skopeo which returns the same json-based results.