### PR TITLE
[merged] Atomic/install.py: Only check args.setvalues if OSTREE_PRESENT

### DIFF
--- a/Atomic/install.py
+++ b/Atomic/install.py
@@ -84,7 +84,7 @@ class Install(Atomic):
             return self.syscontainers.install_user_container(self.image, self.name)
         elif self.system:
             return self.syscontainers.install_system_container(self.image, self.name)
-        elif self.args.setvalues:
+        elif OSTREE_PRESENT and self.args.setvalues:
             raise ValueError("--set is valid only when used with --system or --user")
 
         self._check_if_image_present()


### PR DESCRIPTION
Because the setvalues argument is only present when
OSTREE_PRESENT, we should only check for it when
OSTREE_PRESENT as well.  This bug is raised in
bugzilla #1374676.