### PR TITLE
[merged] Atomic/push.py: Implement push with signing

### DIFF
--- a/Atomic/pull.py
+++ b/Atomic/pull.py
@@ -2,8 +2,9 @@ try:
     from . import Atomic
 except ImportError:
     from atomic import Atomic  # pylint: disable=relative-import
-from .util import skopeo_copy, get_atomic_config, skopeo_inspect, decompose, write_out
 from .trust import Trust
+from .util import skopeo_copy, get_atomic_config, skopeo_inspect,\
+    decompose, write_out, strip_port, is_insecure_registry
 
 ATOMIC_CONFIG = get_atomic_config()
 
@@ -18,20 +19,27 @@ def cli(subparser):
                        help=_("Specify the storage. Default is currently '%s'.  You can"
                               " change the default by editing /etc/atomic.conf and changing"
                               " the 'default_storage' field." % backend))
+    pullp.add_argument("-t", "--type", dest="reg_type", default=None,
+                       help=_("Push to an alternative registry type."))
     pullp.add_argument("image", help=_("image id"))
 
 
 class Pull(Atomic):
     def pull_docker_image(self):
-        _, _, tag = decompose(self.args.image)
+        registry, _, tag = decompose(self.args.image)
+        insecure = True if is_insecure_registry(self.d.info()['RegistryConfig'], strip_port(registry)) else False
         # If no tag is given, we assume "latest"
         tag = tag if tag != "" else "latest"
-        fq_name = skopeo_inspect("docker://{}".format(self.args.image))['Name']
+        if self.args.reg_type == "atomic":
+            pull_uri = 'atomic:'
+        else:
+            pull_uri = 'docker://'
+        fq_name = skopeo_inspect("{}{}".format(pull_uri, self.args.image))['Name']
         image = "docker-daemon:{}:{}".format(fq_name, tag)
         trust = Trust()
         trust.args.assumeyes=self.args.assumeyes
         trust.discover_sigstore(fq_name)
-        skopeo_copy("docker://{}".format(self.args.image), image, debug=self.args.debug)
+        skopeo_copy("docker://{}".format(self.args.image), image, debug=self.args.debug, insecure=insecure)
 
     def pull_image(self):
         handlers = {

--- a/docs/atomic-push.1.md
+++ b/docs/atomic-push.1.md
@@ -13,6 +13,8 @@ atomic-push - push Image to repository
 [**-p**][**--password**[=*PASSWORD*]]
 [**-r**][**--repository_id**[=*REPOSITORY_ID*]]
 [**--satellite**]
+[**--sign-by**]
+[**--t**][**--type**]
 [**-u**][**--username**[=*USERNAME*]]
 [**-U**][**--url**[=*URL*]]
 [**--verify_ssl**[=*VERIFY_SSL*]]
@@ -42,6 +44,14 @@ atomic-push - push Image to repository
 **--satellite**
   Upload using the satellite protocol; defaults to using docker push  
 
+**--sign-by**
+  Override the default signing identity defined in /etc/atomic.conf. Atomic push will always sign if there is a default
+  identity or you pass an indentity here.  If there is a default identity, you can pass **None** to **--sign-by** and
+   signing will be disabled.
+
+**-t REGISTRY_TYPE** **--type REGISTRY_TYPE**
+  Change the registry type.  Currently only **atomic** is the only other supported registry type.
+
 **-u USERNAME** **--username USERNAME**
   Username for remote registry
 
@@ -57,3 +67,5 @@ April 2015, Originally compiled by Daniel Walsh (dwalsh at redhat dot com)
 July 2015, Edited by Jenny Ramseyer (jramseye at redhat dot com)
 
 September 2015, Edited by Daniel Walsh (dwalsh at redhat dot com)
+
+September 2016, Updated by Brent Baude (bbaude at redhat dot com)


### PR DESCRIPTION
Enabling signing and pushing at the same time.  At the time of
this writing, we cannot verify that the atomic targets are
working but the code is there.  THis is enabled with the
--type atomic switch. Otherwise, signatures are written locally
and the image is pushed.