### PR TITLE
[merged] Atomic/mount.py: Break from loop when info found

### DIFF
--- a/Atomic/mount.py
+++ b/Atomic/mount.py
@@ -565,6 +565,7 @@ class DockerMount(Mount):
                 continue
             if dev_name == graph["Data"]["DeviceName"]:
                 cid=c
+                break
 
         return cid, dev_name
 


### PR DESCRIPTION
In the def _get_cid_from_mountpoint, once the cid is found,
we should break from the for loop.  This makes the function
faster.  And also, for an unknown reason (to me), this ensures
that temporary dirs in /run/atomic/<ts> are cleaned up.