### PR TITLE
[merged] Update to error message and install

### DIFF
--- a/Atomic/pull.py
+++ b/Atomic/pull.py
@@ -26,6 +26,7 @@ def cli(subparser):
 
 class Pull(Atomic):
     def pull_docker_image(self):
+        self.ping()
         _, _, tag = decompose(self.args.image)
         # If no tag is given, we assume "latest"
         tag = tag if tag != "" else "latest"

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,8 @@ install-only:
 
 	install -m 644 default.yaml $(DESTDIR)/etc/containers/registries.d
 
+	install -d $(DESTDIR)/var/lib/atomic/sigstore
+
 .PHONY: install
 install: all install-only
 


### PR DESCRIPTION
2 changes:
- allow pull to print a human readable error if the local docker daemon isn't running
- have install create the /var/lib/atomic/sigstore directory so that default signing config will work out of box