### PR TITLE
[merged] Canononicalize system containers as type: `system`

### DIFF
--- a/Atomic/images.py
+++ b/Atomic/images.py
@@ -146,7 +146,7 @@ class Images(Atomic):
             if not image["RepoTags"]:
                 continue
             iid = image["RepoTags"][0]
-            if image["ImageType"] == "System":
+            if image["ImageType"] == "system":
                 continue
             if iid == "<none>:<none>" or iid == "<none>":
                 continue

--- a/Atomic/ps.py
+++ b/Atomic/ps.py
@@ -12,7 +12,7 @@ class Ps(Atomic):
         all_container_info = self.ps()
         all_containers = []
         for each in all_container_info:
-            if each["Type"] == "systemcontainer":
+            if each["Type"] == "system":
                 container = each["Id"]
                 status = "exited"
                 created = datetime.datetime.fromtimestamp(each["Created"])
@@ -29,7 +29,7 @@ class Ps(Atomic):
                 imageId = each['ImageID']
                 command = each["Command"]
                 created = created.strftime("%F %H:%M") # pylint: disable=no-member
-                container_info = {"type" : "systemcontainer", "container" : container,
+                container_info = {"type" : "system", "container" : container,
                               "image" : image, "command" : command, "image_id" : imageId,
                               "created" : created, "status" : status,
                               "runtime" : "runc", "vulnerable" : each["vulnerable"]}

--- a/Atomic/scan.py
+++ b/Atomic/scan.py
@@ -161,7 +161,7 @@ class Scan(Atomic):
         def gen_images():
             slist = []
             for image in self.get_images():
-                if image['ImageType'] == 'System':
+                if image['ImageType'] == 'system':
                     image['Id'] = image['RepoTags'][0]
                 image['input'] = image['Id']
                 slist.append(image)

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -522,7 +522,7 @@ class SystemContainers(object):
                 command = u' '.join(config["process"]["args"])
 
             container = {'Image' : image, 'ImageID' : revision, 'Id' : x, 'Created' : created, 'Names' : [x],
-                         'Command' : command, 'Type' : 'systemcontainer'}
+                         'Command' : command, 'Type' : 'system'}
             ret.append(container)
         return ret
 
@@ -569,9 +569,9 @@ class SystemContainers(object):
                 image_id = manifest['Digest'].replace("sha256:", "")
 
         if self.user:
-            image_type = "User"
+            image_type = "user"
         else:
-            image_type = "System"
+            image_type = "system"
 
         return {'Id' : image_id, 'ImageId' : image_id, 'RepoTags' : [tag], 'Names' : [], 'Created': timestamp,
                 'ImageType' : image_type, 'Labels' : labels, 'OSTree-rev' : commit_rev}


### PR DESCRIPTION
Currently for system containers, in `images list --json`, we have:
`"type": "System"`, and in `ps --json`, it shows up as `"type": "systemcontainer"`.

The extra `"container"` suffixing the type seems redundant, so let's
kill it, and canonicalize on lowercase, hence both cases simply become
`"system"`.

This matters because I am parsing the JSON in Ansible and consistency
is good.