### PR TITLE
Refactor skopeo code

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -725,13 +725,15 @@ class Atomic(object):
             # Shut up pylint in case we're on a machine with upstream
             # docker-py, which lacks the remote keyword arg.
             #pylint: disable=unexpected-keyword-arg
-            inspection = util.skopeo_inspect(self.image)
+            inspection = util.skopeo_inspect("docker://" + self.image)
             # image does not exist on any configured registry
-        try:
+        if 'Config' in inspection and 'Labels' in inspection['Config']:
             labels = inspection['Config']['Labels']
-        except TypeError:  # pragma: no cover
-            # Some images may not have a 'Labels' key.
+        elif 'Labels' in inspection:
+            labels = inspection['Labels']
+        else:
             _no_label()
+
         if labels is not None and len(labels) is not 0:
             for label in labels:
                 self.write_out('{0}: {1}'.format(label, labels[label]))

--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -725,7 +725,7 @@ class Atomic(object):
             # Shut up pylint in case we're on a machine with upstream
             # docker-py, which lacks the remote keyword arg.
             #pylint: disable=unexpected-keyword-arg
-            inspection = util.skopeo(self.image)
+            inspection = util.skopeo_inspect(self.image)
             # image does not exist on any configured registry
         try:
             labels = inspection['Config']['Labels']
@@ -915,42 +915,26 @@ class Atomic(object):
     def _convert_to_skopeo(image):
         i = image.replace("oci:", "")
         if "http:" in i:
-            return ["--insecure", "docker://" + i.replace("http:", "")]
+            return ["--insecure"], "docker://" + i.replace("http:", "")
         else:
-            return ["docker://" + i.replace("https:", "")]
+            return [], "docker://" + i.replace("https:", "")
 
     def _skopeo_get_manifest(self, image):
-        try:
-            r = util.subp(['skopeo', 'inspect', '--raw'] + Atomic._convert_to_skopeo(image))
-            if r.return_code != 0:
-                raise ValueError(r.stderr.decode(sys.getdefaultencoding()))
-            return r.stdout.decode('utf-8')
-        except OSError:
-            raise ValueError("skopeo must be installed to perform remote inspections")
+        args, img = Atomic._convert_to_skopeo(image)
+        return util.skopeo_inspect(img, args)
 
     def _skopeo_get_layers(self, image, layers):
-        temp_dir = tempfile.mkdtemp()
-        try:
-            args = ['skopeo', 'layers'] + Atomic._convert_to_skopeo(image) + layers
-            r = util.subp(args, cwd=temp_dir)
-            if r.return_code != 0:
-                raise ValueError(r.stderr.decode(sys.getdefaultencoding()))
-        except OSError:
-            raise ValueError("skopeo must be installed to perform remote inspections")
-        except Exception as e:
-            shutil.rmtree(temp_dir)
-            raise e
-        return temp_dir
+        args, img = Atomic._convert_to_skopeo(image)
+        return util.skopeo_layers(img, args, layers)
 
     @staticmethod
     def _get_layers_from_manifest(manifest):
-        manifest_json = json.loads(manifest)
-        fs_layers = manifest_json.get("fsLayers")
+        fs_layers = manifest.get("fsLayers")
         if fs_layers:
             layers = list(i["blobSum"] for i in fs_layers)
             layers.reverse()
         else:
-            layers = manifest_json.get("Layers")
+            layers = manifest.get("Layers")
         return layers
 
     @staticmethod
@@ -965,7 +949,7 @@ class Atomic(object):
             repo.transaction_set_ref(None, "%s%s" % (OSTREE_OCIIMAGE_PREFIX, layer), csum)
 
         # create a $OSTREE_OCIIMAGE_PREFIX$image-$tag branch
-        metadata = GLib.Variant("a{sv}", {'docker.manifest': GLib.Variant('s', manifest)})
+        metadata = GLib.Variant("a{sv}", {'docker.manifest': GLib.Variant('s', json.dumps(manifest))})
         mtree = OSTree.MutableTree()
         file_info = Gio.FileInfo()
         file_info.set_attribute_uint32("unix::uid", 0);
@@ -1119,7 +1103,7 @@ class Atomic(object):
             if manifest is None:
                 repo.checkout_tree_at(options, rootfs_fd, rootfs, rev)
             else:
-                layers = Atomic._get_layers_from_manifest(manifest)
+                layers = Atomic._get_layers_from_manifest(json.loads(manifest))
                 for layer in layers:
                     rev_layer = repo.resolve_rev("%s%s" % (OSTREE_OCIIMAGE_PREFIX, layer.replace("sha256:", "")), False)[1]
                     repo.checkout_tree_at(options, rootfs_fd, rootfs, rev_layer)

--- a/Atomic/verify.py
+++ b/Atomic/verify.py
@@ -154,7 +154,7 @@ class Verify(Atomic):
         for repo_ in similar:
             (reg, repo, tag) = util._decompose(repo_)
             results.append(self.is_registry_local(reg))
-        return False if not all(results) else True
+        return all(results)
 
     def is_registry_local(self, registry):
         """
@@ -162,7 +162,7 @@ class Verify(Atomic):
         :param registry: str registry name
         :return: bool
         """
-        return False if registry in self.get_registries() else True
+        return registry not in self.get_registries()
 
     def get_registries(self):
         """

--- a/Atomic/verify.py
+++ b/Atomic/verify.py
@@ -264,7 +264,7 @@ class Verify(Atomic):
         return "{}-Version unavailable".format(name)
 
     def get_latest_remote_version(self, tag, name=None):
-        r_inspect = util.skopeo(tag)
+        r_inspect = util.skopeo_inspect("docker://" + tag)
         if 'Labels' in r_inspect['Config'] \
                 and r_inspect['Config']['Labels'] is not None:
             latest_version = self.assemble_nvr(r_inspect['Config'], image_name=name)

--- a/Atomic/verify.py
+++ b/Atomic/verify.py
@@ -237,7 +237,7 @@ class Verify(Atomic):
             try:
                 _match = (x for x in layers if x["Id"] == _id).__next__()
             except:
-                _match = (x for x in layers if x["Id"] == _id).next()
+                _match = (x for x in layers if x["Id"] == _id).__next__()
         except StopIteration:
             # We were unable to associate IDs due to the local image being set
             # to intermediate by docker bc it is outdated. Therefore we find
@@ -245,7 +245,7 @@ class Verify(Atomic):
             try:
                 _match = (x for x in layers if x["Name"] == name).__next__()
             except:
-                _match = (x for x in layers if x["Name"] == name).next()
+                _match = (x for x in layers if x["Name"] == name).__next__()
         return _match['index']
 
     def get_local_latest_version(self, name):

--- a/Atomic/verify.py
+++ b/Atomic/verify.py
@@ -104,7 +104,9 @@ class Verify(Atomic):
                         if self.is_repo_from_local_registry(iid):
                             # Inspect again by tag in case the image isnt the latest
                             try:
-                                latest_version = self.d.inspect_image(tag)['Version']
+                                image = self.d.inspect_image(tag)
+                                labels = image.get('Config', []).get('Labels', [])
+                                latest_version = labels['Version']
                             except NotFound:
                                 latest_version = layer['Version']
                         else:
@@ -265,9 +267,9 @@ class Verify(Atomic):
 
     def get_latest_remote_version(self, tag, name=None):
         r_inspect = util.skopeo_inspect("docker://" + tag)
-        if 'Labels' in r_inspect['Config'] \
-                and r_inspect['Config']['Labels'] is not None:
-            latest_version = self.assemble_nvr(r_inspect['Config'], image_name=name)
+        if 'Labels' in r_inspect \
+                and r_inspect['Labels'] is not None:
+            latest_version = self.assemble_nvr(r_inspect, image_name=name)
         else:
             latest_version = "Version unavailable"
         return latest_version


### PR DESCRIPTION
the same function used by system containers is used by verify (retrieve a manifest through Skopeo), so I refactored this part in common in util.py.

While I was at it, I also changed verify.py to use a newer Skopeo version