### PR TITLE
[merged] Define openscap image

### DIFF
--- a/atomic.d/openscap
+++ b/atomic.d/openscap
@@ -1,6 +1,6 @@
 type: scanner
 scanner_name: openscap
-image_name: openscap
+image_name: rhel7/openscap
 default_scan: cve
 scans: [ 
       { name: cve,


### PR DESCRIPTION
The fully qualified name of the openscap image is:
  registry.access.redhat.com/rhel7/openscap