### PR TITLE
[merged] syscontainers: add error message to pull --storage=ostree

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -130,6 +130,8 @@ class SystemContainers(object):
             pass
 
     def _pull_image_to_ostree(self, repo, image, upgrade):
+        if not repo:
+            raise ValueError("Cannot find a configured OSTree repo")
         if image.startswith("ostree:"):
             self._check_system_ostree_image(repo, image, upgrade)
         elif self.args.image.startswith("docker:"):


### PR DESCRIPTION
It prints an user friendly message when OSTree is not installed.

Closes: https://github.com/projectatomic/atomic/issues/587

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>