### PR TITLE
[merged] Run SPC containers with /sys/fs/selinux mounted as read/only

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -121,6 +121,7 @@ class Atomic(object):
                 "-v", "/:/host",
                 "-v", "/run:/run",
                 "-v", "/etc/localtime:/etc/localtime",
+                "-v", "/sys/fs/selinux:/sys/fs/selinux:ro",
                 "--net=host",
                 "--ipc=host",
                 "--pid=host",


### PR DESCRIPTION
This tells libselinux inside the container that SELinux is disabled,
even though we are in a SPC container, we don't want the container attempting
to do labeling and especially do not want it loading policy.  If I accidently
load a RHEL6 policy on a RHEL7 machine, bad stuff will happen.