### PR TITLE
[merged] Change options to the agreed syntax.

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -525,13 +525,6 @@ def validate_manifest(spec, img_rootfs=None, img_tar=None, keywords=""):
         cmd += ['-k',keywords]
     return subp(cmd)
 
-def get_local_signature_path(atomic_conf):
-    # If signature path is defined, get it; else return default
-    signature_path = get_atomic_config_item(['default-sigstore-path'], atomic_config=atomic_conf)
-    if signature_path is None:
-        signature_path = ATOMIC_VAR_LIB + '/sigstore'
-    return signature_path
-
 # This is copied from the upstream python os.path.expandvars
 # Expand paths containing shell variable substitutions.
 # This expands the forms $variable and ${variable} only.

--- a/bash/atomic
+++ b/bash/atomic
@@ -581,7 +581,7 @@ _atomic_images_delete() {
 _atomic_sign() {
     local options_with_args="
 	  --sign-by
-	  -o
+	  -d --directory
     "
     local all_options="$options_with_args
 	  --help -h
@@ -590,6 +590,10 @@ _atomic_sign() {
 	local options_with_args_glob=$(__atomic_to_extglob "$options_with_args")
 
 	case "$prev" in
+		"-d"|"--directory")
+			COMPREPLY=( $( compgen -d "$cur" ) )
+			return 0
+			;;
 		$options_with_args_glob )
 			return 0
 			;;
@@ -719,17 +723,6 @@ _atomic_stop() {
 	esac
 }
 
-
-_atomic_sign() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--sign-by -o" -- "$cur" ) )
-			;;
-		*)
-			__atomic_containers_running
-			;;
-	esac
-}
 
 _atomic_host_deploy() {
 	case "$cur" in

--- a/docs/atomic-sign.1.md
+++ b/docs/atomic-sign.1.md
@@ -14,8 +14,8 @@ Only use **atomic sign** if you trust the remote registry which contains the ima
 **atomic sign**
 [**-h**|**--help**]
 
-[**-o**, **--output**]
-[**--sign_key**]
+[**-d**, **--directory**]
+[**--sign-by**]
 [ image ... ]
 
 # DESCRIPTION
@@ -28,11 +28,11 @@ default location can be defined in /etc/atomic.conf with the key **default-sigst
 **-h** **--help**
   Print usage statement.
 
-**-o** **--output**
-  Assign a specific signature file name; otherwise, the file name is generated.  
+**-d** **--directory**
+  Store the signatures in the specified directory.  Default: /var/lib/atomic/signature
  
 
-**--signed-by**
+**--sign-by**
   Override the default identity of the signature. You can define a default in /etc/atomic.conf
   with the key **default_signer**.
 
@@ -44,12 +44,11 @@ Sign the foobar image from privateregistry.example.com
     
 Sign the foobar image with a specific signature name.
 
-    atomic sign -o foobar.sig privateregistry.example.com
+    atomic sign -d /tmp/signatures privateregistry.example.com
 
 Sign the busybox image with the identify of foo@bar.com
 
-    atomic sign --signed-by foo@bar.com privateregistry.example.com
-
+    atomic --sign-by foo@bar.com privateregistry.example.com
 
 # HISTORY
 Initial revision by Brent Baude (bbaude at redhat dot com) August 2016


### PR DESCRIPTION
We agreed on using --sign-by for specifying the signer, and --directory
to specify the output directory for images.