### PR TITLE
[merged] Improve error messages system containers

### DIFF
--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -34,6 +34,29 @@ class TestAtomicUtil(unittest.TestCase):
                selinux.is_selinux_enabled() else '')
         self.assertEqual(exp, util.default_container_context())
 
+    def test_check_call(self):
+        exception_raised = False
+        try:
+            util.check_call(['/usr/bin/does_not_exist'])
+        except util.FileNotFound:
+            exception_raised = True
+        self.assertTrue(exception_raised)
+
+    def test_call(self):
+        exception_raised = False
+        try:
+            util.call(['/usr/bin/does_not_exist'])
+        except util.FileNotFound:
+            exception_raised = True
+        self.assertTrue(exception_raised)
+
+    def test_check_output(self):
+        exception_raised = False
+        try:
+            util.check_call(['/usr/bin/does_not_exist'])
+        except util.FileNotFound:
+            exception_raised = True
+        self.assertTrue(exception_raised)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fail early if runc is not installed when installing a system container, or either if bwrap-oci is not installed or systemctl doesn't support --user when installing an user container.