### PR TITLE
[merged] Trust show

### DIFF
--- a/Atomic/trust.py
+++ b/Atomic/trust.py
@@ -136,10 +136,10 @@ class Trust(Atomic):
         with open(self.policy_filename, 'r+') as policy_file:
             policy = json.load(policy_file)
             try:
-                del policy["transports"][sstype][self.args.registry]
+                del policy["transports"][sstype][registry]
             except KeyError:
                 raise ValueError("Could not find trust policy defined for %s transport %s" % 
-                              (self.args.sigstoretype, self.args.registry))
+                              (sigstoretype, registry))
             policy_file.seek(0)
             json.dump(policy, policy_file, indent=4)
             policy_file.truncate()

--- a/bash/atomic
+++ b/bash/atomic
@@ -659,6 +659,7 @@ _atomic_trust() {
     add
     delete
     default
+    show
   "
 
   __atomic_subcommands "$subcommands" && return

--- a/docs/atomic-trust.1.md
+++ b/docs/atomic-trust.1.md
@@ -6,7 +6,7 @@ atomic-trust - Manage system container trust policy
 
 
 # SYNOPSIS
-**atomic trust add|delete|default**
+**atomic trust add|delete|default|show**
 [**-h**|**--help**]
 
 [**-k**|**--pubkeys** KEY1 [**-k**|**--pubkeys** KEY2,...]]
@@ -97,6 +97,14 @@ Remove a trust scope
 Modify default trust policy
 
     atomic trust default reject
+
+Display system trust policy
+
+    atomic trust show
+
+Display system trust policy as raw JSON
+
+    atomic trust show --json
 
 # HISTORY
 September 2016, originally compiled by Aaron Weitekamp (aweiteka at redhat dot com)

--- a/tests/unit/fixtures/etc/containers/registries.d/docker.io-centos.yaml
+++ b/tests/unit/fixtures/etc/containers/registries.d/docker.io-centos.yaml
@@ -1,0 +1,3 @@
+docker:
+  docker.io/centos:
+    sigstore: https://centos.org/sigstore/

--- a/tests/unit/fixtures/etc/containers/registries.d/registry.access.redhat.com.yaml
+++ b/tests/unit/fixtures/etc/containers/registries.d/registry.access.redhat.com.yaml
@@ -1,0 +1,3 @@
+docker:
+  registry.access.redhat.com:
+    sigstore: https://cdn.redhat.com/containers/signatures

--- a/tests/unit/fixtures/show_policy.json
+++ b/tests/unit/fixtures/show_policy.json
@@ -1,0 +1,48 @@
+{
+    "default": [
+        {
+            "type": "insecureAcceptAnything"
+        }
+    ],
+    "transports": {
+        "docker": {
+            "docker.io": [
+                {
+                    "type": "reject"
+                }
+            ],
+            "registry.access.redhat.com": [
+                {
+                    "keyPath": "/home/aweiteka/dev/proj/atomic/tests/unit/fixtures/key2.pub",
+                    "keyType": "GPGKeys",
+                    "type": "signedBy"
+                }
+            ],
+            "docker.io/centos": [
+                {
+                    "keyPath": "/home/aweiteka/dev/proj/atomic/tests/unit/fixtures/key1.pub",
+                    "keyType": "GPGKeys",
+                    "type": "signedBy"
+                }
+            ]
+        },
+        "atomic": {
+            "private.example.com": [
+                {
+                    "keyPath": "/home/aweiteka/dev/proj/atomic/tests/unit/fixtures/key1.pub",
+                    "keyType": "GPGKeys",
+                    "type": "signedBy"
+                }
+            ]
+        },
+        "dir": {
+            "localhost": [
+                {
+                    "keyPath": "/home/aweiteka/dev/proj/atomic/tests/unit/fixtures/key2.pub",
+                    "keyType": "GPGKeys",
+                    "type": "signedBy"
+                }
+            ]
+        }
+    }
+}

--- a/tests/unit/fixtures/show_policy.output
+++ b/tests/unit/fixtures/show_policy.output
@@ -1,0 +1,5 @@
+docker.io                           reject   
+docker.io/centos                    signed   https://centos.org/sigstore/
+private.example.com                 signed   
+registry.access.redhat.com          signed   https://cdn.redhat.com/containers/signatures
+* (default)                         accept  

--- a/tests/unit/test_trust.py
+++ b/tests/unit/test_trust.py
@@ -78,7 +78,7 @@ class TestAtomicTrust(unittest.TestCase):
         testobj = Trust(policy_filename = os.path.join(FIXTURE_DIR, "etc/containers/policy.json"))
         testobj.atomic_config = util.get_atomic_config(atomic_config = os.path.join(FIXTURE_DIR, "atomic.conf"))
         testobj.set_args(args)
-        testobj.add()
+        testobj.add(confirm="y")
         with open(testobj.policy_filename, 'r') as f:
             d = json.load(f)
             self.assertEqual(d["transports"]["atomic"]["docker.io"][0]["keyPath"], 
@@ -91,7 +91,7 @@ class TestAtomicTrust(unittest.TestCase):
         testobj = Trust(policy_filename = os.path.join(FIXTURE_DIR, "etc/containers/policy.json"))
         testobj.atomic_config = util.get_atomic_config(atomic_config = os.path.join(FIXTURE_DIR, "atomic.conf"))
         testobj.set_args(args)
-        testobj.add()
+        testobj.add(confirm="y")
         with open(testobj.policy_filename, 'r') as f:
             d = json.load(f)
             self.assertEqual(d["transports"]["atomic"]["docker.io"][1]["keyPath"], 


### PR DESCRIPTION
```
$ sudo atomic trust show -h
usage: atomic trust show [-h] [-r]

optional arguments:
  -h, --help  show this help message and exit
  -r, --raw   Output policy file as raw json
$ sudo atomic trust show
docker.io                           reject
docker.io/centos                    signed   https://centos.org/sigstore/
private.example.com                 signed
registry.access.redhat.com          signed   https://cdn.redhat.com/containers/signatures
* (default)                         accept
$ sudo atomic trust show --raw
{
    "default": [
        {
            "type": "insecureAcceptAnything"
        }
    ],
    "transports": {
        "dir": {
            "localhost": [
                {
                    "keyType": "GPGKeys",
                    "type": "signedBy",
                    "keyPath": "/home/aweiteka/dev/proj/atomic/tests/unit/fixtures/key2.pub"
                }
            ]
        },
        "docker": {
            "docker.io/centos": [
                {
                    "keyType": "GPGKeys",
                    "type": "signedBy",
                    "keyPath": "/home/aweiteka/dev/proj/atomic/tests/unit/fixtures/key1.pub"
                }
            ],
            "docker.io": [
                {
                    "type": "reject"
                }
            ],
            "registry.access.redhat.com": [
                {
                    "keyType": "GPGKeys",
                    "type": "signedBy",
                    "keyPath": "/home/aweiteka/dev/proj/atomic/tests/unit/fixtures/key2.pub"
                }
            ]
        },
        "atomic": {
            "private.example.com": [
                {
                    "keyType": "GPGKeys",
                    "type": "signedBy",
                    "keyPath": "/home/aweiteka/dev/proj/atomic/tests/unit/fixtures/key1.pub"
                }
            ]
        }
    }
}
```