### PR TITLE
python3-pylint blows up on this undefined variable

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -21,7 +21,7 @@ _default_docker=None
 _default_docker_lib=None
 
 if sys.version_info[0] < 3:
-    input = raw_input
+    input = raw_input # pylint: disable=undefined-variable
 else:
     input = input
 


### PR DESCRIPTION
The check takes care of it, but python3-pylint is not smart enough to
catch this.