### PR TITLE
[merged]  storage: Don't crash while removing devices when there is no volume group

### DIFF
--- a/Atomic/storage.py
+++ b/Atomic/storage.py
@@ -81,15 +81,20 @@ def query_pvs(pv, fields):
 
 def list_pvs(vgroup):
     res = [ ]
-    for l in util.check_output([ "pvs", "--noheadings", "-o",  "vg_name,pv_name" ]).splitlines():
-        fields = l.split()
-        if len(fields) == 2 and fields[0] == vgroup:
-            res.append(fields[1])
+    if vgroup:
+        for l in util.check_output([ "pvs", "--noheadings", "-o",  "vg_name,pv_name" ]).splitlines():
+            fields = l.split()
+            if len(fields) == 2 and fields[0] == vgroup:
+                res.append(fields[1])
     return res
 
 def list_lvs(vgroup):
-    return map(lambda s: s.strip(), # pylint: disable=deprecated-lambda, map-builtin-not-iterating
-               util.check_output([ "lvs", "--noheadings", "-o", "name", vgroup ]).splitlines())
+    if vgroup:
+        return map(lambda s: s.strip(), # pylint: disable=deprecated-lambda, map-builtin-not-iterating
+                   util.check_output([ "lvs", "--noheadings", "-o", "name", vgroup ]).splitlines())
+    else:
+        return [ ]
+
 def list_parents(dev):
     return util.check_output([ "lsblk", "-snlp", "-o", "NAME", dev ]).splitlines()[1:]
 


### PR DESCRIPTION
When the storage pool is not in a volume group, we would previously
try to list the physical volumes of a volume group called "".  This
would crash.

Now, if the storage pool is not in a volume group, we treat that as a
volume group without any physical or logical volumes, which allows the
rest of the code to cope with that case cleanly.