### PR TITLE
Fix shell expansion on commands.

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -1,3 +1,4 @@
+import shlex
 import sys
 import json
 import subprocess
@@ -76,7 +77,7 @@ def subp(cmd):
 def check_call(cmd, env=os.environ, stderr=None, stdout=None):
     # Make sure cmd is a list
     if not isinstance(cmd, list):
-        cmd = cmd.split(" ")
+        cmd = shlex.split(cmd)
     return subprocess.check_call(cmd, env=env, stderr=stderr, stdout=stdout)
 
 def default_container_context():


### PR DESCRIPTION
Prior to dropping shell=true, shell expansion on run/install/uninstall was
working, now we break in the case of a command like

LABEL INSTALL 'bash -c "echo foo foo foo"'

Adding shlex.split rather then standard split will break this command into
['bash', '-c', '"echo foo foo foo"']

Which will be executed correctly.