### PR TITLE
[merged] Change rules around declaring a default scanner.

### DIFF
--- a/atomic
+++ b/atomic
@@ -394,20 +394,13 @@ def create_parser(atomic):
         return True if myarg.lower() in \
             ('yes', 'true', 't', 'y', '1') else False
     scanners = get_scanners()
-    atomic_config = get_atomic_config()
-    if atomic_config is None or atomic_config.get('default_scanner') is None:
-        sys.stderr.write("\nYou must have a default scanner defined in /etc/atomic.conf. Use --list to see "
-                         "what scanners are available for your system.\n")
-        sys.exit(1)
-
-    default_scanner = atomic_config.get('default_scanner')
     scanp = subparser.add_parser(
         "scan", help=_("scan an image or container for CVEs"),
         epilog="atomic scan <input> scans a container or image for CVEs")
     scanp.set_defaults(_class=Scan, func='scan')
     scan_group = scanp.add_mutually_exclusive_group()
     scanp.add_argument("scan_targets", nargs='*', help=_("container image"))
-    scanp.add_argument("--scanner", choices=[x['scanner_name'] for x in scanners], default=default_scanner, help=_("define the intended scanner"))
+    scanp.add_argument("--scanner", choices=[x['scanner_name'] for x in scanners], default=None, help=_("define the intended scanner"))
     scanp.add_argument("--scan_type", default=None, help=_("define the intended scanner"))
     scanp.add_argument("--list", action='store_true', default=False, help=_("List available scanners"))
     scanp.add_argument("--verbose", action='store_true', default=False, help=_("Show more output from scanning container"))

--- a/atomic.conf
+++ b/atomic.conf
@@ -1,6 +1,6 @@
 # Atomic CLI configuration file
 
-default_scanner: openscap
+default_scanner:
 default_docker: docker
 
 # default_storage: ostree


### PR DESCRIPTION
Previously, with the understanding we would be shipping a single
generic scanner configuration file, would 1) install the config
file and we had preset a default scanner in atomic.conf.

With the realization that the scanner could be variable based
on the distribution, the generic file is not longer installed
by default. Therefore, we should probably not set a default.

The prior code failed if a default was not defined in
/etc/atomic.conf.  That code check has been altered and we now
adhere to the following rules:

* If no default is defined AND there is only one configured
 scanner, we assume the single scanner IS the default.

* If no default is defined AND there are multiple scanners, we
 error out and ask the user to define one.

* If there is a default defined, good to go!