### PR TITLE
Introduce ATOMIC_TRACEBACK

### DIFF
--- a/atomic
+++ b/atomic
@@ -636,6 +636,8 @@ if __name__ == '__main__':
         if str(e).find("Permission denied") > 0:
             need_root()
     except Exception as e:
+        if 'ATOMIC_TRACEBACK' in os.environ:
+            raise
         sys.stderr.write("%s\n" % str(e))
     except SystemExit as e:
         # Overriding debug args to avoid a traceback from sys.exit()


### PR DESCRIPTION
I'm not sure if there's a standard for this in the Python community,
but basically if I want to debug something I'd like to be able to
easily get a traceback.