### PR TITLE
[merged] Highlight used images in atomic images

### DIFF
--- a/docs/atomic-images.1.md
+++ b/docs/atomic-images.1.md
@@ -14,6 +14,8 @@ atomic-images - list locally installed container images
 **atomic images**, by default, will list all installed container images on your
 system.
 
+A `>` preceeding the image name indicates that the image is used by a container.
+
 Using the `--prune` option will free wasted disk space by deleting unused
 `dangling` images.
 


### PR DESCRIPTION
When you run atomic images, we now highlight which images
have been used by a container.  The highlight is bold. Also
improved some output problems with long repository names.

Updated atomic images man page to reflect this change.
