### PR TITLE
Fixes for running atomic on python3

### DIFF
--- a/Atomic/top.py
+++ b/Atomic/top.py
@@ -7,7 +7,7 @@ import select
 from os import isatty
 from operator import itemgetter
 import requests
-from atomic import NoDockerDaemon
+from .util import NoDockerDaemon
 
 
 class Top(Atomic):

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PROFILEDIR ?= $(DESTDIR)/etc/profile.d
 PYTHON ?= /usr/bin/python
 PYLINT ?= /usr/bin/pylint
 GO_MD2MAN ?= /usr/bin/go-md2man
-PYTHONSITELIB=$(shell $(PYTHON) -c "from distutils.sysconfig import get_python_lib; print get_python_lib(0)")
+PYTHONSITELIB=$(shell $(PYTHON) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(0))")
 VERSION=$(shell $(PYTHON) setup.py --version)
 
 .PHONY: all


### PR DESCRIPTION
This also should replace https://github.com/projectatomic/atomic/pull/323