### PR TITLE
[merged] Atomic.sign: fix typo

### DIFF
--- a/Atomic/sign.py
+++ b/Atomic/sign.py
@@ -29,8 +29,8 @@ class Sign(Atomic):
     def sign(self):
         def no_reg_no_default_error(image, registry_path):
             return "Unable to associate {} with configurations in {} and " \
-                   "no 'default-docker' is defined.".format(image,
-                                                            registry_path)
+                   "no 'default_store' is defined.".format(image,
+                                                           registry_path)
 
         if self.args.debug:
             util.write_out(str(self.args))


### PR DESCRIPTION
Replacing default-docker w/ default_signer in sign() of the Atomic/sign.py.

Signed-off-by: Alex Jia <ajia@redhat.com>