### PR TITLE
Atomic/verify.py: Make iterator work on Python2 and 3

### DIFF
--- a/Atomic/verify.py
+++ b/Atomic/verify.py
@@ -239,7 +239,7 @@ class Verify(Atomic):
             try:
                 _match = (x for x in layers if x["Id"] == _id).__next__()
             except:
-                _match = (x for x in layers if x["Id"] == _id).__next__()
+                _match = (x for x in layers if x["Id"] == _id).next()
         except StopIteration:
             # We were unable to associate IDs due to the local image being set
             # to intermediate by docker bc it is outdated. Therefore we find
@@ -247,7 +247,7 @@ class Verify(Atomic):
             try:
                 _match = (x for x in layers if x["Name"] == name).__next__()
             except:
-                _match = (x for x in layers if x["Name"] == name).__next__()
+                _match = (x for x in layers if x["Name"] == name).next()
         return _match['index']
 
     def get_local_latest_version(self, name):


### PR DESCRIPTION
This reverts a portion of d28fcbbf49023550953aece098ad86146dec1385 where the
iterators were accidently changed to a Python 3 implementation.