### PR TITLE
atomic.d/openscap: Do standard compliance scan without CVEs

### DIFF
--- a/Atomic/scan.py
+++ b/Atomic/scan.py
@@ -41,7 +41,7 @@ class Scan(Atomic):
         yaml_error = "The image name or scanner arguments for '{}' is not " \
                      "defined in /etc/atomic.conf".format(self.args.scanner)
 
-        if self.args.scanner not in self.scanners:
+        if self.args.scanner not in [x['scanner_name'] for x in self.scanners]:
             raise ValueError("Unknown scanner '{}' defined in {}".format(self.args.scanner, util.ATOMIC_CONF))
         scanner_image_name, scanner_args, custom_args = get_scan_info(self.args.scanner, scan_type)
 

--- a/atomic.d/openscap
+++ b/atomic.d/openscap
@@ -1,13 +1,13 @@
 type: scanner
 scanner_name: openscap
 image_name: openscap
-default_scan: cve_scan
+default_scan: cve
 scans: [ 
-      { name: cve_scan,
+      { name: cve,
         args: ['oscapd-evaluate', 'scan',  '--no-standard-compliance', '--targets', 'chroots-in-dir:///scanin',  '--output', '/scanout'],
         description: "Performs a CVE scan based on known CVE data"},
-      { name: standards_scan,
-        args: ['oscapd-evaluate', 'scan', '--targets', 'chroots-in-dir:///scanin',  '--output', '/scanout'],
+      { name: standards_compliance,
+        args: ['oscapd-evaluate', 'scan', '--targets', 'chroots-in-dir:///scanin',  '--output', '/scanout', '--no-cve-scan'],
         description: "Performs a standard scan"
       }
 ]


### PR DESCRIPTION
When conducting a compliance scan, we do not want to check CVES
as that is done by the default scan.