### PR TITLE
[merged] images-list: Add --json

### DIFF
--- a/Atomic/images.py
+++ b/Atomic/images.py
@@ -2,6 +2,7 @@ from . import Atomic
 from . import util
 from .mount import Mount
 import os
+import sys
 import json
 import math
 import shutil
@@ -39,6 +40,9 @@ class Images(Atomic):
                 return 1, 1
 
         _images = self.images()
+        if self.args.json:
+            json.dump(_images, sys.stdout)
+            return
 
         if len(_images) >= 0:
             _max_repo, _max_tag = get_col_lengths(_images)

--- a/atomic
+++ b/atomic
@@ -347,6 +347,8 @@ def create_parser(help_text):
     list_parser.add_argument("-q", "--quiet", dest="quiet", default=False,
                              action="store_true",
                              help=_("Only display image IDs"))
+    list_parser.add_argument("--json", action='store_true',dest="json", default=False,
+                             help=_("print in a machine parseable form"))
 
     # atomic images delete
     delete_parser = images_subparser.add_parser("delete",

--- a/bash/atomic
+++ b/bash/atomic
@@ -513,6 +513,7 @@ _atomic_images_list() {
     --noheading -n
     --no-trunc
     --quiet -q
+    --json
   "
 
   local filterables="

--- a/docs/atomic-images.1.md
+++ b/docs/atomic-images.1.md
@@ -44,6 +44,8 @@ will list all images that has "foo" as part of their repository name.
 [**-q|--quiet]
   Only display image IDs
 
+**--json**
+  Output in the form of JSON.
 
 **delete IMAGES...**
 


### PR DESCRIPTION
When trying to script `atomic` via Ansible, in order to implement
idempotence we need the ability to introspect the current state
in a machine-readable way.

`ps` already has `--json`, so teach `images list` about it too;
the implementation is trivial.