### PR TITLE
[merged] Atomic/diff.py: Do not hide SelectionMatchError and clean-up

### DIFF
--- a/Atomic/diff.py
+++ b/Atomic/diff.py
@@ -77,7 +77,13 @@ class DiffHelpers(object):
         """
         image_list = []
         for image in images:
-            image_list.append(DiffObj(image))
+            try:
+                image_list.append(DiffObj(image))
+            except mount.SelectionMatchError as e:
+                if len(image_list) > 0:
+                    DiffHelpers._cleanup(image_list)
+                sys.stderr.write("{}\n".format(e))
+                sys.exit(1)
         return image_list
 
     def output_files(self, images, image_list):

--- a/atomic
+++ b/atomic
@@ -39,7 +39,7 @@ from Atomic.run import Run
 from Atomic.atomic import NoDockerDaemon
 from Atomic.util import get_atomic_config, get_scanners, default_docker_lib
 import traceback
-from Atomic.mount import MountError
+from Atomic.mount import MountError, SelectionMatchError
 
 PROGNAME = "atomic"
 gettext.bindtextdomain(PROGNAME, "/usr/share/locale")


### PR DESCRIPTION
Previously, the raise of SelectionMatchError was not getting to
stderr so diff would fail silently.  We now write the error to
stderr and clean up any mounts and dm devices created.