### PR TITLE
[merged] Atomic/sign.py|util.py Support sigstore from conf files

### DIFF
--- a/Atomic/sign.py
+++ b/Atomic/sign.py
@@ -11,10 +11,6 @@ ATOMIC_CONFIG = util.get_atomic_config()
 def cli(subparser):
     # atomic sign
     signer = ATOMIC_CONFIG.get('default_signer', None)
-    signature_path = util.get_atomic_config_item(['default-sigstore-path'], atomic_config=ATOMIC_CONFIG)
-    if signature_path is None:
-        signature_path = util.ATOMIC_VAR_LIB + '/sigstore'
-
     signp = subparser.add_parser("sign",
                                  help="Sign an image",
                                  epilog="Create a signature for an image which can be "
@@ -25,19 +21,19 @@ def cli(subparser):
                        help=_("Name of the signing key. Currently %s, "
                               "default can be defined in /etc/atomic.conf" % signer))
     signp.add_argument("-d", "--directory",
-                       default=signature_path,
+                       default=None,
                        dest="signature_path",
-                       help=_("The directory to store signatures under: Default {}.".format(signature_path) ))
+                       help=_("Define an alternate directory to store signatures"))
 
 class Sign(Atomic):
     def sign(self):
-        # TODO
-        # Atomic is run as sudo. Should we work around that?
 
         if self.args.debug:
             util.write_out(str(self.args))
 
         signer = self.args.sign_by
+        registry_config_path = util.get_atomic_config_item(["registry_confdir"], ATOMIC_CONFIG)
+        registry_configs, default_store = util.get_registry_configs(registry_config_path)
 
         for sign_image in self.args.images:
             remote_inspect_info = util.skopeo_inspect("docker://{}".format(sign_image))
@@ -50,14 +46,43 @@ class Sign(Atomic):
                 _, _, tag = util.decompose(sign_image)
                 tag = ":{}".format(tag) if tag != "" else ":latest"
                 expanded_image_name = str(remote_inspect_info['Name'])
-                sigstore_path = "{}/{}/{}@{}".format(self.args.signature_path, os.path.dirname(expanded_image_name),
-                                                     os.path.basename(expanded_image_name), manifest_hash)
-                self.make_sig_dirs(sigstore_path)
-                sig_name = self.get_sig_name(sigstore_path)
-                fq_sig_path = os.path.join(sigstore_path, sig_name)
-                if os.path.exists(fq_sig_path):
-                    raise ValueError("The signature {} already exists.  If you wish to "
-                                     "overwrite it, please delete this file first")
+
+                if self.args.signature_path:
+                    if not os.path.exists(self.args.signature_path):
+                        raise ValueError("The path {} does not exist".format(self.args.signature_path))
+                    fq_sig_path = os.path.join(self.args.signature_path,
+                                               self.get_sig_name(self.args.signature_path))
+
+                else:
+                    reg, repo, _ = util.decompose(expanded_image_name)
+                    reg_info = util.have_match_registry("{}/{}".format(reg, repo), registry_configs)
+                    if not reg_info:
+                        reg_info = default_store
+                    if not reg_info:
+                        raise ValueError("Unable to associate {} with "
+                                         "configurations in {} and no 'default-docker' "
+                                         "is defined.".format(sign_image, registry_config_path))
+                    signature_path = util.get_signature_write_path(reg_info)
+                    if signature_path is None:
+                        raise ValueError("No write path for {}/{} was "
+                                         "found in {}".format(reg, repo, registry_config_path))
+
+                    # Deal with write path prepends
+                    if signature_path.startswith("file://"):
+                        signature_path = signature_path.replace("file://", "")
+
+                        # Make sure signature path exists
+                        if not os.path.exists(signature_path):
+                            raise ValueError("The signature path {} does not exist".format(signature_path))
+
+                    sigstore_path = "{}/{}/{}@{}".format(signature_path, os.path.dirname(expanded_image_name),
+                                                         os.path.basename(expanded_image_name), manifest_hash)
+                    self.make_sig_dirs(sigstore_path)
+                    sig_name = self.get_sig_name(sigstore_path)
+                    fq_sig_path = os.path.join(sigstore_path, sig_name)
+                    if os.path.exists(fq_sig_path):
+                        raise ValueError("The signature {} already exists.  If you wish to "
+                                         "overwrite it, please delete this file first")
 
                 util.skopeo_standalone_sign(expanded_image_name + tag, manifest_file.name,
                                             self.get_fingerprint(signer), fq_sig_path)

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -10,7 +10,9 @@ import os
 import selinux
 from .client import AtomicDocker
 from yaml import load as yaml_load
+from yaml import safe_load
 from yaml import YAMLError
+from yaml.scanner import ScannerError
 import tempfile
 import shutil
 import re
@@ -589,3 +591,54 @@ def expandvars(path, environ=None):
             i = len(path)
             path += tail
     return path
+
+def get_registry_configs(yaml_dir):
+    regs = {}
+    default_store = None
+    # Get list of files that end in .yaml and are in fact files
+    for yaml_file in [os.path.join(yaml_dir, x) for x in os.listdir(yaml_dir) if x.endswith('.yaml')
+            and os.path.isfile(os.path.join(yaml_dir, x))]:
+        with open(yaml_file, 'r') as conf_file:
+            try:
+                temp_conf = safe_load(conf_file)
+                if isinstance(temp_conf, dict):
+                    def_store = temp_conf.get('default-docker', None)
+                    if def_store is not None and default_store is not None:
+                        raise ValueError("There are duplicate entries for 'default-docker' in {}.".format(yaml_dir))
+                    elif default_store is None and def_store is not None:
+                        default_store = def_store
+                    registries = temp_conf.get('docker', None)
+                else:
+                    break
+                if registries is None:
+                    break
+                for k,v in registries.items():
+                    if k not in regs:
+                        regs[k] = v
+                    else:
+                        raise ValueError("There is a duplicate entry for {} in {}".format(k, yaml_dir))
+            except ScannerError:
+                raise ValueError("{} appears to not be properly formatted YAML.".format(yaml_file))
+    return regs, default_store
+
+
+def have_match_registry(fq_name, reg_config):
+    # Returns a matching dict or None
+    search_obj = fq_name
+    for _ in fq_name.split('/'):
+        if search_obj in reg_config:
+            return reg_config[search_obj]
+        search_obj = search_obj.rsplit('/', 1)[0]
+    # If no match is found, returning nothing.
+    return None
+
+
+def get_signature_write_path(reg_info):
+    # Return the defined path for where signatures should be written
+    # or none if no entry is found
+    return reg_info.get('sigstore-write', reg_info.get('sigstore', None))
+
+def get_signature_read_path(reg_info):
+    # Return the defined path for where signatures should be read
+    # or none if no entry is found
+    return reg_info.get('sigstore', None)

--- a/atomic.conf
+++ b/atomic.conf
@@ -2,7 +2,14 @@
 
 default_scanner:
 default_docker: docker
+registry_confdir: /etc/containers/registries.d/
 
+
+# Default storage backend [ostree, docker]
 # default_storage: ostree
 # ostree_repository: /ostree/repo
 # checkout_path: /var/lib/containers/atomic
+#
+
+# Default identity for signing images
+# default_signer:

--- a/docs/atomic-sign.1.md
+++ b/docs/atomic-sign.1.md
@@ -20,9 +20,9 @@ Only use **atomic sign** if you trust the remote registry which contains the ima
 
 # DESCRIPTION
 **atomic sign** will create a local signature for one or more local images that have 
-been pulled from a registry. Unless overridden, the signature will end up in the 
-the default storage location (/var/lib/atomic/containers) for signatures.  A different
-default location can be defined in /etc/atomic.conf with the key **default-sigstore-path**.
+been pulled from a registry. By default, the signature will be written into a directory
+derived from the registry configuration files as configured by **registry_confdir**
+in /etc/atomic.conf.  
 
 # OPTIONS
 **-h** **--help**
@@ -42,7 +42,7 @@ Sign the foobar image from privateregistry.example.com
 
     atomic sign privateregistry.example.com/foobar
     
-Sign the foobar image with a specific signature name.
+Sign the foobar image and save the signature in /tmp/signatures/.
 
     atomic sign -d /tmp/signatures privateregistry.example.com
 


### PR DESCRIPTION
We now derive the proper sigstore from a series of YAML
configuration files in /etc/containers/registries.d.  These
configuration files can have: sigstore and sigstore-write as
keys and the values are a file path or http|s URL.

When signing an image, as long as the -d override is not used,
we use those values when writing local signatures.