### PR TITLE
[merged] Atomic/sign.py: Raise error on writing signatures to http

### DIFF
--- a/Atomic/sign.py
+++ b/Atomic/sign.py
@@ -72,6 +72,9 @@ class Sign(Atomic):
                     if signature_path is None:
                         raise ValueError("No write path for {}/{} was "
                                          "found in {}".format(reg, repo, registry_config_path))
+                    elif signature_path.startswith("http"):
+                        raise ValueError("Writing to {} is not supported. Use a "
+                                         "file:///location instead.".format(signature_path))
 
                     # Deal with write path prepends
                     if signature_path.startswith("file://"):

--- a/docs/atomic-sign.1.md
+++ b/docs/atomic-sign.1.md
@@ -63,7 +63,7 @@ docker:
   privateregistry.example.com:
     sigstore: file:///var/lib/atomic/signature
 
-When signing an image preceeded with the registry name 'privateregistrt.example.com',
+When signing an image preceeded with the registry name 'privateregistry.example.com',
 the signature will be written into subdirectories of 
 /var/lib/atomic/signature/privateregistry.example.com. The use of 'sigstore' also means
 the signature will be 'read' from that same location on a pull-related function.


### PR DESCRIPTION
Atomic cannot write a signature to web(http/https) target. We
now raise an error as such.

sudo ./atomic sign docker.io/library/hello-world

Writing to http://123 is not supported. Use a file:///location instead.