### PR TITLE
[merged] Atomic/sign.py: Don't fail for missing /etc/containers/registries.d w…

### DIFF
--- a/Atomic/sign.py
+++ b/Atomic/sign.py
@@ -27,6 +27,10 @@ def cli(subparser):
 
 class Sign(Atomic):
     def sign(self):
+        def no_reg_no_default_error(image, registry_path):
+            return "Unable to associate {} with configurations in {} and " \
+                   "no 'default-docker' is defined.".format(image,
+                                                            registry_path)
 
         if self.args.debug:
             util.write_out(str(self.args))
@@ -59,13 +63,12 @@ class Sign(Atomic):
 
                 else:
                     reg, repo, _ = util.decompose(expanded_image_name)
+                    if not registry_configs and not default_store:
+                        raise ValueError(no_reg_no_default_error(sign_image, registry_config_path))
                     reg_info = util.have_match_registry("{}/{}".format(reg, repo), registry_configs)
                     if not reg_info:
                         reg_info = default_store
-                    if not reg_info:
-                        raise ValueError("Unable to associate {} with "
-                                         "configurations in {} and no 'default-docker' "
-                                         "is defined.".format(sign_image, registry_config_path))
+
                     signature_path = util.get_signature_write_path(reg_info)
                     if signature_path is None:
                         raise ValueError("No write path for {}/{} was "

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -587,6 +587,8 @@ def get_registry_configs(yaml_dir):
     # Returns a dictionary of registries and a str of the default_store if applicable
     regs = {}
     default_store = None
+    if not os.path.exists(yaml_dir):
+        return None, default_store
     # Get list of files that end in .yaml and are in fact files
     for yaml_file in [os.path.join(yaml_dir, x) for x in os.listdir(yaml_dir) if x.endswith('.yaml')
             and os.path.isfile(os.path.join(yaml_dir, x))]:


### PR DESCRIPTION
…ith -d

This is a fix for bugzilla #1375654 where atomic sign -d fails because
it still tries to parse the registries.d/ YAML files.  Theoretically the
directory should always exist but this small code fix provides
a work-around.