### PR TITLE
[merged] Fix reference to containers/images in atomic mount help and man page

### DIFF
--- a/atomic
+++ b/atomic
@@ -395,7 +395,7 @@ def create_parser(help_text):
                             help=_("mount a running container 'live', allowing "
                                    "modification of the contents."))
     mountgroup.add_argument("--shared", dest="shared", action="store_true",
-                            help=_("mount a container 'shared'. Mounts the container with  an SELinux label "
+                            help=_("mount a container image 'shared'. Mounts the container image with  an SELinux label "
                                    "that other containers can read."))
     mountp.add_argument("image", help=_("image/container id"))
     mountp.add_argument("mountpoint", help=_("filesystem location to mount "

--- a/docs/atomic-mount.1.md
+++ b/docs/atomic-mount.1.md
@@ -37,14 +37,13 @@ default, only the 'ro' option set, and the 'rw' option is illegal and will
 cause the program to terminate.
 
 **--live**
-Mount a container live, writable, and synchronized. This option allows the user
-to modify the container's contents as it runs or update the container's
-software without rebuilding the container. If live mode is used, no mount
-options may be provided. Live mode is *not* supported on the OverlayFS docker
-storage driver.
+Mount a running container live, writable, and synchronized. This option allows
+the user to modify the container's contents as the container runs or update
+the container's software without rebuilding the container. If live mode is
+used, no mount options may be provided. Live mode is *not* supported on the OverlayFS docker storage driver.
 
 **--shared**
-Mount a container with a shared SELinux label
+Mount a container image with a shared SELinux label
 
 # HISTORY
 June 2015, Originally compiled by William Temple (wtemple at redhat dot com)


### PR DESCRIPTION
Need this to fix
https://bugzilla.redhat.com/show_bug.cgi?id=1350712