### PR TITLE
[merged] Atomic/pull.py: Use skopeo to perform "pull" and signature verification

### DIFF
--- a/Atomic/pull.py
+++ b/Atomic/pull.py
@@ -1,16 +1,33 @@
-from .syscontainers import SystemContainers
+try:
+    from . import Atomic
+except ImportError:
+    from atomic import Atomic  # pylint: disable=relative-import
+from .util import skopeo_copy, get_atomic_config, skopeo_inspect, decompose
+
+ATOMIC_CONFIG = get_atomic_config()
+
 
 def cli(subparser):
     # atomic pull
+    backend = ATOMIC_CONFIG.get('default_storage', "ostree")
     pullp = subparser.add_parser("pull", help=_("pull latest image from a repository"),
                                  epilog="pull the latest specified image from a repository.")
     pullp.set_defaults(_class=Pull, func='pull_image')
-    pullp.add_argument("--storage", dest="backend", help=_("Specify the storage."))
+    pullp.add_argument("--storage", dest="backend", default=backend,
+                       help=_("Specify the storage. Default is currently '%s'.  You can"
+                              "change the default by editing /etc/atomic.conf and changing"
+                              "the 'default_storage' field." % backend))
     pullp.add_argument("image", help=_("image id"))
 
-class Pull(SystemContainers):
-    def __init__(self):
-        super(Pull, self).__init__()
 
+class Pull(Atomic):
     def pull_image(self):
-        super(Pull, self).pull_image()
+        if self.args.backend == 'ostree':
+            return self.syscontainers.pull_image()
+        _, _, tag = decompose(self.args.image)
+        # If no tag is given, we assume "latest"
+        tag = tag if tag != "" else "latest"
+        fq_name = skopeo_inspect("docker://{}".format(self.args.image))['Name']
+        image = "docker-daemon:{}:{}".format(fq_name, tag)
+        skopeo_copy("docker://{}".format(self.args.image), image)
+

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -322,23 +322,27 @@ def skopeo_layers(image, args=None, layers=None):
             shutil.rmtree(temp_dir)
     return temp_dir
 
-def skopeo_standalone_sign(image, manifest_file_name, fingerprint, signature_path):
-    cmd = ['skopeo', 'standalone-sign', manifest_file_name,
-                       image, fingerprint, "-o", signature_path]
+def skopeo_subprocess(cmd):
     try:
         results = subp(cmd)
     except Exception as e: # pylint: disable=broad-except
         raise ValueError(e)
     if results.return_code is not 0:
         raise ValueError(results.stderr)
+    return results
+
+def skopeo_standalone_sign(image, manifest_file_name, fingerprint, signature_path):
+    cmd = ['skopeo', 'standalone-sign', manifest_file_name,
+                       image, fingerprint, "-o", signature_path]
+    return skopeo_subprocess(cmd)
 
 def skopeo_manifest_digest(manifest_file):
     cmd = ['skopeo', 'manifest-digest', manifest_file]
-    try:
-        results = subp(cmd)
-    except Exception: #pylint: disable=broad-except
-        raise ValueError(results.stderr)
-    return results.stdout.rstrip().decode()
+    return skopeo_subprocess(cmd).stdout.rstrip().decode()
+
+def skopeo_copy(source, destination):
+    cmd = ['skopeo', 'copy', source, destination]
+    return skopeo_subprocess(cmd)
 
 def check_v1_registry(image):
     # Skopeo cannot interact with a v1 registry


### PR DESCRIPTION
There is no change to a pull where --storage is ostree.  But for docker,
we now use skopeo copy to "pull" and image from a registry and verify
its signature (should the policy require it).

When docker is the destination for skopeo copy, it requires a tag.  If
no tag is given by the user, we inject "latest".