### PR TITLE
[merged] add "atomic ps" to show containers

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -516,6 +516,8 @@ class Atomic(object):
         command += self.image
         return command
 
+    #def ps -> Atomic/ps.py
+
     #def run -> Atomic/run.py
 
     def stop(self):

--- a/Atomic/ps.py
+++ b/Atomic/ps.py
@@ -1,0 +1,60 @@
+import os
+import sys
+import rpm
+from filecmp import dircmp
+import json
+
+from . import util
+from . import mount
+from . import Atomic
+from dateutil.parser import parse as dateparse
+
+class Ps(Atomic):
+    def ps(self):
+        all_containers = []
+
+        # Collect the system containers
+        for i in self.get_system_containers():
+            container = i["Id"]
+            inspect_stdout = util.check_output(["runc", "state", container])
+            ret = json.loads(inspect_stdout)
+            status = ret["status"]
+            if not self.args.all and status != "running":
+                continue
+
+            image = i['Image']
+            command = ""
+            created = dateparse(ret['created']).strftime("%F %H:%M") # pylint: disable=no-member
+            all_containers.append({"type" : "systemcontainer", "container" : container,
+                                   "image" : image, "command" : command, "created" : created,
+                                   "status" : status})
+
+        # Collect the docker containers
+        for container in [x["Id"] for x in self.d.containers(all=self.args.all)]:
+            ret = self._inspect_container(name=container)
+            status = ret["State"]["Status"]
+            image = ret['Config']['Image']
+            command = u' '.join(ret['Config']['Cmd']) if ret['Config']['Cmd'] else ""
+            created = dateparse(ret['Created']).strftime("%F %H:%M") # pylint: disable=no-member
+            all_containers.append({"type" : "docker", "container" : container,
+                                   "image" : image, "command" : command,
+                                   "created" : created, "status" : status})
+
+        if self.args.json:
+            self.write_out(json.dumps(all_containers))
+            return
+
+        col_out = "{0:12} {1:20} {2:20} {3:15} {4:9}"
+        if self.args.heading:
+            self.write_out(col_out.format("CONTAINER ID",
+                                          "IMAGE",
+                                          "COMMAND",
+                                          "CREATED",
+                                          "STATUS"))
+
+        for container in all_containers:
+            self.write_out(col_out.format(container["container"][0:12],
+                                          container["image"][0:20],
+                                          container["command"][0:20].encode('utf-8'),
+                                          container["created"][0:15],
+                                          container["status"][0:9]))

--- a/atomic
+++ b/atomic
@@ -36,6 +36,7 @@ from Atomic.mount import Mount
 from Atomic.verify import Verify
 from Atomic.help import AtomicHelp
 from Atomic.run import Run
+from Atomic.ps import Ps
 from Atomic.storage import Storage
 from Atomic.atomic import NoDockerDaemon, OSTREE_PRESENT
 from Atomic.util import get_atomic_config, get_scanners, default_docker_lib
@@ -430,6 +431,20 @@ def create_parser(atomic):
     scan_group.add_argument("--all", default=False, action='store_true', help=_("scan all images (excluding intermediate layers) and containers"))
     scan_group.add_argument("--images", default=False, action='store_true', help=_("scan all images (excluding intermediate layers)"))
     scan_group.add_argument("--containers", default=False, action='store_true', help=_("scan all containers"))
+
+    # atomic ps
+    pss = subparser.add_parser(
+        "ps", help=_("list the containers"),
+        epilog="By default this shows only the running containers.")
+    pss.set_defaults(_class=Ps, func='ps')
+    pss.add_argument("-n", "--noheading", dest="heading", default=True,
+                     action="store_false",
+                     help=_("do not print heading when listing the containers"))
+    pss.add_argument("-a", "--all", action='store_true',dest="all", default=False,
+                     help=_("show all containers"))
+    pss.add_argument("--json", action='store_true',dest="json", default=False,
+                     help=_("print in a machine parseable form"))
+    add_opt(pss)
 
     # atomic stop
     stopp = subparser.add_parser(

--- a/bash/atomic
+++ b/bash/atomic
@@ -295,6 +295,14 @@ _atomic_pull() {
 	esac
 }
 
+_atomic_ps() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "-a --all -n --noheading --json" -- "$cur" ) )
+			;;
+	esac
+}
+
 _atomic_update() {
 	case "$cur" in
 		-*)
@@ -869,6 +877,7 @@ _atomic() {
 		storage
 		mount
 		pull
+		ps
 		rhost
 		run
 		scan

--- a/docs/atomic-ps.1.md
+++ b/docs/atomic-ps.1.md
@@ -1,0 +1,34 @@
+% ATOMIC(1) Atomic Man Pages
+% Giuseppe Scrivano
+% June 2016
+# NAME
+atomic-ps - list locally installed containers
+
+# SYNOPSIS
+**atomic ps**
+[**-h|--help**]
+[**-n|--noheading**]
+[**-a|--all**]
+[**--json**]
+
+# DESCRIPTION
+**atomic ps**, by default, will list all running containers on your
+system.
+
+Using --all will list all the installed containers.
+
+# OPTIONS:
+**-h** **--help**
+  Print usage statement
+
+**-a** **--all**
+  Print all the installed containers
+
+**-n** **--noheading**
+  Do not print heading when listing the containers
+
+**--json**
+  Print in a machine parseable format
+
+# HISTORY
+June 2016, Originally compiled by Giuseppe Scrivano (gscrivan at redhat dot com)

--- a/tests/integration/test_system_containers.sh
+++ b/tests/integration/test_system_containers.sh
@@ -47,6 +47,10 @@ trap teardown EXIT
 
 ${ATOMIC} --debug install --name=${NAME} --set=RECEIVER=${SECRET} --system oci:atomic-test-system
 
+${ATOMIC} ps | grep -q "test-system"
+${ATOMIC} ps --json | grep -q "test-system"
+${ATOMIC} ps --all | grep -q "test-system"
+
 test -e /etc/systemd/system/${NAME}.service
 
 # The value we set is exported into the config file


### PR DESCRIPTION
I'll probably need something like this for https://github.com/openshift/openshift-ansible/ to be able to query what containers are running.  In any case, this is generally a good thing to have.