### PR TITLE
Atomic/scan.py, atomic: Fix scan related errors

### DIFF
--- a/Atomic/scan.py
+++ b/Atomic/scan.py
@@ -70,7 +70,7 @@ class Scan(Atomic):
             util.write_out("Creating the output dir at {}".format(self.results_dir))
 
         # Create the output directory
-        os.mkdir(self.results_dir)
+        os.makedirs(self.results_dir)
 
         docker_args = ['docker', 'run', '-it', '--rm', '-v', '/etc/localtime:/etc/localtime',
                        '-v', '{}:{}'.format(self.chroot_dir, '/scanin'), '-v',

--- a/atomic
+++ b/atomic
@@ -438,7 +438,7 @@ if __name__ == '__main__':
     scanp.add_argument("--scanner", choices=[x['scanner_name'] for x in scanners], default=default_scanner, help=_("define the intended scanner"))
     scanp.add_argument("--scan_type", default=None, help=_("define the intended scanner"))
     scanp.add_argument("--list", action='store_true', default=False, help=_("List available scanners"))
-    scanp.add_argument("--verbose", action='store_false', default=True, help=_("Show more output from scanning container"))
+    scanp.add_argument("--verbose", action='store_true', default=False, help=_("Show more output from scanning container"))
     scan_group.add_argument("--all", default=False, action='store_true', help=_("scan all images (excluding intermediate layers) and containers"))
     scan_group.add_argument("--images", default=False, action='store_true', help=_("scan all images (excluding intermediate layers)"))
     scan_group.add_argument("--containers", default=False, action='store_true', help=_("scan all containers"))
@@ -589,7 +589,7 @@ if __name__ == '__main__':
         parser.print_usage()
         sys.exit(1)
     except (OSError, MountError) as e:
-        if str(e).find("Permission denied"):
+        if str(e).find("Permission denied") > 0:
             need_root()
     except Exception as e:
         sys.stderr.write("%sn" % str(e))


### PR DESCRIPTION
When atomic scan needs to create the output directories, it needs to
do this recursively in case they don't already exist.  Changed from
os.mkdir to os.makedirs to handle this.