### PR TITLE
syscontainers: Suppress stderr from runc status attempt

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -487,7 +487,7 @@ class SystemContainers(object):
             return {'status' : 'unknown'}
 
         try:
-            inspect_stdout = util.check_output([RUNC_PATH, "state", container])
+            inspect_stdout = util.check_output([RUNC_PATH, "state", container], stderr=DEVNULL)
             ret = json.loads(inspect_stdout.decode())
             status = ret["status"]
             created = dateparse(ret['created'])


### PR DESCRIPTION
I noticed this when starting the flannel syscontainer failed, and I
got `open /run/runc/flannel/state.json: no such file or directory`
when running `atomic ps`.