### PR TITLE
[merged] atomic: More completely handle failure to import OSTree

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -15,9 +15,12 @@ from string import Template
 
 try:
     import gi
-    gi.require_version('OSTree', '1.0')
-    from gi.repository import Gio, GLib, OSTree
-    OSTREE_PRESENT = True
+    try:
+        gi.require_version('OSTree', '1.0')
+        from gi.repository import Gio, GLib, OSTree
+        OSTREE_PRESENT = True
+    except ValueError:
+        OSTREE_PRESENT = False
 except ImportError:
     OSTREE_PRESENT = False
 


### PR DESCRIPTION
GI raises `ValueError` apparently, not `ImportError`.  So rework
things to be nested and handle the cases of:

 - No GI
 - GI but no OSTree
 - OSTree