### PR TITLE
[merged] Atomic.util: More robust decompose

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -109,7 +109,7 @@ class Atomic(object):
         self.ping()
         if self.force:
             self.force_delete_containers()
-        registry, _, _ = util.decompose(self.image)
+        registry, _, _, _ = util.decompose(self.image)
         return util.skopeo_copy("docker://{}".format(self.image),
                                 "docker-daemon:{}".format(self.image),
                                 util.is_insecure_registry(self.d.info()['RegistryConfig'], util.strip_port(registry)))

--- a/Atomic/install.py
+++ b/Atomic/install.py
@@ -105,7 +105,7 @@ class Install(Atomic):
             if self.args.display:
                 self.display("Need to pull %s" % self.image)
                 return
-            _, _, tag = util.decompose(self.image)
+            _, _, _, tag = util.decompose(self.image)
             # skopeo requires the use of tags or it will fail
             # if not tag is found, use 'latest'
             if not tag:

--- a/Atomic/pull.py
+++ b/Atomic/pull.py
@@ -34,7 +34,7 @@ class Pull(Atomic):
 
     def pull_docker_image(self):
         self.ping()
-        _, _, tag = decompose(self.args.image)
+        _, _, _, tag = decompose(self.args.image)
         # If no tag is given, we assume "latest"
         tag = tag if tag != "" else "latest"
         if self.args.reg_type == "atomic":
@@ -42,7 +42,7 @@ class Pull(Atomic):
         else:
             pull_uri = 'docker://'
         fq_name = skopeo_inspect("{}{}".format(pull_uri, self.args.image))['Name']
-        registry, _, _ = decompose(fq_name)
+        registry, _, _, _ = decompose(fq_name)
         image = "docker-daemon:{}:{}".format(fq_name, tag)
         insecure = True if is_insecure_registry(self.d.info()['RegistryConfig'], strip_port(registry)) else False
         trust = Trust()

--- a/Atomic/push.py
+++ b/Atomic/push.py
@@ -159,7 +159,7 @@ class Push(Atomic):
                                                      self.args.debug)
 
         else:
-            reg, _, tag = util.decompose(self.image)
+            reg, _, _, tag = util.decompose(self.image)
             # Check if any local tokens exist
             if reg not in [x for x in self.get_local_tokens()]:
                 # If we find a token for the registry, we don't

--- a/Atomic/sign.py
+++ b/Atomic/sign.py
@@ -57,7 +57,7 @@ class Sign(Atomic):
             images = self.args.images
 
         for reg_check in images:
-            reg, _, _ = util.decompose(reg_check)
+            reg, _, _, _ = util.decompose(reg_check)
             if not reg:
                 raise ValueError("Signing can only sign images stored on a registry. Image '{}' is "
                                  "not preceeded with a registry name. See man atomic-sign".format(reg_check))
@@ -85,7 +85,7 @@ class Sign(Atomic):
                 manifest_file.write(manifest)
                 manifest_file.close()
                 manifest_hash = str(util.skopeo_manifest_digest(manifest_file.name))
-                _, _, tag = util.decompose(sign_image)
+                _, _, _, tag = util.decompose(sign_image)
                 tag = ":{}".format(tag) if tag != "" else ":latest"
                 expanded_image_name = str(remote_inspect_info['Name'])
 
@@ -96,7 +96,7 @@ class Sign(Atomic):
 
 
                 else:
-                    reg, repo, _ = util.decompose(expanded_image_name)
+                    reg, repo, _, _ = util.decompose(expanded_image_name)
                     if not registry_configs and not default_store:
                         raise ValueError(no_reg_no_default_error(sign_image, registry_config_path))
                     reg_info = util.have_match_registry("{}/{}".format(reg, repo), registry_configs)

--- a/Atomic/trust.py
+++ b/Atomic/trust.py
@@ -263,7 +263,7 @@ class Trust(Atomic):
         """
         if not util.get_atomic_config_item(['discover_sigstores'], util.get_atomic_config()):
             return True
-        (registry, repo, _) = util.decompose(pull_image)
+        (registry, repo, _, _) = util.decompose(pull_image)
         repo = repo.split('/')
         registry_config_path = util.get_atomic_config_item(["registry_confdir"], self.atomic_config)
         registry_configs, _ = util.get_registry_configs(registry_config_path)

--- a/Atomic/verify.py
+++ b/Atomic/verify.py
@@ -235,7 +235,7 @@ class Verify(Atomic):
                                        if x['Id'] == iid] for _repo in repos]
         results = []
         for repo_ in similar:
-            (reg, _, _) = util.decompose(repo_)
+            (reg, _, _, _) = util.decompose(repo_)
             results.append(self.is_registry_local(reg))
         return all(results)
 

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -5,6 +5,7 @@ from Atomic import util
 
 
 class TestAtomicUtil(unittest.TestCase):
+
     def test_image_by_name(self):
         matches = util.image_by_name('atomic-test-1')
         self.assertEqual(len(matches), 1)
@@ -16,10 +17,6 @@ class TestAtomicUtil(unittest.TestCase):
         self.assertTrue(len(matches) > 2)
         self.assertTrue(all([m['Labels']['Name'].startswith('atomic-test-')
                              for m in matches]))
-
-    def test_image_by_name_tag_glob(self):
-        matches = util.image_by_name('/busybox:*atest*')
-        self.assertTrue(len(matches) == 1)
 
     def test_image_by_name_registry_match(self):
         matches = util.image_by_name('/centos:latest')
@@ -57,6 +54,22 @@ class TestAtomicUtil(unittest.TestCase):
         except util.FileNotFound:
             exception_raised = True
         self.assertTrue(exception_raised)
+
+    def test_decompose(self):
+        images = [('docker.io/library/busybox', ('docker.io', 'library','busybox', 'latest')),
+                  ('docker.io/library/foobar/busybox', ('docker.io', 'library/foobar', 'busybox', 'latest')),
+                  ('docker.io/library/foobar/busybox:2.1', ('docker.io', 'library/foobar', 'busybox', '2.1')),
+                  ('docker.io/busybox:2.1', ('docker.io', 'library', 'busybox', '2.1')),
+                  ('docker.io/busybox', ('docker.io', 'library', 'busybox', 'latest')),
+                  ('busybox', ('', '', 'busybox', 'latest')),
+                  ('busybox:2.1', ('', '', 'busybox', '2.1')),
+                  ('library/busybox', ('', 'library', 'busybox', 'latest')),
+                  ('library/busybox:2.1', ('', 'library', 'busybox', '2.1'))
+                  ]
+
+        for image in images:
+            self.assertEqual(util.decompose(image[0]), image[1])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Colleagues asked for decompose to be improved to where it took
an image name and broke it into registry, repo, image, and tag.
It also should mimic docker's implementation where 'library' is a known
exception

Also added unittests.