### PR TITLE
Signing bootstrap workflow

### DIFF
--- a/Atomic/pull.py
+++ b/Atomic/pull.py
@@ -29,7 +29,8 @@ class Pull(Atomic):
         fq_name = skopeo_inspect("docker://{}".format(self.args.image))['Name']
         image = "docker-daemon:{}:{}".format(fq_name, tag)
         trust = Trust()
-        trust.discover_sigstore(fq_name, confirm=self.args.assumeyes)
+        trust.args.assumeyes=self.args.assumeyes
+        trust.discover_sigstore(fq_name)
         skopeo_copy("docker://{}".format(self.args.image), image, debug=self.args.debug)
 
     def pull_image(self):

--- a/Atomic/pull.py
+++ b/Atomic/pull.py
@@ -2,7 +2,8 @@ try:
     from . import Atomic
 except ImportError:
     from atomic import Atomic  # pylint: disable=relative-import
-from .util import skopeo_copy, get_atomic_config, get_atomic_config_item, skopeo_inspect, decompose, write_out, write_registry_config, install_pubkey, update_trust_policy
+from .util import skopeo_copy, get_atomic_config, skopeo_inspect, decompose, write_out
+from .trust import Trust
 
 ATOMIC_CONFIG = get_atomic_config()
 
@@ -27,9 +28,8 @@ class Pull(Atomic):
         tag = tag if tag != "" else "latest"
         fq_name = skopeo_inspect("docker://{}".format(self.args.image))['Name']
         image = "docker-daemon:{}:{}".format(fq_name, tag)
-        if get_atomic_config_item(['discover_sigstores'], get_atomic_config()):
-            if not self.discover_sigstore():
-                write_out("There was a problem configuring the trust policy")
+        trust = Trust()
+        trust.discover_sigstore(fq_name, confirm=self.args.assumeyes)
         skopeo_copy("docker://{}".format(self.args.image), image, debug=self.args.debug)
 
     def pull_image(self):
@@ -43,73 +43,4 @@ class Pull(Atomic):
             raise ValueError("Destination not known, please choose --storage=%s" % "|".join(handlers.keys()))
         write_out("Image %s is being pulled to %s ..." % (self.args.image, self.args.backend))
         handler()
-
-    def discover_sigstore(self):
-        """
-        Check for registry/repo/sigstore metadata image
-        prompt user for trust on first use workflow
-        :return: True if sigstore discovered and configured
-        """
-        (registry, repo, _) = decompose(self.args.image)
-        # FIXME: this should be handled in util.decompose
-        _repo, _image = repo.split('/')
-        # TODO: check local /etc/containers/registries.d config here
-        repo_sigstore_labels = self._get_sigstore_image_metadata(registry, _repo)
-        if self._validate_sigstore_labels(repo_sigstore_labels):
-            if self._prompt_trust(repo_sigstore_labels):
-                discover_config = False
-                trust_scope = "%s/%s" % (registry, _repo)
-                discover_config = write_registry_config(trust_scope)
-                pubkey_path = install_pubkey(repo_sigstore_labels['pubkey-id'], repo_sigstore_labels['pubkey-url'])
-                discover_config = update_trust_policy(trust_scope, pubkey_path, repo_sigstore_labels['sigstore-url'])
-                return discover_config
-        return False
-
-    def _get_sigstore_image_metadata(self, registry, repo):
-        """
-        Get sigstore metadata image
-        :param registry: registry string
-        :param repo: repo string
-        :return True on success
-        """
-        _img = get_atomic_config_item(['sigstore_metadata_image'], get_atomic_config())
-        sigstoreimage = '/'.join([registry, repo, _img])
-        data = skopeo_inspect("docker://" + sigstoreimage, args=None, fail_silent=True)
-        if data:
-            write_out("Found registry sigstore metadata image %s" % sigstoreimage)
-            return data['Labels']
-        else:
-            return False
-
-    def _validate_sigstore_labels(self, labels):
-        """
-        Validate sigstore metadata.
-        If there's a missing key or something we don't want to perform any automatic trust policy configuration
-        :param labels: unvalidated labels. Should be either dict or False
-        :return: True if labels are valid
-        """
-        valid = False
-        if labels:
-            expected_keys = ["pubkey-id", "pubkey-fingerprint", "pubkey-url", "sigstore-url", "sigstore-type"]
-            for k in expected_keys:
-                valid = k in labels
-        return valid
-
-    def _prompt_trust(self, labels):
-        """
-        Prompt user for trust on first use workflow
-        :param labels: dict of metadata labels defining sigstore trust
-        :return: True if user accepts
-        """
-        write_out("ID: " + labels['pubkey-id'])
-        write_out("Fingerprint: " + labels['pubkey-fingerprint'])
-        write_out("Public key download URL: %s" % labels['pubkey-url'])
-        confirm = None
-        if self.args.assumeyes:
-            confirm = "yes"
-        else:
-            confirm = util.input("Do you want to add trust policy for this registry? (y/N)")
-        if not "y" in confirm.lower():
-            return False
-        return True
 

--- a/Atomic/pull.py
+++ b/Atomic/pull.py
@@ -2,7 +2,7 @@ try:
     from . import Atomic
 except ImportError:
     from atomic import Atomic  # pylint: disable=relative-import
-from .util import skopeo_copy, get_atomic_config, skopeo_inspect, decompose, write_out
+from .util import skopeo_copy, get_atomic_config, get_atomic_config_item, skopeo_inspect, decompose, write_out, write_registry_config, install_pubkey, update_trust_policy
 
 ATOMIC_CONFIG = get_atomic_config()
 
@@ -27,6 +27,9 @@ class Pull(Atomic):
         tag = tag if tag != "" else "latest"
         fq_name = skopeo_inspect("docker://{}".format(self.args.image))['Name']
         image = "docker-daemon:{}:{}".format(fq_name, tag)
+        if get_atomic_config_item(['discover_sigstores'], get_atomic_config()):
+            if not self.discover_sigstore():
+                write_out("There was a problem configuring the trust policy")
         skopeo_copy("docker://{}".format(self.args.image), image, debug=self.args.debug)
 
     def pull_image(self):
@@ -40,4 +43,73 @@ class Pull(Atomic):
             raise ValueError("Destination not known, please choose --storage=%s" % "|".join(handlers.keys()))
         write_out("Image %s is being pulled to %s ..." % (self.args.image, self.args.backend))
         handler()
+
+    def discover_sigstore(self):
+        """
+        Check for registry/repo/sigstore metadata image
+        prompt user for trust on first use workflow
+        :return: True if sigstore discovered and configured
+        """
+        (registry, repo, _) = decompose(self.args.image)
+        # FIXME: this should be handled in util.decompose
+        _repo, _image = repo.split('/')
+        # TODO: check local /etc/containers/registries.d config here
+        repo_sigstore_labels = self._get_sigstore_image_metadata(registry, _repo)
+        if self._validate_sigstore_labels(repo_sigstore_labels):
+            if self._prompt_trust(repo_sigstore_labels):
+                discover_config = False
+                trust_scope = "%s/%s" % (registry, _repo)
+                discover_config = write_registry_config(trust_scope)
+                pubkey_path = install_pubkey(repo_sigstore_labels['pubkey-id'], repo_sigstore_labels['pubkey-url'])
+                discover_config = update_trust_policy(trust_scope, pubkey_path, repo_sigstore_labels['sigstore-url'])
+                return discover_config
+        return False
+
+    def _get_sigstore_image_metadata(self, registry, repo):
+        """
+        Get sigstore metadata image
+        :param registry: registry string
+        :param repo: repo string
+        :return True on success
+        """
+        _img = get_atomic_config_item(['sigstore_metadata_image'], get_atomic_config())
+        sigstoreimage = '/'.join([registry, repo, _img])
+        data = skopeo_inspect("docker://" + sigstoreimage, args=None, fail_silent=True)
+        if data:
+            write_out("Found registry sigstore metadata image %s" % sigstoreimage)
+            return data['Labels']
+        else:
+            return False
+
+    def _validate_sigstore_labels(self, labels):
+        """
+        Validate sigstore metadata.
+        If there's a missing key or something we don't want to perform any automatic trust policy configuration
+        :param labels: unvalidated labels. Should be either dict or False
+        :return: True if labels are valid
+        """
+        valid = False
+        if labels:
+            expected_keys = ["pubkey-id", "pubkey-fingerprint", "pubkey-url", "sigstore-url"]
+            for k in expected_keys:
+                valid = k in labels
+        return valid
+
+    def _prompt_trust(self, labels):
+        """
+        Prompt user for trust on first use workflow
+        :param labels: dict of metadata labels defining sigstore trust
+        :return: True if user accepts
+        """
+        write_out("ID: " + labels['pubkey-id'])
+        write_out("Fingerprint: " + labels['pubkey-fingerprint'])
+        write_out("Public key download URL: %s" % labels['pubkey-url'])
+        confirm = None
+        if self.args.assumeyes:
+            confirm = "yes"
+        else:
+            confirm = util.input("Do you want to add trust policy for this registry? (y/N)")
+        if not "y" in confirm.lower():
+            return False
+        return True
 

--- a/Atomic/pull.py
+++ b/Atomic/pull.py
@@ -90,7 +90,7 @@ class Pull(Atomic):
         """
         valid = False
         if labels:
-            expected_keys = ["pubkey-id", "pubkey-fingerprint", "pubkey-url", "sigstore-url"]
+            expected_keys = ["pubkey-id", "pubkey-fingerprint", "pubkey-url", "sigstore-url", "sigstore-type"]
             for k in expected_keys:
                 valid = k in labels
         return valid

--- a/Atomic/trust.py
+++ b/Atomic/trust.py
@@ -4,6 +4,7 @@ import os
 import argparse
 import json
 import yaml
+import requests
 
 def cli(subparser):
     # atomic trust
@@ -16,9 +17,9 @@ def cli(subparser):
                                          "that must be signed by public keys.")
     commonp = argparse.ArgumentParser(add_help=False)
     registry_help="""Registry to manage trust policy for, REGISTRY[/REPOSITORY].
-                          Trust policy allows for nested scope.
-                          Example: registry.example.com defines trust for entire registry.
-                          Example: registry.example.com/acme defines trust for specific repository."""
+                     Trust policy allows for nested scope.
+                     Example: registry.example.com defines trust for entire registry.
+                     Example: registry.example.com/acme defines trust for specific repository."""
     sigstore_help="""Signature server type (default: web)
                      local: local file 
                      web: remote web server 
@@ -51,7 +52,7 @@ def cli(subparser):
                                  help="Modify default trust policy")
     defaultp.add_argument("default_policy", choices=["reject", "accept"],
                                  help="Default policy action")
-    defaultp.set_defaults(_class=Trust, func="default")
+    defaultp.set_defaults(_class=Trust, func="modify_default")
     deletep = subparsers.add_parser("delete",
                                     help="Delete a trust policy for a registry")
     deletep.add_argument("registry",
@@ -70,10 +71,28 @@ class Trust(Atomic):
         self.policy_filename = policy_filename
         self.atomic_config = util.get_atomic_config()
 
-    def add(self):
+    def add(self, registry=None, pubkeys=None, sigstore=None, sigstoretype=None, keytype=None, trust_type=None, confirm=None):
         """
-        Add or prompt to modify policy.json file and registries.d registry configuration
+        Add trust to policy.json file and optionally update registries.d registry configuration
+        :param sigstoretype: string, human-readable sigstore type, one of "atomic", "web", "local"
+        :param registry: the registry[/repo] to add policy for
+        :param pubkeys: list of pubkeys to add with trust_type "signedBy"
+        :param keytype: string, "GPGKeys"
+        :param trust_type: string, one of "signedBy", "insecureAcceptAnything", "reject"
+        :param sigstore: string, URL of signature server
         """
+        if registry is None:
+            registry=self.args.registry
+        if pubkeys is None:
+            pubkeys=self.args.pubkeys
+        if sigstoretype is None:
+            sigstoretype=self.args.sigstoretype
+        if keytype is None:
+            keytype=self.args.keytype
+        if trust_type is None:
+            trust_type=self.args.trust_type
+        if sigstore is None:
+            sigstore=self.args.sigstore
         sstype = self.get_sigstore_type_map(self.args.sigstoretype)
 
         mode = "r+" if os.path.exists(self.policy_filename) else "w+"
@@ -90,39 +109,52 @@ class Trust(Atomic):
                 policy={"transports":{sstype:{}}}
 
             payload = []
-            for k in self.args.pubkeys:
+            for k in pubkeys:
                 if not os.path.exists(k):
                     raise ValueError("The public key file %s was not found. This file must exist to proceed." % k)
-                payload.append({ "type": self.args.trust_type, "keyType": self.args.keytype, "keyPath": k })
-            if self.args.trust_type == "signedBy":
-                if len(self.args.pubkeys) == 0:
+                payload.append({ "type": trust_type, "keyType": keytype, "keyPath": k })
+            if trust_type == "signedBy":
+                if len(pubkeys) == 0:
                     raise ValueError("At least one public key must be defined for type 'signedBy'")
             else:
-                payload.append({ "type": self.args.trust_type })
-            policy["transports"][sstype][self.args.registry] = payload
+                payload.append({ "type": trust_type })
+            policy["transports"][sstype][registry] = payload
             policy_file.seek(0)
             json.dump(policy, policy_file, indent=4)
             policy_file.truncate()
-            if self.args.sigstore:
+            if sigstore:
                 if sstype == "atomic":
                     raise ValueError("Sigstore cannot be defined for sigstoretype 'atomic'")
                 else:
-                    self.modify_registry_config(self.args.registry, self.args.sigstore)
+                    self.modify_registry_config(registry, sigstore)
 
-    def delete(self):
-        sstype = self.get_sigstore_type_map(self.args.sigstoretype)
+    def delete(self, sigstoretype=None, registry=None):
+        """
+        Remove trust policy entry
+        :param sigstoretype: unmapped sigstore type string
+        :param registry: policy scope string
+        """
+        if not sigstoretype:
+            sigstoretype = self.args.sigstoretype
+        if not registry:
+            registry = self.args.registry
+        sstype = self.get_sigstore_type_map(sigstoretype)
         with open(self.policy_filename, 'r+') as policy_file:
             policy = json.load(policy_file)
             try:
-                del policy["transports"][sstype][self.args.registry]
+                del policy["transports"][sstype][registry]
             except KeyError:
                 raise ValueError("Could not find trust policy defined for %s transport %s" % 
-                              (self.args.sigstoretype, self.args.registry))
+                              (sigstoretype, registry))
             policy_file.seek(0)
             json.dump(policy, policy_file, indent=4)
             policy_file.truncate()
 
-    def default(self):
+<<<<<<< 1a869111587964dddadf90fc48de49010db70fb4
+    def modify_default(self):
+        """
+        Modify global trust policy default
+        """
         mode = "r+" if os.path.exists(self.policy_filename) else "w+"
         with open(self.policy_filename, mode) as policy_file:
             if mode == "r+":
@@ -136,13 +168,37 @@ class Trust(Atomic):
             json.dump(policy, policy_file, indent=4)
             policy_file.truncate()
 
-    def check_policy(self, policy):
+    def install_pubkey(self, key_name, key_url):
+        """
+        Installs remote public key to system config directory
+        :param key_name: id of key used as filename
+        :param key_url: download URI of public key
+        :return: pubkey path string or False
+        """
+        pubkeys_dir = util.get_atomic_config_item(['pubkeys_dir'], util.get_atomic_config())
+        pubkey_file = "%s/%s" % (pubkeys_dir, key_name)
+        if not os.path.exists(pubkeys_dir):
+            os.mkdir(pubkeys_dir)
+        if os.path.exists(pubkey_file):
+            util.write_out("Public key %s already installed at %s" % (key_name, pubkey_file))
+        else:
+            r = requests.get(key_url)
+            if r.status_code == 200:
+                with open(pubkey_file, 'w') as pubfile:
+                    pubfile.write(r.content)
+                util.write_out("Installed public key %s" % pubkey_file)
+            else:
+                util.write_out("WARNING: Could not download public key using URL %s." % key_url)
+                util.write_out("Download the public key manually and install as %s" % pubkey_file)
+        return pubkey_file
+
+    def check_policy(self, policy, sstype):
         """
         Prep the policy file with required data structure
         :param policy: policy data
+        :param sstype: sigstore type
         :return: modified policy
         """
-        sstype = self.get_sigstore_type_map(self.args.sigstoretype)
         if not "transports" in policy:
             policy["transports"] = {}
         if not sstype in policy["transports"]:
@@ -193,9 +249,93 @@ class Trust(Atomic):
 
     def get_sigstore_type_map(self, sigstore_type):
         """
-        Get the skopeo trust policy type for user-friendly value
+        Given the user-friendly trust type, get the skopeo value
         :param sigstore_type: one of web,local,atomic
         :return: skopeo trust policy type string
         """
-        t = { "web": "docker", "local": "dir", "atomic": "atomic" }
+        t = { "docker": "docker", "web": "docker", "local": "dir", "dir": "dir", "atomic": "atomic" }
+        if sigstore_type not in t:
+            raise ValueError("Invalid sigstore type %s" % sigstore_type)
         return t[sigstore_type]
+
+    def discover_sigstore(self, pull_image, confirm=None):
+        """
+        Check for registry/repo/sigstore metadata image
+        prompt user for trust on first use workflow
+        :param pull_image: image being pulled, used to discover matching sigstore meta image
+        :param confirm: string
+        """
+        if not util.get_atomic_config_item(['discover_sigstores'], util.get_atomic_config()):
+            return True
+        (registry, repo, _) = util.decompose(pull_image)
+        # This should be handled in util.decompose
+        repo, _ = repo.split('/')
+        registry_config_path = util.get_atomic_config_item(["registry_confdir"], self.atomic_config)
+        registry_configs, _ = util.get_registry_configs(registry_config_path)
+        sigstore_labels = False
+        scope = '/'.join([registry, repo])
+        if not scope in registry_configs:
+            sigstore_labels = self.get_sigstore_image_metadata(registry, repo)
+            if not sigstore_labels:
+                scope = registry
+                if not scope in registry_configs:
+                    sigstore_labels = self.get_sigstore_image_metadata(registry)
+        if self._validate_sigstore_labels(sigstore_labels):
+            if self.prompt_trust(sigstore_labels, confirm=confirm):
+                pubkey_path = self.install_pubkey(sigstore_labels['pubkey-id'], sigstore_labels['pubkey-url'])
+                explicit_sigstoretype = "web"
+                if sigstore_labels['sigstore-type']:
+                    explicit_sigstoretype = sigstore_labels['sigstore-type']
+                self.add(registry=scope, trust_type="signedBy", sigstoretype=explicit_sigstoretype, keytype="GPGKeys", pubkeys=[pubkey_path], sigstore=sigstore_labels['sigstore-url'])
+
+    def get_sigstore_image_metadata(self, registry, repo=None):
+        """
+        Get sigstore metadata image
+        :param registry: registry string
+        :param repo: repo string
+        :return dict of labels or False
+        """
+        _img = util.get_atomic_config_item(['sigstore_metadata_image'], util.get_atomic_config())
+        if repo:
+            sigstoreimage = '/'.join([registry, repo, _img])
+        else:
+            sigstoreimage = '/'.join([registry, _img])
+        data = util.skopeo_inspect("docker://" + sigstoreimage, args=None, quiet=True)
+        if data:
+            util.write_out("Found registry sigstore metadata image %s" % sigstoreimage)
+            return data['Labels']
+        else:
+            return False
+
+    def _validate_sigstore_labels(self, labels):
+        """
+        Validate sigstore metadata.
+        If there's a missing key or something we don't want to perform any automatic trust policy configuration
+        :param labels: unvalidated labels. Should be either dict or False
+        :return: True if labels are valid
+        """
+        is_valid = False
+        if labels:
+            # sigstore-type is optional
+            expected_keys = ["pubkey-id", "pubkey-fingerprint", "pubkey-url", "sigstore-url"]
+            for k in expected_keys:
+                is_valid = k in labels
+        return is_valid
+
+    def prompt_trust(self, labels, confirm=None):
+        """
+        Prompt user for trust on first use workflow
+        :param labels: dict of metadata labels defining sigstore trust
+        :param confirm: string or none
+        :return: True if user accepts
+        """
+        util.write_out("ID: " + labels['pubkey-id'])
+        util.write_out("Fingerprint: " + labels['pubkey-fingerprint'])
+        util.write_out("Public key download URL: %s" % labels['pubkey-url'])
+        if confirm:
+            confirm = "yes"
+        else:
+            confirm = util.input("Do you want to add trust policy for this registry? (y/N) ")
+        if not "y" in confirm.lower():
+            return False
+        return True

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -247,7 +247,7 @@ def urllib3_disable_warnings():
             if hasattr(urllib3, 'disable_warnings'):
                 urllib3.disable_warnings()
 
-def skopeo_inspect(image, args=None, return_json=True, newline=False, quiet=False):
+def skopeo_inspect(image, args=None, return_json=True, newline=False):
     if not args:
         args=[]
 
@@ -269,8 +269,6 @@ def skopeo_inspect(image, args=None, return_json=True, newline=False, quiet=Fals
     except OSError:
         raise ValueError("skopeo must be installed to perform remote inspections")
     if results.return_code is not 0:
-        if quiet:
-            return False
         raise ValueError(results)
     else:
         if return_json:

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -52,7 +52,9 @@ def check_if_python2():
 input, is_python2 = check_if_python2() # pylint: disable=redefined-builtin
 
 def decompose(compound_name):
-    # '[reg/]repo[:tag]' -> (reg, repo, tag)
+    # TODO: this doesn't behave when the registry is omitted or using hub "library" images
+    #       we should really decompose into reg, repo, image and tag components
+    # 'reg/repo/image[:tag]' -> (reg, repo, image, tag)
     reg, repo, tag = '', compound_name, ''
     if '/' in repo:
         reg, repo = repo.split('/', 1)
@@ -245,14 +247,15 @@ def urllib3_disable_warnings():
             if hasattr(urllib3, 'disable_warnings'):
                 urllib3.disable_warnings()
 
-def skopeo_inspect(image, args=None, return_json=True, newline=False):
+def skopeo_inspect(image, args=None, return_json=True, newline=False, quiet=False):
     if not args:
         args=[]
 
     # Performs remote inspection of an image on a registry
     # :param image: fully qualified name
     # :param args: additional parameters to pass to Skopeo
-    # :return: Returns json formatted data
+    # :param fail_silent: return false if failed
+    # :return: Returns json formatted data or false
 
     # Adding in --verify-tls=false to deal with the change in skopeo
     # policy. The prior inspections were also false.  We need to define
@@ -266,6 +269,8 @@ def skopeo_inspect(image, args=None, return_json=True, newline=False):
     except OSError:
         raise ValueError("skopeo must be installed to perform remote inspections")
     if results.return_code is not 0:
+        if quiet:
+            return False
         raise ValueError(results)
     else:
         if return_json:
@@ -367,6 +372,53 @@ def get_atomic_config(atomic_config=None):
         raise ValueError("{} does not exist".format(atomic_config))
     with open(atomic_config, 'r') as conf_file:
         return yaml_load(conf_file)
+
+def write_registry_config(scope):
+    """
+    Write registry sigstore configuration file
+    :param scope: registry string
+    :return: True on success
+    """
+    # FIXME: pending agreement on registry sigstore layout
+    registry_dir = get_atomic_config_item(['registry_sigstore_dir'], get_atomic_config())
+    write_out("TODO: Writing trust config for %s to %s" % (scope, registry_dir))
+    return False
+
+def install_pubkey(key_name, key_url):
+    """
+    Installs public key to system config directory
+    :param key_name: id of key used as filename
+    :param key_url: download URI of public key
+    :return: pubkey path string or False
+    """
+    pubkeys_dir = get_atomic_config_item(['pubkeys_dir'], get_atomic_config())
+    pubkey_file = "%s/%s" % (pubkeys_dir, key_name)
+    if not os.path.exists(pubkeys_dir):
+        os.mkdir(pubkeys_dir)
+    if os.path.exists(pubkey_file):
+        write_out("Public key %s already installed at %s" % (key_name, pubkey_file))
+    else:
+        r = requests.get(key_url)
+        if r.status_code == 200:
+            with open(pubkey_file, 'w') as pubfile:
+                pubfile.write(r.content)
+            write_out("Installed public key %s" % pubkey_file)
+        else:
+            write_out("WARNING: Could not download public key using URL %s." % key_url)
+            write_out("Download the public key manually and install as %s" % pubkey_file)
+    return pubkey_file
+
+def update_trust_policy(trust_scope, pubkey_path, sigstore_url):
+    """
+    Add trust policy for the specified registry scope
+    :param trust_scope: registry/repository scope
+    :param pubkey_path: absolute public key path
+    :param sigstore_url: url of sigstore
+    :return: True if success
+    """
+    # FIXME: pending feedback on manage policy
+    write_out("TODO: Adding trust policy: %s %s %s" % (trust_scope, pubkey_path, sigstore_url))
+    return False
 
 def add_opt(sub):
     sub.add_argument("--opt1", dest="opt1",help=argparse.SUPPRESS)

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -52,7 +52,7 @@ def check_if_python2():
 input, is_python2 = check_if_python2() # pylint: disable=redefined-builtin
 
 def decompose(compound_name):
-    # TODO: this doesn't behave when the registry is omitted or using hub "library" images
+    # this doesn't behave when the registry is omitted or using hub "library" images
     #       we should really decompose into reg, repo, image and tag components
     # 'reg/repo/image[:tag]' -> (reg, repo, image, tag)
     reg, repo, tag = '', compound_name, ''
@@ -372,53 +372,6 @@ def get_atomic_config(atomic_config=None):
         raise ValueError("{} does not exist".format(atomic_config))
     with open(atomic_config, 'r') as conf_file:
         return yaml_load(conf_file)
-
-def write_registry_config(scope):
-    """
-    Write registry sigstore configuration file
-    :param scope: registry string
-    :return: True on success
-    """
-    # FIXME: pending agreement on registry sigstore layout
-    registry_dir = get_atomic_config_item(['registry_sigstore_dir'], get_atomic_config())
-    write_out("TODO: Writing trust config for %s to %s" % (scope, registry_dir))
-    return False
-
-def install_pubkey(key_name, key_url):
-    """
-    Installs public key to system config directory
-    :param key_name: id of key used as filename
-    :param key_url: download URI of public key
-    :return: pubkey path string or False
-    """
-    pubkeys_dir = get_atomic_config_item(['pubkeys_dir'], get_atomic_config())
-    pubkey_file = "%s/%s" % (pubkeys_dir, key_name)
-    if not os.path.exists(pubkeys_dir):
-        os.mkdir(pubkeys_dir)
-    if os.path.exists(pubkey_file):
-        write_out("Public key %s already installed at %s" % (key_name, pubkey_file))
-    else:
-        r = requests.get(key_url)
-        if r.status_code == 200:
-            with open(pubkey_file, 'w') as pubfile:
-                pubfile.write(r.content)
-            write_out("Installed public key %s" % pubkey_file)
-        else:
-            write_out("WARNING: Could not download public key using URL %s." % key_url)
-            write_out("Download the public key manually and install as %s" % pubkey_file)
-    return pubkey_file
-
-def update_trust_policy(trust_scope, pubkey_path, sigstore_url):
-    """
-    Add trust policy for the specified registry scope
-    :param trust_scope: registry/repository scope
-    :param pubkey_path: absolute public key path
-    :param sigstore_url: url of sigstore
-    :return: True if success
-    """
-    # FIXME: pending feedback on manage policy
-    write_out("TODO: Adding trust policy: %s %s %s" % (trust_scope, pubkey_path, sigstore_url))
-    return False
 
 def add_opt(sub):
     sub.add_argument("--opt1", dest="opt1",help=argparse.SUPPRESS)

--- a/atomic.conf
+++ b/atomic.conf
@@ -3,6 +3,9 @@
 default_scanner:
 default_docker: docker
 registry_confdir: /etc/containers/registries.d/
+discover_sigstores: true
+sigstore_metadata_image: sigstore
+pubkeys_dir: /etc/pki/containers
 
 
 # Default storage backend [ostree, docker]

--- a/tests/unit/test_trust.py
+++ b/tests/unit/test_trust.py
@@ -26,6 +26,10 @@ class TestAtomicTrust(unittest.TestCase):
         testobj = Trust()
         self.assertEqual(testobj.get_sigstore_type_map("web"), "docker")
 
+    def test_sigstoretype_map_local(self):
+        testobj = Trust()
+        self.assertEqual(testobj.get_sigstore_type_map("local"), "dir")
+
     def test_setup_default_policy(self):
         args = self.Args()
         args.sigstoretype = "web"
@@ -33,7 +37,7 @@ class TestAtomicTrust(unittest.TestCase):
         testobj.set_args(args)
         with open(os.path.join(FIXTURE_DIR, "default_policy.json"), 'r') as default:
             policy_default = json.load(default)
-        policy_default = testobj.check_policy(policy_default)
+        policy_default = testobj.check_policy(policy_default, "docker")
         policy_expected = {"default": [{"type": "insecureAcceptAnything" }], "transports": {"docker": {}}}
         self.assertEqual(policy_default, policy_expected)
 
@@ -74,7 +78,7 @@ class TestAtomicTrust(unittest.TestCase):
         testobj = Trust(policy_filename = os.path.join(FIXTURE_DIR, "etc/containers/policy.json"))
         testobj.atomic_config = util.get_atomic_config(atomic_config = os.path.join(FIXTURE_DIR, "atomic.conf"))
         testobj.set_args(args)
-        testobj.add()
+        testobj.add(confirm="y")
         with open(testobj.policy_filename, 'r') as f:
             d = json.load(f)
             self.assertEqual(d["transports"]["atomic"]["docker.io"][0]["keyPath"], 
@@ -87,7 +91,7 @@ class TestAtomicTrust(unittest.TestCase):
         testobj = Trust(policy_filename = os.path.join(FIXTURE_DIR, "etc/containers/policy.json"))
         testobj.atomic_config = util.get_atomic_config(atomic_config = os.path.join(FIXTURE_DIR, "atomic.conf"))
         testobj.set_args(args)
-        testobj.add()
+        testobj.add(confirm="y")
         with open(testobj.policy_filename, 'r') as f:
             d = json.load(f)
             self.assertEqual(d["transports"]["atomic"]["docker.io"][1]["keyPath"], 

--- a/tests/unit/test_trust.py
+++ b/tests/unit/test_trust.py
@@ -78,7 +78,7 @@ class TestAtomicTrust(unittest.TestCase):
         testobj = Trust(policy_filename = os.path.join(FIXTURE_DIR, "etc/containers/policy.json"))
         testobj.atomic_config = util.get_atomic_config(atomic_config = os.path.join(FIXTURE_DIR, "atomic.conf"))
         testobj.set_args(args)
-        testobj.add(confirm="y")
+        testobj.add()
         with open(testobj.policy_filename, 'r') as f:
             d = json.load(f)
             self.assertEqual(d["transports"]["atomic"]["docker.io"][0]["keyPath"], 
@@ -91,7 +91,7 @@ class TestAtomicTrust(unittest.TestCase):
         testobj = Trust(policy_filename = os.path.join(FIXTURE_DIR, "etc/containers/policy.json"))
         testobj.atomic_config = util.get_atomic_config(atomic_config = os.path.join(FIXTURE_DIR, "atomic.conf"))
         testobj.set_args(args)
-        testobj.add(confirm="y")
+        testobj.add()
         with open(testobj.policy_filename, 'r') as f:
             d = json.load(f)
             self.assertEqual(d["transports"]["atomic"]["docker.io"][1]["keyPath"], 


### PR DESCRIPTION
Provide mechanism for automated sigstore discovery.

- [x] implement sigstore config (~~pending #594~~) 
- [x] implement drop in trust policy (~~pending #604~~)
- [ ] ~~add integration tests~~

Example output:
```
$ sudo atomic pull --storage docker docker.io/aweiteka/hello-world
Found registry sigstore metadata image docker.io/aweiteka/sigstore
ID: aweiteka@gmail.com
Fingerprint: B3B04F8CF186436EF8F1CDAD7C6ACC9EE3A31016
Public key download URL: https://pgp.mit.edu/pks/lookup?op=get&search=0xFD5EB4DB480717ED
Do you want to add trust policy for this registry? (y/N) y
TODO: Writing trust config for docker.io/aweiteka to /etc/containers/registries.d
Public key aweiteka@gmail.com already installed at /etc/pki/containers/aweiteka@gmail.com
TODO: Adding trust policy: docker.io/aweiteka /etc/pki/containers/aweiteka@gmail.com sigstore.example.com:8443
There was a problem configuring the trust policy
```