### PR TITLE
Add atomic images --noheading

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -767,8 +767,9 @@ class Atomic(object):
             _max_repo, _max_tag = get_col_lengths(_images)
             col_out = "{0:" + str(_max_repo) + "} {1:" + str(_max_tag) + \
                       "} {2:12} {3:19} {4:10}"
-            self.write_out(col_out.format("REPOSITORY", "TAG", "IMAGE ID",
-                                         "CREATED", "VIRTUAL SIZE"))
+            if self.args.heading:
+                self.write_out(col_out.format("REPOSITORY", "TAG", "IMAGE ID",
+                                              "CREATED", "VIRTUAL SIZE"))
             for image in self.get_images():
                 repo, tag = image["RepoTags"][0].rsplit(":", 1)
                 if "Created" in image:

--- a/atomic
+++ b/atomic
@@ -301,6 +301,9 @@ def create_parser(atomic):
     imagesp.set_defaults(func='images')
     imagesp.add_argument("--prune", action="store_true",
                          help=_("prune dangling images"))
+    imagesp.add_argument("-n", "--noheading", dest="heading", default=True,
+                         action="store_false",
+                         help=_("do not print heading when listing the images"))
 
     # atomic mount
     mountp = subparser.add_parser(

--- a/bash/atomic
+++ b/bash/atomic
@@ -415,6 +415,7 @@ _atomic_images() {
 	local all_options="
 		--prune
 		--help -h
+		--noheading -n
 	"
 
 	case "$cur" in

--- a/docs/atomic-images.1.md
+++ b/docs/atomic-images.1.md
@@ -7,6 +7,7 @@ atomic-images - list locally installed container images
 # SYNOPSIS
 **atomic images**
 [**-h|--help**]
+[**-n|--noheading**]
 [**--prune**]
 
 # DESCRIPTION
@@ -26,6 +27,9 @@ A `*` in the first column indicates a dangling image.
 # OPTIONS:
 **-h** **--help**
   Print usage statement
+
+**-n** **--noheading**
+  Do not print heading when listing the images
 
 **--prune**
   Prune (remove) all dangling images


### PR DESCRIPTION
In certain cases like piping to grep, you do not want to include headings