### PR TITLE
Atomic/scan.py: Custom docker args

### DIFF
--- a/atomic
+++ b/atomic
@@ -37,6 +37,7 @@ from Atomic.help import AtomicHelp
 from Atomic.run import Run
 from Atomic.atomic import NoDockerDaemon
 from Atomic.util import get_atomic_config, get_scanners
+import traceback
 
 PROGNAME = "atomic"
 gettext.bindtextdomain(PROGNAME, "/usr/share/locale")
@@ -115,6 +116,7 @@ if __name__ == '__main__':
     parser = HelpByDefaultArgumentParser(description=atomic.help())
     parser.register('action', 'parsers', AliasedSubParsersAction)
     parser.add_argument('-v', '--version', action='version', version=Atomic.__version__)
+    parser.add_argument('--debug', default=False, action='store_true')
     subparser = parser.add_subparsers(help=_("commands"))
 
     # atomic diff
@@ -556,4 +558,7 @@ if __name__ == '__main__':
         parser.print_usage()
         sys.exit(1)
     except Exception as e:
-        sys.stderr.write("%sn" % str(e))
+        if args.debug:
+            traceback.print_exc(file=sys.stdout)
+        else:
+            sys.stderr.write("%sn" % str(e))


### PR DESCRIPTION
Added the ability to define custom docker args in the plugin
configuration files for things like bind mounting dirs from
the host to the scanner image.

When parsing the atomic scan json files, we can now handle
'Vulnerabilities' or 'Results' for keys.

Added a --debug switch to the base atomic command to allow for
more specifics when an unwanted exception is raised.

Fixed minor bug where if no image/container is provided, the
scanner would still execute.