### PR TITLE
[merged] Atomic/util.py: Fix error in strip port

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -659,7 +659,7 @@ def get_signature_read_path(reg_info):
 
 def strip_port(_input):
     ip, _, _ = _input.rpartition(':')
-    if ip is '':
+    if ip == '':
         return _input
     return ip.strip("[]")
 


### PR DESCRIPTION
An equality operator issue in strip port was causing failures.  Changed
'is' to '=='.