### PR TITLE
[merged] Atomic/diff: Improve docs and output messages for diff

### DIFF
--- a/Atomic/diff.py
+++ b/Atomic/diff.py
@@ -113,7 +113,11 @@ class DiffHelpers(object):
             if ip.has_diff:
                 ip._print_diff(self.args.verbose)
             else:
-                util.write_out("\n{} and {} have no different RPMs".format(ip.i1.name, ip.i2.name))
+                if self.args.names_only:
+                    util.write_out("\n{} and {} has the same RPMs.  Versions may differ.  Remove --names-only"
+                                   " to see if there are version differences.".format(ip.i1.name, ip.i2.name))
+                else:
+                    util.write_out("\n{} and {} have no different RPMs".format(ip.i1.name, ip.i2.name))
 
         # Output JSON content
         else:

--- a/atomic
+++ b/atomic
@@ -134,7 +134,7 @@ def create_parser(atomic):
     diffp.add_argument("-n", "--no-files", default=False, action='store_true',
                        help=_("Do not perform a file diff between the docker objects"))
     diffp.add_argument("--names-only", default=False,
-                       action='store_true', help=_("Only show RPM names and not versions"))
+                       action='store_true', help=_("Only compare RPM names and not versions"))
     diffp.add_argument("-r", "--rpms", default=False, action='store_true',
                        help=_("List different rpms between the container images."))
     diffp.add_argument("-v", "--verbose", default=False, action='store_true',

--- a/docs/atomic-diff.1.md
+++ b/docs/atomic-diff.1.md
@@ -14,8 +14,9 @@ atomic-diff - show the differences between two images|containers RPMs
 image|container image|container ...]
 
 # DESCRIPTION
-**atomic diff** will compare the RPMs found in two different images or containers and output to stdout or as JSON.
-By default, the comparison is done by name and version of the RPMs.
+**atomic diff** will compare the RPMs found in two different images or containers
+and output to stdout or as JSON. By default,  the comparison is done by name and
+version of the RPMs.
 
 # OPTIONS
 **-h** **--help**
@@ -29,7 +30,7 @@ By default, the comparison is done by name and version of the RPMs.
   when performing an RPM-based diff to restrict output.
 
 **--names-only**
-  Only show the RPM names and not versions.
+  When performing the diff, only compare package names and not their versions.
 
 **-r** **--rpms**
   Show the where the two docker objects have different RPMs.
@@ -57,4 +58,5 @@ Compare the files and RPMs (without versions) in images 'foo1' and 'foo2' and ou
     atomic diff -r --json foo1 foo2
 
 # HISTORY
+Updated by Brent Baude (bbaude at redhat dot com) May 2016
 Initial revision by Brent Baude (bbaude at redhat dot com) November 2015


### PR DESCRIPTION
https://github.com/projectatomic/atomic/issues/378 points out that
when an rpm diff is done with --names-only, the output messaging was
not clear enough.  Reworked the man page, --help, and output message
to clarify that when --names-only is used, it only compares RPMs
based on names and NOT versions.

Nice find by Micah.