### PR TITLE
[merged] Add image container version to json output

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -958,6 +958,7 @@ class Atomic(object):
             images = self.d.images(all=get_all)
             for i in images:
                 i["ImageType"] = "Docker"
+                i["ImageId"] = i["Id"]
         except requests.exceptions.ConnectionError:
             raise NoDockerDaemon()
         return images

--- a/Atomic/images.py
+++ b/Atomic/images.py
@@ -124,6 +124,7 @@ class Images(Atomic):
                 image_dict["created"] = created
                 image_dict["virtual_size"] = virtual_size
                 image_dict["type"] = image_type
+                image_dict["image_id"] = image["ImageId"]
                 if image_dict["vulnerable"]:
                     image_dict["vuln_info"] = all_vuln_info[image["Id"]]
                 else:

--- a/Atomic/images.py
+++ b/Atomic/images.py
@@ -136,13 +136,13 @@ class Images(Atomic):
     def generate_validation_manifest(self):
         """
         Generates a gomtree validation manifest for a non-system image and stores it in
-        ATOMIC_VAR
+        ATOMIC_VAR_LIB
         :param:
         :return: None
         """
         _images = self.get_images(get_all=True)
         for image in _images:
-            atomic_var = util.ATOMIC_VAR
+            atomic_var_lib = util.ATOMIC_VAR_LIB
             if not image["RepoTags"]:
                 continue
             iid = image["RepoTags"][0]
@@ -150,9 +150,9 @@ class Images(Atomic):
                 continue
             if iid == "<none>:<none>" or iid == "<none>":
                 continue
-            if os.path.exists(os.path.join(atomic_var,"gomtree-manifests/%s.mtree" % iid)):
+            if os.path.exists(os.path.join(atomic_var_lib, "gomtree-manifests/%s.mtree" % iid)):
                 continue
-            manifestname = os.path.join(atomic_var, "gomtree-manifests/%s.mtree" % iid)
+            manifestname = os.path.join(atomic_var_lib, "gomtree-manifests/%s.mtree" % iid)
             dname = os.path.dirname(manifestname)
             if not os.path.exists(dname):
                 os.makedirs(dname)

--- a/Atomic/ps.py
+++ b/Atomic/ps.py
@@ -26,10 +26,11 @@ class Ps(Atomic):
                     continue
 
                 image = each['Image']
+                imageId = each['ImageID']
                 command = each["Command"]
                 created = created.strftime("%F %H:%M") # pylint: disable=no-member
                 container_info = {"type" : "systemcontainer", "container" : container,
-                              "image" : image, "command" : command,
+                              "image" : image, "command" : command, "image_id" : imageId,
                               "created" : created, "status" : status,
                               "runtime" : "runc", "vulnerable" : each["vulnerable"]}
 
@@ -44,10 +45,11 @@ class Ps(Atomic):
                 ret = self._inspect_container(name=container)
                 status = ret["State"]["Status"]
                 image = ret['Config']['Image']
+                imageId = ret['Image']
                 command = u' '.join(ret['Config']['Cmd']) if ret['Config']['Cmd'] else ""
                 created = dateparse(ret['Created']).strftime("%F %H:%M") # pylint: disable=no-member
                 container_info = {"type" : "docker", "container" : container,
-                                  "image" : image, "command" : command,
+                                  "image" : image, "image_id" : imageId, "command" : command,
                                   "created" : created, "status" : status,
                                   "runtime" : "Docker", "vulnerable" : each["vulnerable"]}
 

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -567,7 +567,7 @@ class SystemContainers(object):
         else:
             image_type = "System"
 
-        return {'Id' : image_id, 'RepoTags' : [tag], 'Names' : [], 'Created': timestamp,
+        return {'Id' : image_id, 'ImageId' : image_id, 'RepoTags' : [tag], 'Names' : [], 'Created': timestamp,
                 'ImageType' : image_type, 'Labels' : labels, 'OSTree-rev' : commit_rev}
 
     def get_system_images(self, get_all=False, repo=None):

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -487,7 +487,7 @@ class SystemContainers(object):
             return {'status' : 'unknown'}
 
         try:
-            inspect_stdout = util.check_output([RUNC_PATH, "state", container])
+            inspect_stdout = util.check_output([RUNC_PATH, "state", container], stderr=DEVNULL)
             ret = json.loads(inspect_stdout.decode())
             status = ret["status"]
             created = dateparse(ret['created'])

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -827,8 +827,7 @@ class SystemContainers(object):
         for i in layers:
             layer = i.replace("sha256:", "")
             has_layer = repo.resolve_rev("%s%s" % (OSTREE_OCIIMAGE_PREFIX, layer), True)[1]
-            has_gomtree_manifest = os.path.isfile(os.path.join(ATOMIC_VAR, "gomtree-manifests/%s.mtree" % layer))
-            if not has_layer or not has_gomtree_manifest:
+            if not has_layer:
                 missing_layers.append(layer)
                 util.write_out("Missing layer %s" % layer)
         layers_dir = None

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -25,7 +25,7 @@ ReturnTuple = collections.namedtuple('ReturnTuple',
 ATOMIC_CONF = os.environ.get('ATOMIC_CONF', '/etc/atomic.conf')
 ATOMIC_CONFD = os.environ.get('ATOMIC_CONFD', '/etc/atomic.d/')
 ATOMIC_LIBEXEC = os.environ.get('ATOMIC_LIBEXEC', '/usr/libexec/atomic')
-ATOMIC_VAR = os.environ.get('ATOMIC_VAR', '/var/lib/containers/atomic')
+ATOMIC_VAR_LIB = os.environ.get('ATOMIC_VAR_LIB', '/var/lib/atomic')
 
 def check_if_python2():
     if int(sys.version_info[0]) < 3:

--- a/Atomic/verify.py
+++ b/Atomic/verify.py
@@ -380,7 +380,7 @@ class Verify(Atomic):
         :return: None
         """
         iid = self._is_image(self.image)
-        manifestname = os.path.join(util.ATOMIC_VAR, "gomtree-manifests/%s.mtree" % iid)
+        manifestname = os.path.join(util.ATOMIC_VAR_LIB, "gomtree-manifests/%s.mtree" % iid)
         if not os.path.exists(manifestname):
             return
         tmpdir = tempfile.mkdtemp()
@@ -396,7 +396,7 @@ class Verify(Atomic):
         shutil.rmtree(tmpdir)
 
     @staticmethod
-    def get_gomtree_manifest(layer, root=os.path.join(util.ATOMIC_VAR, "gomtree-manifests")):
+    def get_gomtree_manifest(layer, root=os.path.join(util.ATOMIC_VAR_LIB, "gomtree-manifests")):
         manifestpath = os.path.join(root,"%s.mtree" % layer)
         if os.path.isfile(manifestpath):
             return manifestpath

--- a/tests/integration/test_system_containers.sh
+++ b/tests/integration/test_system_containers.sh
@@ -116,6 +116,9 @@ grep -q ${SECRET} ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.0/config.json
 # The default value $PORT specified in the manifest.json is exported
 grep -q 8081 ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.0/config.json
 
+${ATOMIC} update --container ${NAME} > update.out
+grep -q "Latest version already installed" update.out
+
 ${ATOMIC} update --set=PORT=8082 --container ${NAME}
 
 # Check that the same SECRET value is kept, and that $PORT gets the new value

--- a/tests/integration/test_system_containers.sh
+++ b/tests/integration/test_system_containers.sh
@@ -173,6 +173,11 @@ test \! -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.1
 
 
 ${ATOMIC} pull docker.io/busybox
+${ATOMIC} pull docker.io/busybox > second.pull.out
+if grep -q "Missing layer" second.pull.out; then
+    exit 1
+fi
+
 ostree --repo=${ATOMIC_OSTREE_REPO} refs > refs
 grep -q busybox refs
 ${ATOMIC} images delete -f busybox

--- a/tests/integration/test_system_containers.sh
+++ b/tests/integration/test_system_containers.sh
@@ -72,6 +72,8 @@ teardown () {
 trap teardown EXIT
 
 ${ATOMIC} install --name=${NAME} --set=RECEIVER=${SECRET} --system oci:atomic-test-system
+${ATOMIC} update --container ${NAME} > update.out
+grep -q "Latest version already installed" update.out
 
 ${ATOMIC} ps --no-trunc > ps.out
 grep -q "test-system" ps.out

--- a/tests/integration/test_verify.sh
+++ b/tests/integration/test_verify.sh
@@ -16,7 +16,7 @@ IFS=$'\n\t'
 echo "testing"
 IMAGE="atomic-test-4"
 ID=`${DOCKER} inspect ${IMAGE} | grep '"Id"' | cut -f4 --delimiter=\"`
-ATOMIC_VAR='/var/lib/containers/atomic'
+ATOMIC_VAR_LIB='/var/lib/atomic'
 
 setup () {
     # Perform setup routines here.
@@ -48,8 +48,8 @@ if [[ ${rc} != 1 ]]; then
 fi
 
 ${ATOMIC} images generate
-if [ ! -d ${ATOMIC_VAR}/gomtree-manifests ]; then
+if [ ! -d ${ATOMIC_VAR_LIB}/gomtree-manifests ]; then
     echo "gomtree manifests not created"
     exit 1
 fi
-rm -rf ${ATOMIC_VAR}/gomtree-manifests
+rm -rf ${ATOMIC_VAR_LIB}/gomtree-manifests


### PR DESCRIPTION
enhance the `ps --json` and `images list --json` output with the image id.

It allows to check what version of an image a container is using, and what is the latest version available (locally) of the image.

A couple of bug fixes are included as well.

@cgwalters 