### PR TITLE
[merged] [RFC] syscontainers: change ostree tag separator to '/'

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1017,7 +1017,7 @@ class SystemContainers(object):
         if "ostree:" in img:
             imagebranch = img.replace("ostree:", "")
         else: # assume "oci:" image
-            imagebranch = "%s%s" % (OSTREE_OCIIMAGE_PREFIX, SystemContainers._encode_to_ostree_ref(img))
+            imagebranch = "%s%s" % (OSTREE_OCIIMAGE_PREFIX, SystemContainers._encode_to_ostree_ref(img.replace("sha256:", "")))
         return imagebranch
 
     def has_system_container_image(self, img):

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -610,8 +610,8 @@ class SystemContainers(object):
         commit_rev = repo.resolve_rev(imagebranch, False)[1]
         commit = repo.load_commit(commit_rev)[1]
 
-        branch_id = imagebranch.replace(OSTREE_OCIIMAGE_PREFIX, "")
-        tag = ":".join(branch_id.rsplit('-', 1))
+        branch_id = SystemContainers._decode_from_ostree_ref(imagebranch.replace(OSTREE_OCIIMAGE_PREFIX, ""))
+        tag = ":".join(branch_id.rsplit(':', 1))
         timestamp = OSTree.commit_get_timestamp(commit)
         labels = {}
 
@@ -892,8 +892,8 @@ class SystemContainers(object):
                     with open(manifest_file, 'r') as mfile:
                         manifest = mfile.read()
                     for m in json.loads(manifest):
-                        _, image, tag = SystemContainers._parse_imagename(m["RepoTags"][0])
-                        imagebranch = "%s%s-%s" % (OSTREE_OCIIMAGE_PREFIX, image.replace("sha256:", ""), tag)
+                        imagename = m["RepoTags"][0]
+                        imagebranch = "%s%s" % (OSTREE_OCIIMAGE_PREFIX, SystemContainers._encode_to_ostree_ref(imagename))
                         input_layers = m["Layers"]
                         self._pull_dockertar_layers(repo, imagebranch, temp_dir, input_layers)
                 else:
@@ -901,8 +901,8 @@ class SystemContainers(object):
                     repositories_file = os.path.join(temp_dir, "repositories")
                     with open(repositories_file, 'r') as rfile:
                         repositories = rfile.read()
-                    _, image, tag = SystemContainers._parse_imagename(list(json.loads(repositories).keys())[0])
-                    imagebranch = "%s%s-%s" % (OSTREE_OCIIMAGE_PREFIX, image, tag)
+                    imagename = list(json.loads(repositories).keys())[0]
+                    imagebranch = "%s%s" % (OSTREE_OCIIMAGE_PREFIX, SystemContainers._encode_to_ostree_ref(imagename))
                     input_layers = []
                     for name in os.listdir(temp_dir):
                         if name == "repositories":
@@ -921,8 +921,7 @@ class SystemContainers(object):
         return repo.pull(remote, [branch], 0, None)
 
     def _check_system_oci_image(self, repo, img, upgrade):
-        _, image, tag = SystemContainers._parse_imagename(img.replace("oci:", ""))
-        imagebranch = "%s%s-%s" % (OSTREE_OCIIMAGE_PREFIX, image.replace("sha256:", ""), tag)
+        imagebranch = "%s%s" % (OSTREE_OCIIMAGE_PREFIX, SystemContainers._encode_to_ostree_ref(img))
         current_rev = repo.resolve_rev(imagebranch, True)
         if not upgrade and current_rev[1]:
             return False
@@ -982,12 +981,43 @@ class SystemContainers(object):
         return self._checkout_system_container(repo, img, img, 0, False, destination=destination, extract_only=True)
 
     @staticmethod
+    def _encode_to_ostree_ref(name):
+        def convert(x):
+            return (x if str.isalnum(str(x)) or x in '.-' else "_%02X" % ord(x))
+
+        if name.startswith("oci:"):
+            name = name[len("oci:"):]
+        registry, image, tag = SystemContainers._parse_imagename(name)
+        if registry:
+            fullname = "%s/%s:%s" % (registry, image, tag)
+        else:
+            fullname = "%s:%s" % (image, tag)
+
+        ret = "".join([convert(i) for i in fullname])
+        return ret
+
+    @staticmethod
+    def _decode_from_ostree_ref(name):
+        try:
+            l = []
+            i = 0
+            while i < len(name):
+                if name[i] == '_':
+                    l.append(str(chr(int(name[i+1:i+3], 16))))
+                    i = i + 3
+                else:
+                    l.append(name[i])
+                    i = i + 1
+            return "".join(l)
+        except ValueError:
+            return name
+
+    @staticmethod
     def _get_ostree_image_branch(img):
         if "ostree:" in img:
             imagebranch = img.replace("ostree:", "")
         else: # assume "oci:" image
-            _, image, tag = SystemContainers._parse_imagename(img.replace("oci:", "").replace("docker:", ""))
-            imagebranch = "%s%s-%s" % (OSTREE_OCIIMAGE_PREFIX, image.replace("sha256:", ""), tag)
+            imagebranch = "%s%s" % (OSTREE_OCIIMAGE_PREFIX, SystemContainers._encode_to_ostree_ref(img))
         return imagebranch
 
     def has_system_container_image(self, img):

--- a/tests/integration/test_system_containers.sh
+++ b/tests/integration/test_system_containers.sh
@@ -51,7 +51,7 @@ ${ATOMIC} pull --storage ostree dockertar:/${WORK_DIR}/atomic-test-system.tar
 
 # Check that the branch is created in the OSTree repository
 ostree --repo=${ATOMIC_OSTREE_REPO} refs > refs
-assert_matches "ociimage/atomic-test-system-latest" refs
+assert_matches "ociimage/atomic-test-system_3Alatest" refs
 
 ${ATOMIC} images list > ${WORK_DIR}/images
 grep -q "atomic-test-system" ${WORK_DIR}/images
@@ -216,25 +216,25 @@ test \! -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.0
 test \! -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.1
 
 
-${ATOMIC} pull --storage ostree docker.io/busybox
-${ATOMIC} pull --storage ostree docker.io/busybox > second.pull.out
+${ATOMIC} pull --storage ostree busybox
+${ATOMIC} pull --storage ostree busybox > second.pull.out
 assert_not_matches "Pulling layer" second.pull.out
 
 ostree --repo=${ATOMIC_OSTREE_REPO} refs > refs
 assert_matches busybox refs
-${ATOMIC} -y images delete -f busybox
+${ATOMIC} --assumeyes images delete -f busybox
 ostree --repo=${ATOMIC_OSTREE_REPO} refs > refs
 OUTPUT=$(! grep -c busybox refs)
 if test $OUTPUT \!= 0; then
     exit 1
 fi
-${ATOMIC} pull --storage ostree docker.io/busybox
+${ATOMIC} pull --storage ostree busybox
 ostree --repo=${ATOMIC_OSTREE_REPO} refs | grep busybox
 
 ${ATOMIC} verify busybox > verify.out
 assert_not_matches "contains images or layers that have updates" verify.out
 
-image_digest=$(ostree --repo=${ATOMIC_OSTREE_REPO} show --print-metadata-key=docker.manifest ociimage/busybox-latest | sed -e"s|.*Digest\": \"sha256:\([a-z0-9]\+\).*|\1|" | head -c 12)
+image_digest=$(ostree --repo=${ATOMIC_OSTREE_REPO} show --print-metadata-key=docker.manifest ociimage/busybox_3Alatest | sed -e"s|.*Digest\": \"sha256:\([a-z0-9]\+\).*|\1|" | head -c 12)
 ${ATOMIC} images list > images.out
 grep "busybox.*$image_digest" images.out
 
@@ -244,14 +244,14 @@ test $(wc -l < images.out) -lt $(wc -l < images.all.out)
 assert_matches '<none>' images.all.out
 assert_not_matches '<none>' images.out
 
-${ATOMIC} -y images delete -f busybox
+${ATOMIC} --assumeyes images delete -f busybox
 ${ATOMIC} images prune
 
 # Test there are still intermediate layers left after prune
 ${ATOMIC} images list -f type=system --all > images.all.out
 assert_matches "<none>" images.all.out
 
-${ATOMIC} -y images delete -f atomic-test-system
+${ATOMIC} --assumeyes images delete -f atomic-test-system
 ${ATOMIC} images prune
 
 # Test there are not intermediate layers left layers now

--- a/tests/integration/test_system_containers.sh
+++ b/tests/integration/test_system_containers.sh
@@ -216,12 +216,14 @@ test \! -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.0
 test \! -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.1
 
 
+${ATOMIC} pull --storage ostree docker.io/busybox
 ${ATOMIC} pull --storage ostree busybox
 ${ATOMIC} pull --storage ostree busybox > second.pull.out
 assert_not_matches "Pulling layer" second.pull.out
 
 ostree --repo=${ATOMIC_OSTREE_REPO} refs > refs
 assert_matches busybox refs
+${ATOMIC} --assumeyes images delete -f docker.io/busybox
 ${ATOMIC} --assumeyes images delete -f busybox
 ostree --repo=${ATOMIC_OSTREE_REPO} refs > refs
 OUTPUT=$(! grep -c busybox refs)


### PR DESCRIPTION
translating the ':' separator for tag to '-' for the ostree branch was
a wrong choice as we are not able to handle tags like 1.2-3.
It is a breaking change with what we are shipping with atomic 1.12,
but better to do this now than carrying this issue.

Fetched images can be converted executing the output of:

```
find /ostree/repo/refs/ -type f | sed -ne "/ociimage.*-/ s|\(.*ociimage/\)\(.*\)-\(.*\)|mkdir -p \1\2; mv \1\2-\3 \1\2/\3|g p"
```

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>