### PR TITLE
Atomic/diff.py Add release to version, name, and epoch of RPM

### DIFF
--- a/Atomic/diff.py
+++ b/Atomic/diff.py
@@ -183,9 +183,10 @@ class RpmDiff(object):
                 continue
             else:
                 if not self.names_only:
-                    foo = "{0}-{1}-{2}".format(name, 
-                                               hdr['epochnum'],
-                                               hdr['version'].decode(enc))
+                    foo = "{0}-{1}-{2}-{3}".format(name,
+                                                   hdr['epochnum'],
+                                                   hdr['version'].decode(enc),
+                                                   hdr['release'])
 
                 else:
                     foo = "{0}".format(name)


### PR DESCRIPTION
When an RPM diff was performed between two docker objects, we
previously only store the name, version, and epoch of the RPM for
comparision.  It turns out versioning information is also done in
the release portion as well.

This addresses https://github.com/projectatomic/atomic/issues/315