### PR TITLE
Atomic/scan.py: Don't keep open STDIN for scan

### DIFF
--- a/Atomic/scan.py
+++ b/Atomic/scan.py
@@ -113,7 +113,7 @@ class Scan(Atomic):
         # Create the output directory
         os.makedirs(self.results_dir)
 
-        docker_args = ['docker', 'run', '-it', '--rm', '-v', '/etc/localtime:/etc/localtime',
+        docker_args = ['docker', 'run', '-t', '--rm', '-v', '/etc/localtime:/etc/localtime',
                        '-v', '{}:{}'.format(self.chroot_dir, '/scanin'), '-v',
                        '{}:{}:rw,Z'.format(self.results_dir, '/scanout')]
 


### PR DESCRIPTION
`atomic scan fedora:24` runs `docker -it ...` and it needs to have interactive terminal.

Consequences: `atomic scan fedora:24` is not usable in cases like
- `nohup atomic scan fedora:24`
- `ssh root@localhost atomic scan fedora:24`
- ...

It only prints `cannot enable tty mode on non tty input`.