### PR TITLE
[merged] Atomic/util.py Catch/Ignore errors in tempfiles /etc/atomic.d

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -9,6 +9,7 @@ import os
 import selinux
 from .client import AtomicDocker
 from yaml import load as yaml_load
+from yaml import YAMLError
 import tempfile
 import shutil
 import re
@@ -353,7 +354,10 @@ def get_scanners():
     files = [os.path.join(ATOMIC_CONFD, x) for x in os.listdir(ATOMIC_CONFD) if os.path.isfile(os.path.join(ATOMIC_CONFD, x))]
     for f in files:
         with open(f, 'r') as conf_file:
-            temp_conf = yaml_load(conf_file)
+            try:
+                temp_conf = yaml_load(conf_file)
+            except YAMLError:
+                write_err("Error: Unable to load scannerfile %s.  Continuing..." %f)
             try:
                 if temp_conf.get('type') == "scanner":
                     scanners.append(temp_conf)


### PR DESCRIPTION
When the util.get_scanners method was run, if there was a tempfile
or swa file existent in /etc/atomic.d/, atomic scan would throw
an unhandled exception.  We now handle the exception with a try/except
and print an error message but do not fail.

This should fix bug 1346921