### PR TITLE
[merged] Atomic/diff.py: Fix --json output/formatting

### DIFF
--- a/Atomic/diff.py
+++ b/Atomic/diff.py
@@ -12,7 +12,7 @@ class Diff(Atomic):
     def diff_tty(self):
         diff_dict = self.diff()
         if self.args.json:
-            util.output_json(diff_dict)
+            util.output_json(json.loads(diff_dict))
 
     def diff(self):
         '''


### PR DESCRIPTION
With the tty changes, we were sending a str to the
util.output_json method which expects a dict|json.