### PR TITLE
[merged] Atomic update and install: Use skopeo for pulling

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -108,7 +108,10 @@ class Atomic(object):
         self.ping()
         if self.force:
             self.force_delete_containers()
-        return util.check_call([self.docker_binary(), "pull", self.image])
+        registry, _, _ = util.decompose(self.image)
+        return util.skopeo_copy("docker://{}".format(self.image),
+                                "docker-daemon:{}".format(self.image),
+                                util.is_insecure_registry(self.d.info()['RegistryConfig'], util.strip_port(registry)))
 
     def pull(self):
         prevstatus = ""

--- a/Atomic/install.py
+++ b/Atomic/install.py
@@ -105,6 +105,11 @@ class Install(Atomic):
             if self.args.display:
                 self.display("Need to pull %s" % self.image)
                 return
+            _, _, tag = util.decompose(self.image)
+            # skopeo requires the use of tags or it will fail
+            # if not tag is found, use 'latest'
+            if not tag:
+                self.image += ":{}".format("latest")
             self.update()
             self.inspect = self._inspect_image()
 


### PR DESCRIPTION
Atomic update and install now use skopeo for pulling images
from registries.  This allows us to enforce signature policies
as part of pull and update operations.