### PR TITLE
[merged] default.yaml: Define a default yaml for signing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,10 @@ install-only:
 
 	install -d $(DESTDIR)/etc/atomic.d
 
+	install -d $(DESTDIR)/etc/containers/registries.d
+
+	install -m 644 default.yaml $(DESTDIR)/etc/containers/registries.d
+
 .PHONY: install
 install: all install-only
 

--- a/default.yaml
+++ b/default.yaml
@@ -1,0 +1,26 @@
+# This is a default registries.d configuration file.  You may
+# add to this file or create additional files in registries.d/.
+#
+# sigstore: indicates a location that is read and write
+# sigstore-staging: indicates a location that is only for write
+#
+# sigstore and sigstore-staging take a value of the following:
+#   sigstore:  {schema}://location
+#
+# For reading signatures, schema may be http, https, or file.
+# For writing signatures, schema may only be file.
+
+# This is the default signature write location for registries.
+default-docker:
+#  sigstore: file:///var/lib/atomic/sigstore
+  sigstore-staging: file:///var/lib/atomic/sigstore
+
+# The 'docker' indicator here is the start of the configuration
+# for docker registries.
+#
+# docker:
+#
+#   privateregistry.com:
+#    sigstore: http://privateregistry.com/sigstore/
+#    sigstore-staging: /mnt/nfs/privateregistry/sigstore
+


### PR DESCRIPTION
The default.yaml is useful for out of the box
experience.  It allows the user to begin signing
once atomic is install (and they have the proper
gpg requirements).

Note the .spec file will need to be updated to
handle /etc/containers/registries.d/default.yaml.