### PR TITLE
[merged] Improve errors msgs for no configured scanners

### DIFF
--- a/Atomic/scan.py
+++ b/Atomic/scan.py
@@ -344,6 +344,9 @@ class Scan(Atomic):
                              format(self.args.scan_type, self.args.scanner))
 
     def print_scan_list(self):
+        if len(self.scanners) == 0:
+            util.write_out("There are no scanners configured for this system.")
+            sys.exit(0)
         default_scanner = self.atomic_config.get('default_scanner')
         if default_scanner is None:
             default_scanner = ''

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,12 @@ install-only:
 	install -m 644 atomic.conf $(DESTDIR)/etc
 
 	install -d $(DESTDIR)/etc/atomic.d
-	install -m 644 atomic.d/openscap $(DESTDIR)/etc/atomic.d
 
 .PHONY: install
 install: all install-only
+
+
+.PHONY: install-openscap
+install-openscap:
+	install -m 644 atomic.d/openscap $(DESTDIR)/etc/atomic.d
+

--- a/atomic
+++ b/atomic
@@ -396,7 +396,8 @@ def create_parser(atomic):
     scanners = get_scanners()
     atomic_config = get_atomic_config()
     if atomic_config is None or atomic_config.get('default_scanner') is None:
-        sys.stderr.write("You must have a default scanner defined in /etc/atomic.conf\n")
+        sys.stderr.write("\nYou must have a default scanner defined in /etc/atomic.conf. Use --list to see "
+                         "what scanners are available for your system.\n")
         sys.exit(1)
 
     default_scanner = atomic_config.get('default_scanner')


### PR DESCRIPTION
Eventually we will not ship any default scanner configurations.  Previous
code relied on there always being one (default) defined so improved
error messages and a conditional check was in order.