### PR TITLE
If given image name is included repository list use it.

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -680,6 +680,9 @@ class Atomic(object):
 
     def get_fq_name(self, image_info):
         if len(image_info['RepoTags']) > 1:
+            if self.image in image_info['RepoTags']:
+                return self.image
+
             raise ValueError("\n{} is tagged with multiple repositories. "
                              "Please use a repository name instead.\n".format(self.image))
         else:


### PR DESCRIPTION
If given image name is included repository list use it.

This change allows the following workflow:

```
$ docker pull kubernetes/pause
$ docker tag kubernetes/pause localhost:5000/my/pause
$ docker push localhost:5000/my/pause
$ atomic info localhost:5000/kubernetes/pause:latest
```

Signed-off-by: Jhon Honce <jhonce@redhat.com>