### PR TITLE
[merged] Atomic/pull.py: Fix logic error in pull

### DIFF
--- a/Atomic/pull.py
+++ b/Atomic/pull.py
@@ -26,8 +26,7 @@ def cli(subparser):
 
 class Pull(Atomic):
     def pull_docker_image(self):
-        registry, _, tag = decompose(self.args.image)
-        insecure = True if is_insecure_registry(self.d.info()['RegistryConfig'], strip_port(registry)) else False
+        _, _, tag = decompose(self.args.image)
         # If no tag is given, we assume "latest"
         tag = tag if tag != "" else "latest"
         if self.args.reg_type == "atomic":
@@ -35,7 +34,9 @@ class Pull(Atomic):
         else:
             pull_uri = 'docker://'
         fq_name = skopeo_inspect("{}{}".format(pull_uri, self.args.image))['Name']
+        registry, _, _ = decompose(fq_name)
         image = "docker-daemon:{}:{}".format(fq_name, tag)
+        insecure = True if is_insecure_registry(self.d.info()['RegistryConfig'], strip_port(registry)) else False
         trust = Trust()
         trust.set_args(self.args)
         trust.discover_sigstore(fq_name)

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -62,7 +62,7 @@ def decompose(compound_name):
         reg, repo = repo.split('/', 1)
     if ':' in repo:
         repo, tag = repo.rsplit(':', 1)
-    return reg, repo, tag
+    return str(reg), str(repo), str(tag)
 
 def image_by_name(img_name, images=None):
     # Returns a list of image data for images which match img_name. Will


### PR DESCRIPTION
When a image without a registry is provided as input, i.e.

atomic pull busybox

We are not able to resolve that reference now because we can
no longer depend on docker's algo's for that as we now
use skopeo. Therefore, we now take the input, see if skopeo
inspect can resolve it; and then decompose the fqdn so we
can check if the registry is secure.  Had to make a small
change on the return types of util.decompose to ensure
it returns str objects or else it will return unicode in
python2.