### PR TITLE
[merged] atomic.d/openscap: Fix race condition (bz #1368896)

### DIFF
--- a/atomic.d/openscap
+++ b/atomic.d/openscap
@@ -5,10 +5,10 @@ default_scan: cve
 custom_args: ['-v', '/etc/oscapd:/etc/oscapd:ro']
 scans: [ 
       { name: cve,
-        args: ['oscapd-evaluate', 'scan',  '--no-standard-compliance', '--targets', 'chroots-in-dir:///scanin',  '--output', '/scanout'],
+        args: ['oscapd-evaluate', 'scan',  '--no-standard-compliance', '--targets', 'chroots-in-dir:///scanin',  '--output', '/scanout', '-j1'],
         description: "Performs a CVE scan based on known CVE data"},
       { name: standards_compliance,
-        args: ['oscapd-evaluate', 'scan', '--targets', 'chroots-in-dir:///scanin',  '--output', '/scanout', '--no-cve-scan'],
+        args: ['oscapd-evaluate', 'scan', '--targets', 'chroots-in-dir:///scanin',  '--output', '/scanout', '--no-cve-scan', '-j1'],
         description: "Performs a standard scan"
       }
 ]


### PR DESCRIPTION
There is a race condition in oscpd where it sometimes fails to scan
because of a threading issue.  While that is resolved upstream, we
set the max number of threads to 1 to avoid it.

This resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1368896