### PR TITLE
[merged] Atomic/sign.py: Add tag to signing image

### DIFF
--- a/Atomic/pull.py
+++ b/Atomic/pull.py
@@ -29,5 +29,5 @@ class Pull(Atomic):
         tag = tag if tag != "" else "latest"
         fq_name = skopeo_inspect("docker://{}".format(self.args.image))['Name']
         image = "docker-daemon:{}:{}".format(fq_name, tag)
-        skopeo_copy("docker://{}".format(self.args.image), image)
+        skopeo_copy("docker://{}".format(self.args.image), image, debug=self.args.debug)
 

--- a/Atomic/sign.py
+++ b/Atomic/sign.py
@@ -47,7 +47,8 @@ class Sign(Atomic):
                 manifest_file.write(manifest)
                 manifest_file.close()
                 manifest_hash = str(util.skopeo_manifest_digest(manifest_file.name))
-
+                _, _, tag = util.decompose(sign_image)
+                tag = ":{}".format(tag) if tag != "" else ":latest"
                 expanded_image_name = str(remote_inspect_info['Name'])
                 sigstore_path = "{}/{}/{}@{}".format(self.args.signature_path, os.path.dirname(expanded_image_name),
                                                      os.path.basename(expanded_image_name), manifest_hash)
@@ -58,7 +59,7 @@ class Sign(Atomic):
                     raise ValueError("The signature {} already exists.  If you wish to "
                                      "overwrite it, please delete this file first")
 
-                util.skopeo_standalone_sign(expanded_image_name, manifest_file.name,
+                util.skopeo_standalone_sign(expanded_image_name + tag, manifest_file.name,
                                             self.get_fingerprint(signer), fq_sig_path)
                 util.write_out("Created: {}".format(fq_sig_path))
 

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -331,17 +331,29 @@ def skopeo_subprocess(cmd):
         raise ValueError(results.stderr)
     return results
 
-def skopeo_standalone_sign(image, manifest_file_name, fingerprint, signature_path):
-    cmd = ['skopeo', 'standalone-sign', manifest_file_name,
-                       image, fingerprint, "-o", signature_path]
+def skopeo_standalone_sign(image, manifest_file_name, fingerprint, signature_path, debug=False):
+    cmd = ['skopeo']
+    if debug:
+        cmd = cmd + ['--debug']
+    cmd = cmd + ['standalone-sign', manifest_file_name, image,
+                 fingerprint, "-o", signature_path]
     return skopeo_subprocess(cmd)
 
-def skopeo_manifest_digest(manifest_file):
-    cmd = ['skopeo', 'manifest-digest', manifest_file]
+def skopeo_manifest_digest(manifest_file, debug=False):
+    cmd = ['skopeo']
+    if debug:
+        cmd = cmd + ['--debug']
+    cmd = cmd  + ['manifest-digest', manifest_file]
     return skopeo_subprocess(cmd).stdout.rstrip().decode()
 
-def skopeo_copy(source, destination):
-    cmd = ['skopeo', 'copy', source, destination]
+def skopeo_copy(source, destination, debug=False):
+    cmd = ['skopeo']
+    if debug:
+        cmd = cmd + ['--debug']
+    cmd = cmd + ['copy']
+    if destination.startswith("docker-daemon"):
+        cmd = cmd + ['--remove-signatures']
+    cmd = cmd + [source, destination]
     return skopeo_subprocess(cmd)
 
 def check_v1_registry(image):


### PR DESCRIPTION
Skopeo discards the tag when expanding the docker image
name.  We need the tag included when doing the verification,
so use util.decompose to derive the tag from the input name
and be sure to add it.

Also added some simple debug extensions to be able to see
what skopeo is doing when --debug is provided.