### PR TITLE
[merged] Atomic/util.py: Add filename to registries configurations

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -584,6 +584,7 @@ def expandvars(path, environ=None):
     return path
 
 def get_registry_configs(yaml_dir):
+    # Returns a dictionary of registries and a str of the default_store if applicable
     regs = {}
     default_store = None
     # Get list of files that end in .yaml and are in fact files
@@ -606,8 +607,11 @@ def get_registry_configs(yaml_dir):
                 for k,v in registries.items():
                     if k not in regs:
                         regs[k] = v
+                        # Add filename of yaml into registry config
+                        regs[k]['filename'] = yaml_file
                     else:
                         raise ValueError("There is a duplicate entry for {} in {}".format(k, yaml_dir))
+
             except ScannerError:
                 raise ValueError("{} appears to not be properly formatted YAML.".format(yaml_file))
     return regs, default_store


### PR DESCRIPTION
Aaron's work in policy and configuration editing would be simplier
if we retained a relationship between the registry configuration
and the filename it came from.  Now we simply add a 'filename'
key into the dictionary being returned by
get_registry_configs().