### PR TITLE
[merged] Atomic/scan.py: Set default scanner

### DIFF
--- a/Atomic/scan.py
+++ b/Atomic/scan.py
@@ -43,13 +43,14 @@ class Scan(Atomic):
 
             if len(self.scanners) == 1:
                 self.scanner = self.scanners[0]['scanner_name']
-
             # If a scanner is defined in parseargs
-            if self.args.scanner:
-                    self.scanner = self.args.scanner
-
-            if self.scanner is None:
-                raise ValueError("You must specify a scanner")
+            elif self.args.scanner:
+                self.scanner = self.args.scanner
+            # Use default
+            elif default_scanner is not None:
+                self.scanner = default_scanner
+            elif self.scanner is None:
+                raise ValueError("You must specify a scanner (--scanner) or set a default in /etc/atomic.conf")
 
             # Check if the scanner name is valid
             if self.scanner not in [x['scanner_name'] for x in self.scanners]:
@@ -61,12 +62,16 @@ class Scan(Atomic):
         # Set debug bool
         self.set_debug()
 
-        set_scanner()
-
+        # Show list of scanners and exit
         if self.args.list:
             self.print_scan_list()
 
+        default_scanner = self.atomic_config['default_scanner']
+        set_scanner()
+
+
         scan_type = self.get_scan_type()
+
         # Load the atomic config file and check scanner settings
         yaml_error = "The image name or scanner arguments for '{}' is not " \
                      "defined in /etc/atomic.conf".format(self.scanner)


### PR DESCRIPTION
After reworking the logic in set_scanner(), we missed the
condition that if a default scanner is defined in atomic.conf,
it should be set as self.scanner unless otherwise overriden.