### PR TITLE
[merged] SELinux: Don't scan with selinux separation if scan is using rootfs

### DIFF
--- a/Atomic/scan.py
+++ b/Atomic/scan.py
@@ -77,13 +77,15 @@ class Scan(Atomic):
 
             if self.debug:
                 util.write_out("Creating the output dir at {}".format(self.results_dir))
-
+            security_args = []
         else:
             # Check to make sure all the chroots provided are legit
             for _path in self.args.rootfs:
                 if not os.path.exists(_path):
                     raise ValueError("The path {} does not exist".format(_path))
             self.setup_rootfs_dirs()
+            # Have to disable SELinux checking of scanning not docker images
+            security_args = [ "--security-opt", "label:disable" ]
 
         # Create the output directory
         os.makedirs(self.results_dir)
@@ -93,7 +95,7 @@ class Scan(Atomic):
                        '{}:{}:rw,Z'.format(self.results_dir, '/scanout')]
 
         # Assemble the cmd line for the scan
-        scan_cmd = docker_args
+        scan_cmd = docker_args + security_args
         if custom_args is not None:
             scan_cmd = scan_cmd + custom_args
         scan_cmd = scan_cmd + [scanner_image_name] + scanner_args

--- a/docs/atomic-scan.1.md
+++ b/docs/atomic-scan.1.md
@@ -49,6 +49,8 @@ Select a scan_type other than the default.
 
 **--rootfs**
   Rootfs path to scan.  Can provide _--rootfs_ multiple times.
+  Note: SELinux separation will be disabled for --rootfs scans, but all other container
+  separation will still be in place.
 
 # EXAMPLES
 List all the scanners atomic knows about and display their default scan types.


### PR DESCRIPTION
We don't have a way to relabel content off of random rootfs so that
a SELinux confined process can read the content.