### PR TITLE
[merged] Atomic.pull: add lost whitespace in help document

### DIFF
--- a/Atomic/pull.py
+++ b/Atomic/pull.py
@@ -15,8 +15,8 @@ def cli(subparser):
     pullp.set_defaults(_class=Pull, func='pull_image')
     pullp.add_argument("--storage", dest="backend", default=backend,
                        help=_("Specify the storage. Default is currently '%s'.  You can"
-                              "change the default by editing /etc/atomic.conf and changing"
-                              "the 'default_storage' field." % backend))
+                              " change the default by editing /etc/atomic.conf and changing"
+                              " the 'default_storage' field." % backend))
     pullp.add_argument("image", help=_("image id"))
 
 


### PR DESCRIPTION
The whitespace is lost in atomic pull help docs, it looks like this:

$ atomic pull -h
usage: atomic pull [-h] [--storage BACKEND] image

positional arguments:
  image              image id

optional arguments:
  -h, --help         show this help message and exit
  --storage BACKEND  Specify the storage. Default is currently 'ostree'. You
                     **canchange** the default by editing /etc/atomic.conf and
                     **changingthe** 'default_storage' field.

pull the latest specified image from a repository.


Signed-off-by: Alex Jia <ajia@redhat.com>