### PR TITLE
[merged] atomic: fix a pylint error when OSTree is not installed

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -17,7 +17,7 @@ try:
     import gi
     try:
         gi.require_version('OSTree', '1.0')
-        from gi.repository import Gio, GLib, OSTree
+        from gi.repository import Gio, GLib, OSTree  # pylint: disable=no-name-in-module
         OSTREE_PRESENT = True
     except ValueError:
         OSTREE_PRESENT = False


### PR DESCRIPTION
Closes: https://github.com/projectatomic/atomic/issues/409

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>