### PR TITLE
Atomic/client.py: Universal method for docker.Client()

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -24,8 +24,8 @@ from . import satellite
 from . import pulp
 from .Export import export_docker
 from .Import import import_docker
-from docker.utils import kwargs_from_env
 import re
+from .client import get_docker_client
 
 IMAGES = []
 
@@ -92,7 +92,7 @@ class Atomic(object):
                 "${IMAGE}"]
 
     def __init__(self):
-        self.d = docker.Client(**kwargs_from_env())
+        self.d = get_docker_client()
         self.name = None
         self.image = None
         self.spc = False

--- a/Atomic/client.py
+++ b/Atomic/client.py
@@ -1,0 +1,12 @@
+import docker
+from docker.utils import kwargs_from_env
+
+def get_docker_client():
+    """
+    Universal method to use docker.client()
+    """
+    try:
+        return docker.AutoVersionClient(**kwargs_from_env())
+
+    except docker.errors.DockerException:
+        return docker.Client(**kwargs_from_env())

--- a/Atomic/mount.py
+++ b/Atomic/mount.py
@@ -26,9 +26,8 @@ import json
 from fnmatch import fnmatch as matches
 import time
 import docker
-
+from .client import get_docker_client
 from . import util
-from docker.utils import kwargs_from_env
 
 
 """ Module for mounting and unmounting containerized applications. """
@@ -190,7 +189,7 @@ class DockerMount(Mount):
 
     def __init__(self, mountpoint, live=False, mnt_mkdir=False):
         Mount.__init__(self, mountpoint, live)
-        self.client = docker.AutoVersionClient(**kwargs_from_env())
+        self.client = get_docker_client()
         self.mnt_mkdir = mnt_mkdir
         self.tmp_image = None
 

--- a/Atomic/top.py
+++ b/Atomic/top.py
@@ -1,13 +1,11 @@
 from . import Atomic
 from . import util
 import tty
-import docker
 import sys
 import termios
 import select
 from os import isatty
 from operator import itemgetter
-from docker.utils import kwargs_from_env
 
 
 class Top(Atomic):
@@ -21,7 +19,6 @@ class Top(Atomic):
         super(Top, self).__init__()
         self.input_var = None
         self._sort = 'CID'
-        self.AD = docker.Client(**kwargs_from_env())
         self.name_id = {}
         self.optional = None
         self.titles = None
@@ -157,7 +154,7 @@ class Top(Atomic):
         # Assemble the ps args
         ps_args = [header['ps_opt']for header in sorted(self.headers, key=itemgetter('index')) if header['ps_opt']
                    is not None and header['active']]
-        con_procs = self.AD.top(con_id, ps_args="-eo {}".format(",".join(ps_args)))
+        con_procs = self.d.top(con_id, ps_args="-eo {}".format(",".join(ps_args)))
         # Set the column header titles one-time
         if self.titles is None:
             self.titles = con_procs['Titles']

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -3,11 +3,9 @@ import json
 import subprocess
 import collections
 from fnmatch import fnmatch as matches
-from docker.utils import kwargs_from_env
 import os
-import docker
 import selinux
-
+from .client import get_docker_client
 """Atomic Utility Module"""
 
 ReturnTuple = collections.namedtuple('ReturnTuple',
@@ -44,7 +42,7 @@ def image_by_name(img_name, images=None):
 
     # If the images were not passed in, go get them.
     if images is None:
-        c = docker.AutoVersionClient(**kwargs_from_env())
+        c = get_docker_client()
         images = c.images(all=False)
 
     valid_images = []


### PR DESCRIPTION
All uses of docker.Client() (docker-py) now should be using
the DockerClient definition in client.py.  Any changes to the
client instantiation or function can now be changed in a
singular location.

Also, the DockerClient function has a fallback from
docker.AutoVersionClient to docker.Client using a try and
except condition.  This fixes an issue raised in:

https://github.com/projectatomic/atomic/issues/302

where atomic cannot be built due to imports when dockerd is not
running.