### PR TITLE
Improvements(?) to "atomic run"

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -128,7 +128,7 @@ class Atomic(object):
                 "-e", "IMAGE=${IMAGE}",
                 "${IMAGE}"]
 
-    RUN_ARGS = ["create",
+    RUN_ARGS = ["run",
                 "-t",
                 "-i",
                 "--name", "${NAME}",

--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -125,6 +125,7 @@ class Atomic(object):
                 "-e", "HOST=/host",
                 "-e", "NAME=${NAME}",
                 "-e", "IMAGE=${IMAGE}",
+                "--name", "${NAME}",
                 "${IMAGE}"]
 
     RUN_ARGS = ["run",

--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -115,7 +115,6 @@ class Atomic(object):
     SPC_ARGS = ["run",
                 "-t",
                 "-i",
-                "--rm",
                 "--privileged",
                 "-v", "/:/host",
                 "-v", "/run:/run",

--- a/Atomic/run.py
+++ b/Atomic/run.py
@@ -48,6 +48,9 @@ class Run(Atomic):
                 else:
                     args = [self.docker_binary()] + self.RUN_ARGS + self._get_cmd()
 
+        if len(args) > 0 and args[0] == "docker":
+            args[0] = self.docker_binary()
+
         cmd = self.gen_cmd(args)
         cmd = self.sub_env_strings(cmd)
         self.display(cmd)

--- a/Atomic/run.py
+++ b/Atomic/run.py
@@ -38,12 +38,6 @@ class Run(Atomic):
                 args = [self.docker_binary()] + self.SPC_ARGS + self.command
             else:
                 args = [self.docker_binary()] + self.SPC_ARGS + self._get_cmd()
-
-            cmd = self.gen_cmd(args)
-            cmd = self.sub_env_strings(cmd)
-            self.display(cmd)
-            if self.args.display:
-                return
         else:
             args = self._get_args("RUN")
             if args:
@@ -54,11 +48,11 @@ class Run(Atomic):
                 else:
                     args = [self.docker_binary()] + self.RUN_ARGS + self._get_cmd()
 
-            cmd = self.gen_cmd(args)
-            cmd = self.sub_env_strings(cmd)
-            self.display(cmd)
-            if self.args.display:
-                return
+        cmd = self.gen_cmd(args)
+        cmd = self.sub_env_strings(cmd)
+        self.display(cmd)
+        if self.args.display:
+            return
 
         if self.args.quiet:
             self.check_args(cmd)

--- a/Atomic/run.py
+++ b/Atomic/run.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from . import util
 
 try:
@@ -15,6 +16,9 @@ except ImportError:
 class Run(Atomic):
     def run(self):
         self.inspect = self._inspect_container()
+
+        if not self.args.name:
+            self.name = str(uuid.uuid4())
 
         if self.inspect:
             self._check_latest()

--- a/Atomic/run.py
+++ b/Atomic/run.py
@@ -51,6 +51,13 @@ class Run(Atomic):
         if len(args) > 0 and args[0] == "docker":
             args[0] = self.docker_binary()
 
+        if not self.args.remain:
+            # Splice a "--rm" option into the command line
+            if args[0] == self.docker_binary():
+                run_index = args.index("run")
+                if run_index:
+                    args.insert(run_index + 1, "--rm")
+
         cmd = self.gen_cmd(args)
         cmd = self.sub_env_strings(cmd)
         self.display(cmd)

--- a/Atomic/run.py
+++ b/Atomic/run.py
@@ -14,7 +14,6 @@ except ImportError:
 
 class Run(Atomic):
     def run(self):
-        missing_RUN = False
         self.inspect = self._inspect_container()
 
         if self.inspect:
@@ -50,7 +49,6 @@ class Run(Atomic):
             if args:
                 args += self.command
             else:
-                missing_RUN = True
                 if self.command:
                     args = [self.docker_binary()] + self.RUN_ARGS + self.command
                 else:
@@ -61,13 +59,6 @@ class Run(Atomic):
             self.display(cmd)
             if self.args.display:
                 return
-
-            if missing_RUN:
-                util.check_call(cmd,
-                                env=self.cmd_env(),
-                                stderr=DEVNULL,
-                                stdout=DEVNULL)
-                return self._start()
 
         if self.args.quiet:
             self.check_args(cmd)

--- a/atomic
+++ b/atomic
@@ -458,6 +458,8 @@ def create_parser(atomic):
     runp.add_argument("--spc", default=False, action="store_true",
                       help=_("use super privileged container mode: '%s'" %
                              atomic.print_spc()))
+    runp.add_argument("--remain", action="store_true",
+                      help=_("don't remove the container when it's done"))
     runp.add_argument("image", help=_("container image"))
     runp.add_argument("command", nargs=argparse.REMAINDER,
                       help=_("command to execute within the container. "


### PR DESCRIPTION
This makes "atomic run" behave more like "docker run" in that it doesn't reuse an existing container by default.

This is motivated by https://bugzilla.redhat.com/show_bug.cgi?id=1299813

It also addresses some potential inconsistencies:
- `atomic run --spc` would pass `--rm`, while the rest would not
- `atomic run --spc` would not pass `--name`, while the rest would
- `atomic run` with a RUN label might not run docker-latest

If one wants to use "atomic run" reliably without this, one can explicitly pass a unique "--name" option and delete the container explicitly afterwards.  However, I think it would be nice if atomic run itself would offer a easy way to do the right thing, even if only optionally via explicit "--unique" and "--rm" options, say.
