### PR TITLE
Unify error messages for no docker daemon (BZ #1300187)

### DIFF
--- a/Atomic/top.py
+++ b/Atomic/top.py
@@ -6,6 +6,8 @@ import termios
 import select
 from os import isatty
 from operator import itemgetter
+import requests
+from atomic import NoDockerDaemon
 
 
 class Top(Atomic):
@@ -105,7 +107,10 @@ class Top(Atomic):
         while True:
             proc_info = []
             if len(self.args.containers) < 1:
-                con_ids = [x['Id'] for x in self.get_active_containers(refresh=True)]
+                try:
+                    con_ids = [x['Id'] for x in self.get_active_containers(refresh=True)]
+                except requests.exceptions.ConnectionError:
+                    raise NoDockerDaemon()
             else:
                 con_ids = self.args.containers
             for cid in con_ids:

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -267,3 +267,6 @@ def skopeo(image):
     else:
         return json.loads(results.stdout.decode('utf-8'))
 
+class NoDockerDaemon(Exception):
+    def __init__(self):
+        Exception.__init__(self, "The docker daemon does not appear to be running.")

--- a/atomic
+++ b/atomic
@@ -34,6 +34,7 @@ from Atomic.top import Top
 from Atomic.verify import Verify
 from Atomic.help import AtomicHelp
 from Atomic.run import Run
+from Atomic.atomic import NoDockerDaemon
 
 PROGNAME = "atomic"
 gettext.bindtextdomain(PROGNAME, "/usr/share/locale")
@@ -524,7 +525,7 @@ if __name__ == '__main__':
         sys.exit(_func())
     except KeyboardInterrupt:
         sys.exit(0)
-    except (ValueError, IOError, docker.errors.DockerException) as e:
+    except (ValueError, IOError, docker.errors.DockerException, NoDockerDaemon) as e:
         sys.stderr.write("%s\n" % str(e))
         sys.exit(1)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
In the case where the docker daemon is not running, each
Atomic subcommand was returning a different error message. This
PR unifies the errors messages for each subcommand.

This work was done for Bugzilla #1300187