### PR TITLE
Atomic/atomic.py: Fix def update()

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -172,7 +172,7 @@ class Atomic(object):
                     self.d.remove_container(c["Id"], force=True)
 
     def update(self):
-        if self.args.container:
+        if 'container' in self.args and self.args.container:
             if self._system_container_exists(self.args.image):
                 return self._update_system_container(self.args.image)
             raise ValueError("Container '%s' is not installed" % self.args.image)


### PR DESCRIPTION
When self.args.container was not defined, the update() def
was failing.  Fixed the conditional to check if self.args.container
exists first.

This failure would make an atomic install <image> fail when the
image was not locally present.