### PR TITLE
[merged] Improve debug and exception tracebacks

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -143,6 +143,7 @@ class Atomic(object):
         self.active_containers = []
         self.atomic_config = None
         self.docker_cmd = None
+        self.debug = False
 
     def docker_binary(self):
         if not self.docker_cmd:
@@ -1543,6 +1544,10 @@ class Atomic(object):
         if self.atomic_config is None:
             self.atomic_config = util.get_atomic_config()
         return _recursive_get(config_items)
+
+    def set_debug(self):
+        if self.args.debug:
+            self.debug = True
 
 class AtomicError(Exception):
     pass

--- a/Atomic/scan.py
+++ b/Atomic/scan.py
@@ -11,6 +11,7 @@ class Scan(Atomic):
     """
     Scan class that can generically work any scanner
     """
+
     results = '/var/lib/atomic'
 
     def __init__(self):
@@ -34,6 +35,9 @@ class Scan(Atomic):
                             return i['image_name'], x['args'], i.get('custom_args')
         if self.args.debug:
             self.debug = True
+
+        # Set debug bool
+        self.set_debug()
 
         if self.args.list:
             self.print_scan_list()

--- a/Atomic/top.py
+++ b/Atomic/top.py
@@ -15,7 +15,6 @@ class Top(Atomic):
     Class to support atomic top; based on the Atomic class
     """
     # Set to true to output debug information
-    DEBUG = False
 
     def __init__(self):
         super(Top, self).__init__()
@@ -24,6 +23,7 @@ class Top(Atomic):
         self.name_id = {}
         self.optional = None
         self.titles = None
+        self.debug = False
         # To add a new column to the output, create a new dict inside self.headers
         # The fields are as follows:
         # shortname: <str> a unique key used to describe the dict
@@ -95,6 +95,8 @@ class Top(Atomic):
         """
         # Make sure the docker daemon is running
         self.ping()
+        # Set debug bool
+        self.set_debug()
         # Activate optional columns
         self._activate_optionals()
         # Do we have a tty?
@@ -122,7 +124,7 @@ class Top(Atomic):
             for cid in con_ids:
                 proc_info += self.get_pids_by_container(cid)
             # Reset screen
-            if not self.DEBUG and has_tty:
+            if not self.debug and has_tty:
                 util.write_out("\033c")
             sorted_info = self.reformat_ps_info(proc_info)
             self._set_dynamic_column_widths(sorted_info)
@@ -222,7 +224,7 @@ class Top(Atomic):
         """
         # Determine if the sort field needs to reverse the order of the sort
         _reverse = next((header['sort_order'] for header in self.headers if header['shortname'] == self._sort), False)
-        if self.DEBUG:
+        if self.debug:
             util.write_out("sorting on {0} and reverse is {1}".format(self._sort, _reverse))
         return sorted(proc_info, key=itemgetter(self._sort), reverse=_reverse)
 

--- a/Atomic/verify.py
+++ b/Atomic/verify.py
@@ -6,7 +6,9 @@ from operator import itemgetter
 from .atomic import AtomicError
 
 class Verify(Atomic):
-    DEBUG = False
+    def __init__(self):
+        super(Verify, self).__init__()
+        self.debug = False
 
     def verify(self):
         """
@@ -27,6 +29,9 @@ class Verify(Atomic):
                     layer['Name'] = layer['Tag']
             return layers
 
+        # Set debug bool
+        self.set_debug()
+
         # Check if the input is an image id associated with more than one
         # repotag.  If so, error out.
         if self.is_iid(self.image):
@@ -40,12 +45,12 @@ class Verify(Atomic):
                 self._no_such_image()
 
         layers = fix_layers(self.get_layers())
-        if self.DEBUG:
+        if self.debug:
             for l in layers:
                 util.output_json(l)
         uniq_names = list(set(x['Name'] for x in layers if x['Name'] != ''))
         base_images = self.get_tagged_images(uniq_names, layers)
-        if self.DEBUG:
+        if self.debug:
             for b in base_images:
                 util.output_json(b)
         if self.args.verbose:

--- a/atomic
+++ b/atomic
@@ -591,7 +591,10 @@ if __name__ == '__main__':
         if str(e).find("Permission denied"):
             need_root()
     except Exception as e:
+        sys.stderr.write("%sn" % str(e))
+    except SystemExit:
+        # Overriding debug args to avoid a traceback from sys.exit()
+        args.debug = False
+    finally:
         if args.debug:
             traceback.print_exc(file=sys.stdout)
-        else:
-            sys.stderr.write("%sn" % str(e))


### PR DESCRIPTION
Reworked the exception handling leveraging a final clause
to print the stacktrace.  One side effect of this is that
sys.exit() under normal considerations is still considered
an Exception and therefore you get a stacktrace for
SystemExit when --debug is enabled.

Reworked DEBUG contants to be variables defined by default
as False in the class' __init__.  Then use a def called
set_debug to set to True if --debug is True.