### PR TITLE
[merged] Atomic/scan.py: Fail on Dead containers

### DIFF
--- a/Atomic/scan.py
+++ b/Atomic/scan.py
@@ -162,7 +162,10 @@ class Scan(Atomic):
         def gen_containers():
             slist = []
             for con in self.get_containers():
-                con['input'] = con['Id']
+                if con['Status'].upper() != 'DEAD':
+                    con['input'] = con['Id']
+                else:
+                    raise ValueError("The container ID {} is Dead and therefor cannot be scanned.".format(con['Id'][:12]))
                 slist.append(con)
             return slist
 


### PR DESCRIPTION
When someone trys to scan a dead container (typically
with --containers or --all), we usually observe DM or
mount issues.  In turn, this usually causes Atomic to
traceback and fail.  Adding in a quick check for those
cases where we nicely fail and cite the Dead container
as a reason.