### PR TITLE
[merged] atomic.conf: Set docker as default backend

### DIFF
--- a/Atomic/pull.py
+++ b/Atomic/pull.py
@@ -11,7 +11,7 @@ ATOMIC_CONFIG = get_atomic_config()
 
 def cli(subparser):
     # atomic pull
-    backend = ATOMIC_CONFIG.get('default_storage', "ostree")
+    backend = ATOMIC_CONFIG.get('default_storage', "docker")
     pullp = subparser.add_parser("pull", help=_("pull latest image from a repository"),
                                  epilog="pull the latest specified image from a repository.")
     pullp.set_defaults(_class=Pull, func='pull_image')

--- a/atomic.conf
+++ b/atomic.conf
@@ -9,7 +9,7 @@ pubkeys_dir: /etc/pki/containers
 
 
 # Default storage backend [ostree, docker]
-# default_storage: ostree
+# default_storage: docker
 # ostree_repository: /ostree/repo
 # checkout_path: /var/lib/containers/atomic
 #

--- a/docs/atomic-pull.1.md
+++ b/docs/atomic-pull.1.md
@@ -7,13 +7,21 @@ atomic-pull - fetch an image locally
 # SYNOPSIS
 **atomic pull**
 [**-h|--help**]
-[**--storage=[ostree]**]
+[**--storage=[ostree|docker]**]
+[**-t**|**--type** atomic]
 IMAGE
 
 # DESCRIPTION
 **atomic pull**, will fetch a remote image and store it locally.
 
-Use the `--ostree` option to store it into the OSTree repository.
+You can pull an image from a docker registry (like docker.io) to your
+local docker daemon with atomic pull.
+
+`atomic pull docker.io/busybox:latest`
+
+Use the `--storage ostree` option to store it into the OSTree repository. You can
+define a default storage type in **/etc/atomic.conf** with the key of 
+**default_storage**.
 
 IMAGE has the form `SOURCE:IMAGE-NAME`, where `SOURCE` can be one of
 'oci', 'docker', 'dockertar', 'ostree'.  If no `SOURCE` is specified
@@ -30,28 +38,47 @@ accessing the network.  It is equivalent to saving the image from
 docker (`docker save IMAGE`) and importing it into the OSTree
 repository:
 
-`atomic pull docker:fedora`
+`atomic pull --storage ostree docker:fedora`
 
 A 'dockertar' image works in a similar way to 'docker' images, except
 that the saved tarball is specified:
 
-`atomic pull dockertar:/path/to/the/image.tar`
+`atomic pull --storage ostree dockertar:/path/to/the/image.tar`
 
 An 'ostree' image refers to an image which is fetched from a remote
 OSTree repository.  The remote has to be already configured in the
 local OSTree repository:
 
-`atomic pull ostree:REMOTE/branch`
+`atomic pull --storage ostree ostree:REMOTE/branch`
 
 If the user is not privileged, the image will be stored in the user
 specific repository.
+
+If your /etc/containers/policy.json requires signature verification, the 
+pulled image is verified prior to being made available to the local docker
+daemon. When interacting with a docker registry, Atomic uses the policy 
+and YAML configuration files /etc/containers/ to determine:
+
+* if the image should be verified with a signature
+* and where to get the signature
+
+If you use the `--type atomic` switch to interact with an atomic registry,
+Atomic will still use the policy to determine if verification is needed.  The
+signature itself will be obtained from the atomic registry. An example of 
+pulling from an atomic registry could be:
+
+`atomic pull --type atomic my-atomic-registry:images/foobar`
 
 # OPTIONS:
 **-h** **--help**
 Print usage statement
 
-**--storage=[ostree]**
+**--storage=[ostree|docker]**
 Define the destination storage for the pulled image.
+
+**-t** **--type atomic**
+Define an alternate registry type.  The only valid option is **atomic** for
+when you want to take advantage of advanced atomic registry options.
 
 # HISTORY
 April 2016, Originally compiled by Giuseppe Scrivano (gscrivan at

--- a/tests/integration/test_system_containers.sh
+++ b/tests/integration/test_system_containers.sh
@@ -47,7 +47,7 @@ export ATOMIC_OSTREE_CHECKOUT_PATH=${WORK_DIR}/checkout
 
 docker save atomic-test-system > ${WORK_DIR}/atomic-test-system.tar
 
-${ATOMIC} pull dockertar:/${WORK_DIR}/atomic-test-system.tar
+${ATOMIC} pull --storage ostree dockertar:/${WORK_DIR}/atomic-test-system.tar
 
 # Check that the branch is created in the OSTree repository
 ostree --repo=${ATOMIC_OSTREE_REPO} refs > refs
@@ -216,8 +216,8 @@ test \! -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.0
 test \! -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.1
 
 
-${ATOMIC} pull docker.io/busybox
-${ATOMIC} pull docker.io/busybox > second.pull.out
+${ATOMIC} pull --storage ostree docker.io/busybox
+${ATOMIC} pull --storage ostree docker.io/busybox > second.pull.out
 assert_not_matches "Pulling layer" second.pull.out
 
 ostree --repo=${ATOMIC_OSTREE_REPO} refs > refs
@@ -228,7 +228,7 @@ OUTPUT=$(! grep -c busybox refs)
 if test $OUTPUT \!= 0; then
     exit 1
 fi
-${ATOMIC} pull docker.io/busybox
+${ATOMIC} pull --storage ostree docker.io/busybox
 ostree --repo=${ATOMIC_OSTREE_REPO} refs | grep busybox
 
 ${ATOMIC} verify busybox > verify.out


### PR DESCRIPTION
Setting docker as the default backend instead of ostree.