### PR TITLE
Improve error handling with the docker-py client

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -270,3 +270,7 @@ def skopeo(image):
 class NoDockerDaemon(Exception):
     def __init__(self):
         Exception.__init__(self, "The docker daemon does not appear to be running.")
+
+class DockerObjectNotFound(ValueError):
+    def __init__(self, msg):
+        Exception.__init__(self, "Unable to associate '{}' with an image or container".format(msg))


### PR DESCRIPTION
In python-docker-py-1.6, the error handling improved
significantly.  When a docker object cannot be found,
say with client.inspect(), it now throws a specific
exception called NotFound instead of the old, generic
Docker error.  We have now updated some of our functions
to use the specific error because it was 'covering' other
docker client failures such as API compatibilies.

Also added a new custom Error class to handle a common
error message we used repeatidly.  The new class is
called 'DockerObjectNotFound' and will output a
consistent messages and takes the dockerobject as input.
This is most commonly used when we verify the users'
input for validity and is different that the docker
client NotFound error.