### PR TITLE
[merged] If OSTree is not installed, atomic images is blowing up

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -1297,6 +1297,9 @@ class Atomic(object):
             "/var/lib/containers/atomic"
 
     def _get_ostree_repo(self):
+        if not OSTREE_PRESENT:
+            return None
+
         repo_location = os.environ.get("ATOMIC_OSTREE_REPO") or \
                         self.get_atomic_config_item(["ostree_repository"]) or \
                         "/ostree/repo"


### PR DESCRIPTION
This fix will check if OSTREE_PRESENT, and return None so
that OSTree will not get called.  Will not do any of the system containers
checks.