### PR TITLE
Atomic/help.py: cmd_env no longer a property

### DIFF
--- a/Atomic/help.py
+++ b/Atomic/help.py
@@ -91,5 +91,5 @@ class AtomicHelp(Atomic):
         """
         cmd = self.gen_cmd(self.alt_help_cmd.split(" "))
         self.display(cmd)
-        util.check_call(cmd, env=self.cmd_env)
+        util.check_call(cmd, env=self.cmd_env())
 


### PR DESCRIPTION
When the cmd_env defition had its property decorator removed,
a single call to cmd_env in help.py was missed.