### PR TITLE
[merged] atomic: remove any symlink from the destination path

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -1124,6 +1124,7 @@ class Atomic(object):
                 sysroot.load()
                 osname = sysroot.get_booted_deployment().get_osname()
                 destination = os.path.join("/ostree/deploy/", osname, os.path.relpath(destination, "/"))
+                destination = os.path.realpath(destination)
             except:
                 pass
             rootfs = os.path.join(destination, "rootfs")


### PR DESCRIPTION
Convert /ostree -> /sysroot/ostree as runc doesn't like symlinks in
the path to the bundle

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>