### PR TITLE
[merged] Work correctly with fully qualified image names

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -995,7 +995,7 @@ class Atomic(object):
         for i in ["oci:", "http:", "https:"]:
             image = image.replace(i, "")
 
-        fqn_image = self.find_remote_image(image)
+        fqn_image = self.find_remote_image(image) or image
         if insecure:
             return ["--insecure"], "docker://" + fqn_image
         else:

--- a/tests/integration/test_system_containers.sh
+++ b/tests/integration/test_system_containers.sh
@@ -28,6 +28,8 @@ docker save atomic-test-system > ${WORK_DIR}/atomic-test-system.tar
 
 ${ATOMIC} pull dockertar:/${WORK_DIR}/atomic-test-system.tar
 
+${ATOMIC} pull docker.io/busybox
+
 # Check that the branch is created in the OSTree repository
 ostree --repo=${ATOMIC_OSTREE_REPO} refs | grep -q "ociimage/atomic-test-system-latest"
 
@@ -93,6 +95,7 @@ test \! -e /etc/systemd/system/${NAME}.service
 
 # check that there are not any "ociimage/" prefixed branch left after images --prune
 ostree --repo=${ATOMIC_OSTREE_REPO} refs --delete "ociimage/atomic-test-system-latest"
+ostree --repo=${ATOMIC_OSTREE_REPO} refs --delete "ociimage/busybox-latest"
 ${ATOMIC} images --prune
 OUTPUT=$(! ostree --repo=${ATOMIC_OSTREE_REPO} refs | grep -c ociimage)
 if test $OUTPUT \!= 0; then


### PR DESCRIPTION
Atomic.find_remote_image can return None if the image name provided by
the user has not the same name as the one found.  In that case, use the
name provided by the user.

Problem introduced by d29c801ee78597b0ef3f9773467882da8ac9ec71

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>