### PR TITLE
A couple of testing fixes

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -652,7 +652,9 @@ class Atomic(object):
 
         default_uid = "0"
         with open("/proc/self/loginuid") as f:
-            default_uid = f.readline()
+            val = f.readline()
+            if int(val) <= 2147483647:
+                default_uid = val
 
         if "SUDO_UID" not in os.environ:
             os.environ["SUDO_UID"] = default_uid

--- a/tests/integration/test_printenv.sh
+++ b/tests/integration/test_printenv.sh
@@ -32,7 +32,7 @@ trap teardown EXIT
 
 OUTPUT=$(/bin/true)
 
-${ATOMIC} run atomic-test-5 | grep -v ^NAME= | grep -v ^IMAGE= | grep -v printenv | grep -v atomic | grep -v coverage | sort > ${TESTDIR}/atomic-test-5.1
+${ATOMIC} run atomic-test-5 | grep -v ^NAME= | grep -v ^IMAGE= | grep -v ^SUDO | grep -v printenv | grep -v atomic | grep -v coverage | sort > ${TESTDIR}/atomic-test-5.1
 
 printenv | grep -v printenv | grep -v atomic | grep -v coverage | sort > ${TESTDIR}/atomic-test-5.2
 diff ${TESTDIR}/atomic-test-5.1 ${TESTDIR}/atomic-test-5.2


### PR DESCRIPTION
On certain systems loginuid might not be set which could give a value of
4294967295

docker will not allow users > 2147483647, if you loginuid is -1 it ends up
being bigger

SUDO_UID and SUDO_GID, not always defined in environment