### PR TITLE
[merged] Do not show scanning container stdout

### DIFF
--- a/Atomic/scan.py
+++ b/Atomic/scan.py
@@ -85,8 +85,11 @@ class Scan(Atomic):
         # Show the command being run
         util.write_out(" ".join(scan_cmd))
 
+        # Show stdout from container if --debug or --verbose
+        stdout = None if (self.args.verbose or self.args.debug) else open(os.devnull, 'w')
+
         # do the scan
-        util.check_call(scan_cmd)
+        util.check_call(scan_cmd, stdout=stdout)
 
         # umount all the rootfs
         self._umount_rootfs_in_dir()

--- a/atomic
+++ b/atomic
@@ -438,6 +438,7 @@ if __name__ == '__main__':
     scanp.add_argument("--scanner", choices=[x['scanner_name'] for x in scanners], default=default_scanner, help=_("define the intended scanner"))
     scanp.add_argument("--scan_type", default=None, help=_("define the intended scanner"))
     scanp.add_argument("--list", action='store_true', default=False, help=_("List available scanners"))
+    scanp.add_argument("--verbose", action='store_false', default=True, help=_("Show more output from scanning container"))
     scan_group.add_argument("--all", default=False, action='store_true', help=_("scan all images (excluding intermediate layers) and containers"))
     scan_group.add_argument("--images", default=False, action='store_true', help=_("scan all images (excluding intermediate layers)"))
     scan_group.add_argument("--containers", default=False, action='store_true', help=_("scan all containers"))


### PR DESCRIPTION
Early users have suggested the stdout output from the openscap
container is too verbose and confusing.  By default, we now
do not show the container's stdout.  This default can be
overriden with --verbose or --debug.