### PR TITLE
host: Pass through unlock -> ostree admin unlock

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -527,11 +527,18 @@ class Atomic(object):
         except KeyError:
             pass
 
-    def _rpmostree(self, args):
+    def _passthrough(self, args):
+        cmd = args[0]
         aargs = self.args.args
         if len(aargs) > 0 and aargs[0] == "--":
             aargs = aargs[1:]
-        os.execl("/usr/bin/rpm-ostree", "rpm-ostree", *(args + aargs))
+        os.execl("/usr/bin/" + cmd, *(args + aargs))
+
+    def _rpmostree(self, args):
+        self._passthrough(['rpm-ostree'] + args)
+
+    def _ostreeadmin(self, args):
+        self._passthrough(['ostree', 'admin'] + args)
 
     def host_status(self):
         argv = ["status"]
@@ -572,6 +579,12 @@ class Atomic(object):
         if self.args.preview:
             argv.append("--preview")
         self._rpmostree(argv)
+
+    def host_unlock(self):
+        argv = ['unlock']
+        if self.args.hotfix:
+            argv.append("--hotfix")
+        self._ostreeadmin(argv)
 
     def uninstall(self):
         self.inspect = self._inspect_container()

--- a/atomic
+++ b/atomic
@@ -230,6 +230,19 @@ if __name__ == '__main__':
                                     "if you want to pass additional "
                                     "unsupported arguments to rpm-ostree."))
 
+        # atomic host unlock
+        unlockp = host_subparser.add_parser(
+            "unlock", help=_("Make the current deployment mutable (for development or a hotfix)"))
+        unlockp.set_defaults(func='host_unlock')
+        unlockp.add_argument("--hotfix", dest="hotfix",
+                               action="store_true",
+                               help=_("Retain any changes after reboot"))
+        unlockp.add_argument("args", nargs=argparse.REMAINDER,
+                               help=_("Additional arguments appended to the "
+                                      "unlock method.  Use `-- --OPTION=VAL` "
+                                      "if you want to pass additional "
+                                      "unsupported arguments to ostree."))
+
     # atomic info
     infop = subparser.add_parser(
         "info", help=_("display label information about an image"),

--- a/bash/atomic
+++ b/bash/atomic
@@ -506,6 +506,16 @@ _atomic_host_upgrade() {
 	esac
 }
 
+_atomic_host_unlock() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--hotfix -h --help" -- "$cur" ) )
+			;;
+		*)
+			;;
+	esac
+}
+
 _atomic_host_host() {
 	local boolean_options="
 		--help -h
@@ -553,6 +563,7 @@ _atomic_host() {
 	        rollback
 		status
 		upgrade
+	        unlock	
 	)
 
 	local completions_func=_atomic_host_${prev}

--- a/docs/atomic-host.1.md
+++ b/docs/atomic-host.1.md
@@ -34,8 +34,18 @@ Upgrade to the latest Atomic tree if one is available
 **deploy**
 Download and deploy a specific Atomic tree
 
+**unlock**
+Remove the read-only bind mount on `/usr`
+and replace it with a writable overlay filesystem.  This
+default invocation of "unlock" is intended for
+development/testing purposes.  All changes in the overlay
+are lost on reboot (or upgrade).  Pass `--hotfix` to create changes
+that persist on reboot (but still not upgrades).
+
+
 # SEE ALSO
     man rpm-ostree 
+    man ostree 
 
 # HISTORY
 January 2015, Originally compiled by Daniel Walsh (dwalsh at redhat dot com)


### PR DESCRIPTION
It's nicer for branding the command.  The more correct thing would be
to add it to the rpm-ostree daemon and pass through there, but we have
more important problems to fix for the production code path.  This is
just for local development, so the slightly dirty way is just fine.