### PR TITLE
Atomic/atomic.py: Fix pylint error

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -581,7 +581,6 @@ class Atomic(object):
             self.writeOut("docker rmi %s" % self.image)
             subprocess.check_call(["docker", "rmi", self.image])
 
-    @property
     def cmd_env(self):
         os.environ['NAME'] = self.name
         os.environ['IMAGE'] = self.image


### PR DESCRIPTION
cmd_env is not a property, remove the decorator.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>