### PR TITLE
[merged] tests: add SKIP variable to skip some tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ all: python-build docs pylint-check dockertar-sha256-helper
 test: all
 	./test.sh
 
+test-destructive: all
+	ENABLE_DESTRUCTIVE=1 ./test.sh
+
 .PHONY: python-build
 python-build:
 	$(PYTHON) setup.py build

--- a/test.sh
+++ b/test.sh
@@ -167,13 +167,24 @@ for tf in `find ./tests/integration/ -name test_*.sh`; do
         fi
     fi
 
+    # If it is not running with ENABLE_DESTRUCTIVE and the test has
+    # not the :test-destructive tag, skip it silently.
+    if test -z "${ENABLE_DESTRUCTIVE-}" && grep ":destructive-test" ${tf} &> /dev/null; then
+        continue
+    fi
+
     printf "Running test $(basename ${tf})...\t\t"
     printf "\n==== ${tf} ====\n" >> ${LOG}
+
     if ${tf} &>> ${LOG}; then
         printf "PASS\n";
     else
-        printf "FAIL\n";
-        let "failures += 1"
+        if test $? = 77; then
+            printf "SKIP\n";
+        else
+            printf "FAIL\n";
+            let "failures += 1"
+        fi
     fi
 done
 

--- a/test.sh
+++ b/test.sh
@@ -173,7 +173,7 @@ for tf in `find ./tests/integration/ -name test_*.sh`; do
         continue
     fi
 
-    printf "Running test $(basename ${tf})...\t\t"
+    printf "Running test %-40.40s" "$(basename ${tf})...."
     printf "\n==== ${tf} ====\n" >> ${LOG}
 
     if ${tf} &>> ${LOG}; then

--- a/tests/integration/test_storage.sh
+++ b/tests/integration/test_storage.sh
@@ -13,6 +13,9 @@ set -euo pipefail
 # In addition, the test harness creates some images for use in testing.
 #   See tests/test-images/
 
+# run only when ENABLE_DESTRUCTIVE is set
+# :destructive-test
+
 # This can copy non-existing files
 #
 smarter_copy() {


### PR DESCRIPTION
I don't feel comfortable with running test_storage.sh on my
development machine, so add a SKIP env variable.

In my case, it would be:

make test SKIP="test_storage.sh"

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>