### PR TITLE
[merged] TRUST_POLICY env var

### DIFF
--- a/Atomic/trust.py
+++ b/Atomic/trust.py
@@ -75,7 +75,7 @@ class Trust(Atomic):
         :param policy_filename: override policy filename
         """
         super(Trust, self).__init__()
-        self.policy_filename = policy_filename
+        self.policy_filename = os.environ.get('TRUST_POLICY', policy_filename)
         self.atomic_config = util.get_atomic_config()
 
     def add(self, registry=None, pubkeys=None, sigstore=None, sigstoretype=None, keytype=None, trust_type=None):

--- a/docs/atomic-trust.1.md
+++ b/docs/atomic-trust.1.md
@@ -39,6 +39,10 @@ Trust may be updated using the command **atomic trust add** for an existing trus
 
 The default trust policy is managed by the default command. Options are **accept** or **reject**.
 
+The default **/etc/containers/policy.json** file may be overriden using
+environment variable **TRUST_POLICY**. This is typically only useful for
+testing.
+
 # OPTIONS
 **-h** **--help**
   Print usage statement.


### PR DESCRIPTION
Overrides default policy env var. Pending [corresponding support in skopeo](https://github.com/projectatomic/skopeo/issues/213).
Resolves #657 