### PR TITLE
syscontainers: Don't start on install

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -407,11 +407,10 @@ class SystemContainers(object):
             os.unlink(sym)
         os.symlink(destination, sym)
 
-        self._systemctl_command("enable", name)
         if upgrade:
             self._systemctl_command("restart", name)
         else:
-            self._systemctl_command("start", name)
+            self._systemctl_command("enable", name)
 
     def _get_system_checkout_path(self):
         if os.environ.get("ATOMIC_OSTREE_CHECKOUT_PATH"):


### PR DESCRIPTION
Interactive users or deployment systems may want to perform
configuration before starting.  For example, I may want to configure
the flannel data in etcd before starting flannel.

This topic comes up a lot in the RPM/deb worlds too; most RPM
distributions are inconsistent about this, whereas Debian basically
never starts a service on package install.

I think also it's better to teach admins to use systemd for service
management directly.

(This commit also changes things so we only `enable` on initial install,
 which is a minor tweak)