### PR TITLE
Fix include of NoDockerDaemon

### DIFF
--- a/Atomic/top.py
+++ b/Atomic/top.py
@@ -7,7 +7,7 @@ import select
 from os import isatty
 from operator import itemgetter
 import requests
-from atomic import NoDockerDaemon
+from Atomic.util import NoDockerDaemon
 
 
 class Top(Atomic):


### PR DESCRIPTION
It fixes this problem:

from atomic import NoDockerDaemon
ImportError: No module named 'atomic'

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>