### PR TITLE
Add test for atomic verify

### DIFF
--- a/Atomic/verify.py
+++ b/Atomic/verify.py
@@ -5,7 +5,7 @@ from docker.errors import NotFound
 from operator import itemgetter
 
 class Verify(Atomic):
-    DEBUG = True
+    DEBUG = False
 
     def verify(self):
         """
@@ -291,7 +291,7 @@ class Verify(Atomic):
         for layer in layers:
             if layer['Name'] is name:
                 return layer['Version'] if 'Version' in layer \
-                    else "Version unavailable".format(name)
+                    else "Version unavailable"
 
     @staticmethod
     def pull_label(image, key):

--- a/tests/test-images/Dockerfile.4
+++ b/tests/test-images/Dockerfile.4
@@ -1,0 +1,9 @@
+FROM centos
+MAINTAINER "Sally O'Malley <somalley at redhat dot com>
+ENV container docker
+
+LABEL "Name"="atomic-test-4"
+
+LABEL RUN "/usr/bin/docker run -t --user \${SUDO_UID}:\${SUDO_GID} \${OPT1}  -v /var/log/\${NAME}:/var/log -v /var/lib/\${NAME}:/var/lib \$OPT2 --name \${NAME} \${IMAGE} \$OPT3 echo I am the run label."
+
+LABEL INSTALL "/usr/bin/docker \${OPT1} run  -v /etc/\${NAME}:/etc -v /var/log/\${NAME}:/var/log -v /var/lib/\${NAME}:/var/lib \$OPT2 --name \${NAME} \${IMAGE} \$OPT3 echo I am the install label."


### PR DESCRIPTION
Added a test case to test for failure when an image has
multiple repotags and is asked to be verified by image
id.  This should result in a failure.

Also, turned verify debug off.