### PR TITLE
atomic: show help when lack of args provided

### DIFF
--- a/atomic
+++ b/atomic
@@ -71,6 +71,7 @@ class HelpByDefaultArgumentParser(argparse.ArgumentParser):
     def error(self, message):
         write_err('%s: %s' % (self.prog, message))
         write_err("Try '%s --help' for more information." % self.prog)
+        self.print_help()
         sys.exit(2)
 
     def print_usage(self, message="too few arguments"):


### PR DESCRIPTION
When a lack of arguements is provided to atomic or its
sub-commands, it displays the following error.
```
atomic push: too few arguments
Try 'atomic push --help' for more information.
```
This instructs the user to re-run the command with
--help to see which args are needed.  With this simple
change, the help is produced automatically:
```
atomic push: too few arguments
Try 'atomic push --help' for more information.
usage: atomic push [-h] [--pulp | --satellite] [--verify_ssl] [-U URL]
                   [-u USERNAME] [-p PASSWORD] [-a ACTIVATION_KEY]
                   [-r REPO_ID] [-t REG_TYPE] [--sign-by SIGN_BY]
                   image

positional arguments:
  image                 container image

optional arguments:
  -h, --help            show this help message and exit
  --pulp                push image using pulp
  --satellite           push image using Satellite
  --verify_ssl          flag to verify ssl of registry
  -U URL, --url URL     URL for remote registry
  -u USERNAME, --username USERNAME
                        Username for remote registry
  -p PASSWORD, --password PASSWORD
                        Password for remote registry
  -a ACTIVATION_KEY, --activation_key ACTIVATION_KEY
                        Activation Key
  -r REPO_ID, --repository_id REPO_ID
                        Repository ID
  -t REG_TYPE, --type REG_TYPE
                        Push to an alternative registry type.
  --sign-by SIGN_BY     Name of the signing key. Currently baudesign2@foo.bar,
                        default can be defined in /etc/atomic.conf

push the latest specified image to a repository.
```