### PR TITLE
[merged] [RFC] User containers

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -296,6 +296,11 @@ class Atomic(object):
         except (NameError, AttributeError):
             pass
 
+        try:
+            self.user = args.user
+        except (NameError, AttributeError):
+            pass
+
         if not self.name and self.image is not None:
             self.name = self.image.split("/")[-1].split(":")[0]
             if self.spc:
@@ -806,10 +811,14 @@ class Atomic(object):
         if self._container_exists(self.name):
             raise ValueError("A container '%s' is already present" % self.name)
 
-        if self.system:
+        if self.user:
+            if not util.is_user_mode():
+                raise ValueError("--user does not work for privileged user")
+            return self.syscontainers.install_user_container(self.image, self.name)
+        elif self.system:
             return self.syscontainers.install_system_container(self.image, self.name)
         elif self.args.setvalues:
-            raise ValueError("--set is valid only when used with --system")
+            raise ValueError("--set is valid only when used with --system or --user")
 
         self._check_if_image_present()
         args = self._get_args("INSTALL")

--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -387,11 +387,8 @@ class Atomic(object):
             if self.syscontainers.has_system_container_image(image):
                 return self.syscontainers.inspect_system_image(image)
             return self.d.inspect_image(image)
-        except NotFound:
+        except (NotFound, requests.exceptions.ConnectionError):
             pass
-        except requests.exceptions.ConnectionError:
-            raise NoDockerDaemon()
-
         return None
 
     def _inspect_container(self, name=None):
@@ -399,10 +396,8 @@ class Atomic(object):
             name = self.name
         try:
             return self.d.inspect_container(name)
-        except NotFound:
+        except (NotFound, requests.exceptions.ConnectionError):
             pass
-        except requests.exceptions.ConnectionError:
-            raise NoDockerDaemon()
         return None
 
     def _get_args(self, label):

--- a/Atomic/ps.py
+++ b/Atomic/ps.py
@@ -2,10 +2,8 @@ import json
 
 from . import util
 from . import Atomic
-import subprocess
-from dateutil.parser import parse as dateparse
-from . import atomic
 import datetime
+from dateutil.parser import parse as dateparse
 
 class Ps(Atomic):
 
@@ -18,13 +16,11 @@ class Ps(Atomic):
                 container = each["Id"]
                 status = "exited"
                 created = datetime.datetime.fromtimestamp(each["Created"])
-                try:
-                    inspect_stdout = util.check_output(["runc", "state", container], stderr=atomic.DEVNULL)
-                    ret = json.loads(inspect_stdout.decode())
-                    status = ret["status"]
-                    created = dateparse(ret['created'])
-                except (subprocess.CalledProcessError):
-                    pass
+                info = self.syscontainers.get_container_runtime_info(container)
+                if 'status' in info:
+                    status = info["status"]
+                    if 'created' in info:
+                        created = info['created']
 
                 if not self.args.all and status != "running":
                     continue

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -328,7 +328,7 @@ class SystemContainers(object):
     def _get_ostree_repo_location(self):
         if self.user:
             home_dir = os.getenv("HOME")
-            return os.path.expanduser("%s/ostree/repo" % home_dir)
+            return os.path.expanduser("%s/.containers/repo" % home_dir)
         else:
             return os.environ.get("ATOMIC_OSTREE_REPO") or \
                 self.get_atomic_config_item(["ostree_repository"]) or \

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -12,6 +12,7 @@ import subprocess
 import time
 from .client import AtomicDocker
 from ctypes import cdll, CDLL
+from dateutil.parser import parse as dateparse
 
 try:
     import gi
@@ -405,6 +406,19 @@ class SystemContainers(object):
         values = info["values"]
 
         self._checkout_system_container(repo, name, image, next_deployment, True, values)
+
+    def get_container_runtime_info(self, container):
+        if self.user:
+            return {'status' : 'unknown'}
+
+        try:
+            inspect_stdout = util.check_output(["runc", "state", container])
+            ret = json.loads(inspect_stdout.decode())
+            status = ret["status"]
+            created = dateparse(ret['created'])
+            return {"status" : status, "created" : created}
+        except (subprocess.CalledProcessError):
+            return {}
 
     def get_system_containers(self):
         checkouts = self._get_system_checkout_path()

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -667,7 +667,7 @@ class SystemContainers(object):
                     info.set_attribute_uint32("unix::mode", info.get_attribute_uint32("unix::mode") | stat.S_IWUSR)
                 return OSTree.RepoCommitFilterResult.ALLOW
 
-            modifier = OSTree.RepoCommitModifier(0, filter_func, None)
+            modifier = OSTree.RepoCommitModifier.new(0, filter_func, None)
             repo.write_archive_to_mtree(Gio.File.new_for_path(tar), mtree, modifier, True)
             root = repo.write_mtree(mtree)[1]
             metav = GLib.Variant("a{sv}", {'docker.layer': GLib.Variant('s', layer)})

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -414,3 +414,6 @@ def find_remote_image(client, image):
         if e.args[0].args[0] == errno.ENOENT:
             raise ValueError("Image not found")
     return None
+
+def is_user_mode():
+    return os.geteuid() != 0

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ docs/%.1: docs/%.1.md
 .PHONY: docs
 docs: $(MANPAGES_MD:%.md=%)
 
-dockertar-sha256-helper:
+dockertar-sha256-helper: dockertar-sha256-helper.go
 	$(GO) build dockertar-sha256-helper.go
 
 .PHONY: clean

--- a/atomic
+++ b/atomic
@@ -298,6 +298,8 @@ def create_parser(help_text):
         help=_("preview the command that %s would execute") % sys.argv[0])
     installp.add_argument("image", help=_("container image"))
     if Atomic.syscontainers.OSTREE_PRESENT:
+        installp.add_argument("--user", dest="user", action="store_true",
+                              help=_("Flag to specify if user is non-root privileged."))
         installp.add_argument("--system", dest="system",
                               action='store_true', default=False,
                               help=_('install a system container'))

--- a/atomic
+++ b/atomic
@@ -398,8 +398,6 @@ def create_parser(help_text):
         epilog="pull the latest specified image from a repository.")
     pullp.add_argument("--storage", dest="backend", help=_("Specify the storage."))
     pullp.add_argument("image", help=_("image id"))
-    pullp.add_argument("--user", dest="user", action="store_true",
-                       help=_("Flag to specify if user is non-root privileged."))
     pullp.set_defaults(func='pull_image')
 
     # making it so we cannot call both the --pulp and --satellite commands

--- a/bash/atomic
+++ b/bash/atomic
@@ -305,7 +305,7 @@ _atomic_version() {
 _atomic_pull() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--storage --user" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--storage" -- "$cur" ) )
 			;;
 	esac
 }

--- a/bash/atomic
+++ b/bash/atomic
@@ -452,6 +452,7 @@ _atomic_install() {
                --display
                --system
                --set
+               --user
 	"
 
 	local options_with_args_glob=$(__atomic_to_extglob "$options_with_args")

--- a/docs/atomic-install.1.md
+++ b/docs/atomic-install.1.md
@@ -77,6 +77,10 @@ Installing a system container consists of checking it the image by
 default under /var/lib/containers/atomic/ and generating the
 configuration files for runc and systemd.
 
+**--user**
+If running as non-root, specify to install the image from the current
+OSTree repository and manage it through systemd and bubblewrap.
+
 # HISTORY
 January 2015, Originally compiled by Daniel Walsh (dwalsh at redhat dot com)
 July 2015, edited by Sally O'Malley (somalley at redhat dot com)

--- a/docs/atomic-pull.1.md
+++ b/docs/atomic-pull.1.md
@@ -43,12 +43,12 @@ local OSTree repository:
 
 `atomic pull ostree:REMOTE/branch`
 
+If the user is not privileged, the image will be stored in the user
+specific repository.
+
 # OPTIONS:
 **-h** **--help**
 Print usage statement
-
-**--user**
-User flag to specify the user is non-privileged. Default to False.
 
 **--storage=[ostree]**
 Define the destination storage for the pulled image.


### PR DESCRIPTION
user containers use bwrap-oci (https://github.com/giuseppe/bubblewrap/tree/bwrap-oci) to convert from the OCI configuration, which is already used for runc, to the bubblewrap command line.

I dropped `--user` from pull, as it should happen by default when the user is not root.

I added `--user` to install, so that it is clear that the user wants to install an user container, and also leave space in future to add new types of containers.