### PR TITLE
[merged] For make test on Fedora 24 to even start the tests, additional steps are needed.

### DIFF
--- a/docs/install/Fedora.md
+++ b/docs/install/Fedora.md
@@ -43,6 +43,23 @@ Your install will now be complete!
 1.8
 ```
 
+##Test
+
+To test the checked out tree, install dependencies
+```
+dnf install -y python3-pylint /usr/bin/coverage2
+```
+
+Start the docker daemon
+```
+systemctl start docker
+```
+
+Run the tests
+```
+make test
+```
+
 ##Notes
 
 Warning: Atomic no longer packages the CLI as an egg and thus upgrading from `atomic` 1.5 to 1.8 requires removing conflicting folders.


### PR DESCRIPTION
Addressing:

```
# make test
[...]
/usr/bin/python3 -m pylint --disable=all --enable=E --enable=W --additional-builtins=_ *.py atomic Atomic tests/unit/*.py -d=no-absolute-import,print-statement,no-absolute-import,bad-builtin
/usr/bin/python3: No module named pylint
Makefile:20: recipe for target 'test-python3-pylint' failed
make: *** [test-python3-pylint] Error 1

# make test
[...]
./test.sh
Pulling standard images from Docker Hub...
Cannot connect to the Docker daemon. Is the docker daemon running on this host?
Makefile:27: recipe for target 'test' failed
make: *** [test] Error 1

# make test
[...]
UNIT TESTS:
./test.sh: line 153: /usr/bin/coverage2: No such file or directory
[...]
Coverage report:
./test.sh: line 200: /usr/bin/coverage2: No such file or directory
Makefile:27: recipe for target 'test' failed
make: *** [test] Error 1
```