### PR TITLE
[merged] syscontainers: define RUN_DIRECTORY and STATE_DIRECTORY

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -316,6 +316,14 @@ class SystemContainers(object):
         if extract_only:
             return
 
+        if self.user:
+            home = os.path.expanduser("~")
+            values["RUN_DIRECTORY"] = "/run/user/%s" % (os.getuid())
+            values["STATE_DIRECTORY"] = "%s/.data" % (home)
+        else:
+            values["RUN_DIRECTORY"] = "/run"
+            values["STATE_DIRECTORY"] = "/var/lib"
+
         # When installing a new system container, set values in this order:
         #
         # 1) What comes from manifest.json, if present, as default value.

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -318,7 +318,7 @@ class SystemContainers(object):
 
         if self.user:
             home = os.path.expanduser("~")
-            values["RUN_DIRECTORY"] = "/run/user/%s" % (os.getuid())
+            values["RUN_DIRECTORY"] = os.environ["XDG_RUNTIME_DIR"] if "XDG_RUNTIME_DIR" in os.environ else "/run/user/%s" % (os.getuid())
             values["STATE_DIRECTORY"] = "%s/.data" % (home)
         else:
             values["RUN_DIRECTORY"] = "/run"


### PR DESCRIPTION
instead of hardcoding /var/lib or /run in the config.json of the
containers, use these two variables.  They also change value when run as
not root user so to support both modes.

Differently from other defined variables, it is possible to override
these via --set.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>