### PR TITLE
[merged] Add cluster subcommand

### DIFF
--- a/atomic
+++ b/atomic
@@ -122,6 +122,15 @@ def create_parser(atomic):
     parser.add_argument('--debug', default=False, action='store_true')
     subparser = parser.add_subparsers(help=_("commands"))
 
+    # atomic cluster (if commctl.cli is available)
+    try:
+        import commctl.cli
+        clusterp = subparser.add_parser(
+            "cluster", help=_("execute cluster management commands"))
+        commctl.cli.add_cluster_commands(clusterp)
+    except ImportError:
+        pass
+
     # atomic diff
     diffp = subparser.add_parser(
     "diff", help=_("Show differences between two container images, file diff or RPMS."),
@@ -392,6 +401,15 @@ def create_parser(atomic):
     #                      default=None,
     #                      dest="org_name",
     #                      help=_("Organization Name"))
+
+    # atomic rhost (if commctl.cli is available)
+    try:
+        import commctl.cli
+        rhostp = subparser.add_parser(
+            "rhost", help=_("execute cluster host management commands"))
+        commctl.cli.add_host_commands(rhostp)
+    except ImportError:
+        pass
 
     # atomic scan
     def bool_detect(myarg):

--- a/bash/atomic
+++ b/bash/atomic
@@ -729,12 +729,138 @@ _atomic_storage_import() {
 
 }
 
+_atomic_no_opts() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "$main_options_with_args" -- "$cur" ) )
+			;;
+		*)
+			;;
+	esac
+}
+
+_atomic_cluster_create() {
+	_atomic_no_opts
+}
+
+_atomic_cluster_delete() {
+	_atomic_no_opts
+}
+
+_atomic_cluster_get() {
+	_atomic_no_opts
+}
+
+_atomic_cluster_list() {
+	_atomic_no_opts
+}
+
+_atomic_cluster_deploy_start() {
+	_atomic_no_opts
+}
+
+_atomic_cluster_deploy_status() {
+	_atomic_no_opts
+}
+
+_atomic_cluster_restart_start() {
+	_atomic_no_opts
+}
+
+_atomic_cluster_restart_status() {
+	_atomic_no_opts
+}
+
+_atomic_cluster_upgrade_start() {
+	_atomic_no_opts
+}
+
+_atomic_cluster_upgrade_status() {
+	_atomic_no_opts
+}
+
+_atomic_cluster() {
+	local commands=()
+	local completions_func=_atomic_cluster_${prev}
+
+	case "$prev" in
+		cluster)
+			commands=(create delete get list deploy restart upgrade)
+			;;
+		deploy)
+			commands=(start status)
+			;;
+		restart)
+			commands=(start status)
+			;;
+		upgrade)
+			commands=(start status)
+			;;
+		start|status)
+			if [ $cword -gt 2 ]; then
+				local completions_func=_atomic_cluster_${words[$cword-2]}_${prev}
+			fi
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			declare -F $completions_func >/dev/null && $completions_func
+			;;
+		*)
+			COMPREPLY=( $( compgen -W "${commands[*]}" -- "$cur" ) )
+			;;
+	esac
+}
+
+_atomic_rhost_create() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "-c --cluster $main_options_with_args" -- "$cur" ) )
+			;;
+		*)
+			;;
+	esac
+}
+
+_atomic_rhost_delete() {
+	_atomic_no_opts
+}
+
+_atomic_rhost_get() {
+	_atomic_no_opts
+}
+
+_atomic_rhost_list() {
+	_atomic_no_opts
+}
+
+_atomic_rhost() {
+	local commands=()
+	local completions_func=_atomic_rhost_${prev}
+
+	case "$prev" in
+		rhost)
+			commands=(create delete get list)
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			declare -F $completions_func >/dev/null && $completions_func
+			;;
+		*)
+			COMPREPLY=( $( compgen -W "${commands[*]}" -- "$cur" ) )
+			;;
+	esac
+}
 
 _atomic() {
 	local previous_extglob_setting=$(shopt -p extglob)
 	shopt -s extglob
 
 	local commands=(
+		cluster
 		host
 		diff
 		info
@@ -743,6 +869,7 @@ _atomic() {
 		storage
 		mount
 		pull
+		rhost
 		run
 		scan
 		stop

--- a/docs/atomic-cluster.1.md
+++ b/docs/atomic-cluster.1.md
@@ -1,0 +1,55 @@
+% ATOMIC(1) Atomic Man Pages
+% Matthew Barnes
+% May 2016
+# NAME
+atomic-cluster - Manage cluster hosts
+
+# SYNOPSIS
+**atomic cluster [OPTIONS] SUBCOMMAND**
+
+**atomic cluster** will issue commands to a Commissaire server over HTTP.
+
+Commissaire allows administrators of a Kubernetes, Atomic Enterprise or
+OpenShift installation to perform administrative tasks without the need
+to write custom scripts or manually intervene on systems.
+
+# NOTE
+The `cluster` subcommand is only available when `commctl` is installed.
+
+# OPTIONS
+**-h** **-help**
+  Print usage statement.
+
+# SUBCOMMANDS
+**create** CLUSTER_NAME
+  Register a new cluster with the specified name.
+
+**delete** CLUSTER_NAME
+  Unregister the specified cluster and disassociate all of its hosts.
+
+**get** CLUSTER_NAME
+  Report status of the specified cluster.
+
+**list**
+  List all available clusters by name.
+
+**deploy start** CLUSTER_NAME VERSION
+  Initiate deployment of a tree image with a version tag matching VERSION on all hosts associated with the specified cluster.
+
+**deploy status** CLUSTER_NAME
+  Report status of a deployment operation on the specified cluster.
+
+**restart start** CLUSTER_NAME
+  Initiate a restart of all hosts associated with the specified cluster.
+
+**restart status** CLUSTER_NAME
+  Report status of a restart operation on the specified cluster.
+
+**upgrade start** CLUSTER_NAME
+  Initiate an upgrade of all hosts associated with the specified cluster.
+
+**upgrade status** CLUSTER_NAME
+  Report status of an upgrade operation on the specified cluster.
+
+# HISTORY
+Initial revision by Matthew Barnes (mbarnes at redhat dot com) May 2016

--- a/docs/atomic-rhost.1.md
+++ b/docs/atomic-rhost.1.md
@@ -1,0 +1,37 @@
+% ATOMIC(1) Atomic Man Pages
+% Matthew Barnes
+% May 2016
+# NAME
+atomic-rhost - Manage cluster hosts
+
+# SYNOPSIS
+**atomic rhost [OPTIONS] SUBCOMMAND**
+
+**atomic rhost** will issue commands to a Commissaire server over HTTP.
+
+Commissaire allows administrators of a Kubernetes, Atomic Enterprise or
+OpenShift installation to perform administrative tasks without the need
+to write custom scripts or manually intervene on systems.
+
+# NOTE
+The `rhost` subcommand is only available when `commctl` is installed.
+
+# OPTIONS
+**-h** **-help**
+  Print usage statement.
+
+# SUBCOMMANDS
+**create** [**-c**/**--cluster** CLUSTER_NAME] IP_ADDRESS SSH_PRIV_KEY
+  Register a new host with the specified IP address.  SSH_PRIV_KEY is a file path to the host's private SSH key (e.g. id_rsa), used to drive operations on the host.  Use **--cluster** to add the host to an existing cluster.
+
+**delete** IP_ADDRESS
+  Unregister the specified IP address and, if applicable, disassociate it from its cluster.
+
+**get** IP_ADDRESS
+  Report status of the host with the specified IP address.
+
+**list**
+  List all available hosts by IP address.
+
+# HISTORY
+Initial revision by Matthew Barnes (mbarnes at redhat dot com) May 2016


### PR DESCRIPTION
This adds a `cluster` subcommand to integrate with Commissaire, as discussed in https://github.com/projectatomic/atomic/issues/329.

One thing to note about `atomic cluster` is it does **not** require root privilege; it's just talking over HTTP.  I tried to solve that cleanly in followup commits by delaying the root user check until after the command line is parsed and then adding a way for subcommands to opt out of requiring the root user.  This has the added benefit of letting non-root users at least get `--help` output for any `atomic` command.