### PR TITLE
[merged] Change sigstore-write to sigstore-staging

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -636,7 +636,7 @@ def have_match_registry(fq_name, reg_config):
 def get_signature_write_path(reg_info):
     # Return the defined path for where signatures should be written
     # or none if no entry is found
-    return reg_info.get('sigstore-write', reg_info.get('sigstore', None))
+    return reg_info.get('sigstore-staging', reg_info.get('sigstore', None))
 
 def get_signature_read_path(reg_info):
     # Return the defined path for where signatures should be read

--- a/docs/atomic-sign.1.md
+++ b/docs/atomic-sign.1.md
@@ -72,11 +72,11 @@ You can also scope the registry definitions by repository and even name.  Consid
 following addition to the configuration above.
 
   privateregistry.exaple.com/john:
-    sigstore-write: file:///mnt/export/signatures
+    sigstore-staging: file:///mnt/export/signatures
     sigstore: https://www.example.com/signatures/
 
-Now any image from the john repository will use the sigstore-write location of
-'/mnt/export/signatures'.  Also note the use of sigstore-write versus sigstore. This
+Now any image from the john repository will use the sigstore-staging location of
+'/mnt/export/signatures'.  Also note the use of sigstore-staging versus sigstore. This
 means that signatures should be written to that location but read should occur from
 the http URL provided.
 


### PR DESCRIPTION
The registries.d YAML files label for sigstore-write
has been changed to sigstore-staging for a more accurate
description.  Skopeo has made this change in its
85e4551eab00f9c3c973b309544329eb5558dfcd commit in
the integrate-all-the-things branch.