### PR TITLE
[merged] Symlink LICENSE -> COPYING

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+COPYING


### PR DESCRIPTION
Because Github apparently is happy to ignore 25+ years of Free
Software history and just look at `LICENSE`.