### PR TITLE
Atomic/top.py Make sure dockerd is running

### DIFF
--- a/Atomic/top.py
+++ b/Atomic/top.py
@@ -93,6 +93,8 @@ class Top(Atomic):
         Main sub-function for top
         :return: None
         """
+        # Make sure the docker daemon is running
+        self.ping()
         # Activate optional columns
         self._activate_optionals()
         # Do we have a tty?


### PR DESCRIPTION
Using self.ping(), we now check to make sure the docker
daemon is running before executing any code to display
atomic top.

This fixes a followup bug reported in:

https://bugzilla.redhat.com/show_bug.cgi?id=1300187#c5