### PR TITLE
[merged] Fix build issues on python3 with python3-pylint

### DIFF
--- a/Atomic/dockerimageid.py
+++ b/Atomic/dockerimageid.py
@@ -81,7 +81,7 @@ def iter_subs(tree, key=None):
         if str(tree).startswith(DockerImageID.ALGO) and key in SUB_KEYS:
             return DockerImageID(str(tree))
     # In py2, it is unicode and not str
-    elif is_python2 and isinstance(tree, unicode) and key in SUB_KEYS:
+    elif is_python2 and isinstance(tree, unicode) and key in SUB_KEYS: # pylint: disable=undefined-variable
         if str(tree).startswith(DockerImageID.ALGO):
             return DockerImageID(str(tree))
     elif isinstance(tree, dict):

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -13,7 +13,7 @@ import shutil
 import re
 import requests
 try:
-    from urlparse import urlparse
+    from urlparse import urlparse #pylint: disable=import-error
 except:
     from urllib.parse import urlparse #pylint: disable=no-name-in-module,import-error
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SYSCONFDIR ?= $(DESTDIR)/etc/sysconfig
 PROFILEDIR ?= $(DESTDIR)/etc/profile.d
 PYTHON ?= /usr/bin/python
 PYLINT ?= /usr/bin/pylint
+PYTHON3_PYLINT ?= /usr/bin/python3-pylint
 GO_MD2MAN ?= /usr/bin/go-md2man
 GO ?= /usr/bin/go
 PYTHONSITELIB=$(shell $(PYTHON) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(0))")
@@ -12,8 +13,12 @@ VERSION=$(shell $(PYTHON) setup.py --version)
 .PHONY: all
 all: python-build docs pylint-check dockertar-sha256-helper
 
+.PHONY: test-python3-pylint
+test-python3-pylint: 
+	$(PYTHON3_PYLINT) -E --additional-builtins=_ *.py atomic Atomic tests/unit/*.py
+
 .PHONY: test
-test: all
+test: all test-python3-pylint
 	./test.sh
 
 test-destructive: all

--- a/atomic_client.py
+++ b/atomic_client.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
         elif(sys.argv[1] == "verify"):
             resp = dbus_proxy.verify(sys.argv[2:])
             for r in resp:
-                print r
+                print(r)
 
         elif(sys.argv[1] == "storage"):
             #handles atomic storage export
@@ -106,7 +106,7 @@ if __name__ == "__main__":
         elif(sys.argv[1] == "diff"):
             #case where rpms flag is passed in
             resp = json.loads(dbus_proxy.diff(sys.argv[2], sys.argv[3]))
-            print resp
+            print(resp)
 
         elif(sys.argv[1] == "scan"):
             if(sys.argv[2] == "list"):

--- a/atomic_dbus.py
+++ b/atomic_dbus.py
@@ -35,7 +35,7 @@ class atomic_dbus(slip.dbus.service.Object):
             self.tty = True
 
     def __init__(self, *p, **k):
-	super(atomic_dbus, self).__init__(*p, **k)
+        super(atomic_dbus, self).__init__(*p, **k)
         self.atomic = Atomic()
 
     """


### PR DESCRIPTION
Force make test to test python3-pylint.

Our tests are not catching python3 issues.  This patch fixes some issues and forces python3-pylint to to be tested.