### PR TITLE
[merged] For make command on Fedora 24 to pass, additional packages are needed.

### DIFF
--- a/docs/install/Fedora.md
+++ b/docs/install/Fedora.md
@@ -15,8 +15,12 @@ dnf install atomic
 On Fedora, You need to install required build dependencies
 ```
 yum-builddep atomic
+yum install -y python-requests libselinux-python python-docker-py \
+    python-dateutil python-yaml pylint python-slip-dbus python-gobject
 # or
 dnf builddep atomic
+dnf install -y python-requests libselinux-python python-docker-py \
+    python-dateutil python-yaml pylint python-slip-dbus python-gobject
 ```
 
 Optionally, to use the builddep plugin in DNF you need to install dnf-plugins-core


### PR DESCRIPTION
Addressing:

```
# make all
/usr/bin/python setup.py build
Traceback (most recent call last):
  File "setup.py", line 5, in <module>
    import Atomic as _Atomic
  File "/root/atomic/Atomic/__init__.py", line 1, in <module>
    from .pulp import PulpServer, PulpConfig
  File "/root/atomic/Atomic/pulp.py", line 8, in <module>
    import requests
ImportError: No module named requests
Makefile:34: recipe for target 'python-build' failed
make: *** [python-build] Error 1

# make all
/usr/bin/python setup.py build
Traceback (most recent call last):
  File "setup.py", line 5, in <module>
    import Atomic as _Atomic
  File "/root/atomic/Atomic/__init__.py", line 1, in <module>
    from .pulp import PulpServer, PulpConfig
  File "/root/atomic/Atomic/pulp.py", line 10, in <module>
    from . import util
  File "/root/atomic/Atomic/util.py", line 10, in <module>
    import selinux
ImportError: No module named selinux
Makefile:34: recipe for target 'python-build' failed
make: *** [python-build] Error 1

# make all
/usr/bin/python setup.py build
Traceback (most recent call last):
  File "setup.py", line 5, in <module>
    import Atomic as _Atomic
  File "/root/atomic/Atomic/__init__.py", line 1, in <module>
    from .pulp import PulpServer, PulpConfig
  File "/root/atomic/Atomic/pulp.py", line 10, in <module>
    from . import util
  File "/root/atomic/Atomic/util.py", line 11, in <module>
    from .client import AtomicDocker
  File "/root/atomic/Atomic/client.py", line 1, in <module>
    import docker
ImportError: No module named docker
Makefile:34: recipe for target 'python-build' failed
make: *** [python-build] Error 1

# make all
/usr/bin/python setup.py build
Traceback (most recent call last):
  File "setup.py", line 5, in <module>
    import Atomic as _Atomic
  File "/root/atomic/Atomic/__init__.py", line 1, in <module>
    from .pulp import PulpServer, PulpConfig
  File "/root/atomic/Atomic/pulp.py", line 10, in <module>
    from . import util
  File "/root/atomic/Atomic/util.py", line 12, in <module>
    from yaml import load as yaml_load
ImportError: No module named yaml
Makefile:34: recipe for target 'python-build' failed
make: *** [python-build] Error 1

# make all
/usr/bin/python setup.py build
Traceback (most recent call last):
  File "setup.py", line 5, in <module>
    import Atomic as _Atomic
  File "/root/atomic/Atomic/__init__.py", line 3, in <module>
    from .atomic import Atomic
  File "/root/atomic/Atomic/atomic.py", line 7, in <module>
    from .syscontainers import SystemContainers
  File "/root/atomic/Atomic/syscontainers.py", line 15, in <module>
    from dateutil.parser import parse as dateparse
ImportError: No module named dateutil.parser
Makefile:34: recipe for target 'python-build' failed

# make all
[...]
/usr/bin/go-md2man -in docs/atomic-storage.1.md -out docs/atomic-storage.1.tmp && touch docs/atomic-storage.1.tmp && mv docs/atomic-storage.1.tmp docs/atomic-storage.1
/usr/bin/python -m pylint --disable=all --enable=E --enable=W --additional-builtins=_ *.py atomic Atomic tests/unit/*.py -d=no-absolute-import,print-statement,no-absolute-import,bad-builtin
/usr/bin/python: No module named pylint
Makefile:38: recipe for target 'pylint-check' failed
make: *** [pylint-check] Error 1

# make all
/usr/bin/python setup.py build
running build
running build_py
running build_scripts
/usr/bin/python -m pylint --disable=all --enable=E --enable=W --additional-builtins=_ *.py atomic Atomic tests/unit/*.py -d=no-absolute-import,print-statement,no-absolute-import,bad-builtin
No config file found, using default configuration
************* Module atomic_client
E:  8, 0: Unable to import 'slip.dbus' (import-error)
************* Module atomic_dbus
E:  9, 0: Unable to import 'gi.repository' (import-error)
E: 10, 0: Unable to import 'slip.dbus.service' (import-error)
************* Module Atomic.mount
E: 35, 0: Unable to import 'gi.repository' (import-error)
************* Module Atomic.syscontainers
E: 21, 8: Unable to import 'gi.repository' (import-error)
[...]
Makefile:38: recipe for target 'pylint-check' failed
make: *** [pylint-check] Error 2
```