### PR TITLE
[merged] status: support JSON output

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -464,6 +464,8 @@ class Atomic(object):
         argv = ["status"]
         if self.args.pretty:
             argv.append("--pretty")
+        if self.args.json:
+            argv.append("--json")
         self._rpmostree(argv)
 
     def host_upgrade(self):

--- a/atomic
+++ b/atomic
@@ -181,6 +181,9 @@ def create_parser(atomic):
         # atomic host status
         statusp = host_subparser.add_parser(
             "status", help=_("list information about all deployments"))
+        statusp.add_argument("-j", "--json", dest="json",
+                             action="store_true",
+                             help=_("Display status in JSON format"))
         statusp.add_argument("-p", "--pretty", dest="pretty",
                               action="store_true",
                               help=_("Display status in formatted rows"))

--- a/atomic
+++ b/atomic
@@ -185,8 +185,9 @@ def create_parser(atomic):
                              action="store_true",
                              help=_("Display status in JSON format"))
         statusp.add_argument("-p", "--pretty", dest="pretty",
-                              action="store_true",
-                              help=_("Display status in formatted rows"))
+                             action="store_true",
+                             help=_("This option is deprecated and no "
+                                    "longer has any effect"))
         statusp.add_argument("args", nargs=argparse.REMAINDER,
                              help=_("Additional arguments appended to the "
                                     "status method.  Use `-- --OPTION=VAL` "

--- a/bash/atomic
+++ b/bash/atomic
@@ -560,7 +560,7 @@ _atomic_host_rollback() {
 _atomic_host_status() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "-p --pretty -h --help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "-j --json -p --pretty -h --help" -- "$cur" ) )
 			;;
 		*)
 			;;


### PR DESCRIPTION
Add support for `rpm-ostree status --json`

Fixes #469

Signed-off-by: Micah Abbott <miabbott@redhat.com>