### PR TITLE
[merged] Atomic/scan: fix image naming error

### DIFF
--- a/Atomic/scan.py
+++ b/Atomic/scan.py
@@ -91,7 +91,6 @@ class Scan(Atomic):
         if len(self.args.rootfs) == 0:
             scan_list = self._get_scan_list()
             for i in scan_list:
-                i['Id'] = i['Id'].replace(":", "-")
                 self.scan_content[i['Id']] = i.get('input')
 
             # mount all the rootfs


### PR DESCRIPTION
The image naming looks like 'sha256:XXXXX' in atomic, but set_scanner() in Atomic/scan.py replaces '**:**' with '**-**', the result is atomic scan can't match any image.

```shell
# atomic images|grep rhel7
  registry.access.redhat.com/rhel7/rhel-tools           latest   sha256:00211   2016-05-06 17:49   1.27 GB       
  registry.access.redhat.com/rhel7                      latest   sha256:bf203   2016-05-05 12:43   203.43 MB     

# atomic scan --verbose sha256:bf203
sha256-bf203442783741aad6d82b528bcfecd45f40e63c83d981eb5e644a2fa6356e60 did not match any image or container.
```

Signed-off-by: Alex Jia <ajia@redhat.com>