### PR TITLE
[merged] Allow pull from registry not in docker conf

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -707,7 +707,11 @@ class Atomic(object):
         if not image:
             raise ValueError('Error parsing input: "{}" invalid'.format(input_image))
         if all([True if x else False for x in [registry, image, tag]]):
-            return input_image
+            img = registry
+            if repo:
+                img += "/{}".format(repo)
+            img += "/{}:{}".format(image, tag)
+            return img
         if not registry:
             ri = RegistryInspect(registry, repo, image, tag, debug=self.args.debug, orig_input=self.image)
             return ri.find_image_on_registry()

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -72,11 +72,17 @@ def get_registries():
 
 
 def decompose(compound_name):
-    registries = [x['name'] for x in get_registries()]
+    def is_network_address(_input):
+        try:
+            socket.gethostbyname(_input)
+        except socket.gaierror:
+            return False
+        return True
+
     reg, repo, image, tag = '', compound_name, '', ''
     if '/' in repo:
         reg, repo = repo.split('/', 1)
-        if reg not in registries:
+        if not is_network_address(reg):
             repo = '{}/{}'.format(reg, repo)
             reg = ''
     if ':' in repo:
@@ -90,6 +96,10 @@ def decompose(compound_name):
         repo = 'library'
     if not tag:
         tag = "latest"
+
+    if reg and not repo and not is_network_address(repo):
+        repo = reg
+        reg = ''
 
     return str(reg), str(repo), str(image), str(tag)
 

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -64,7 +64,9 @@ class TestAtomicUtil(unittest.TestCase):
                   ('busybox', ('', '', 'busybox', 'latest')),
                   ('busybox:2.1', ('', '', 'busybox', '2.1')),
                   ('library/busybox', ('', 'library', 'busybox', 'latest')),
-                  ('library/busybox:2.1', ('', 'library', 'busybox', '2.1'))
+                  ('library/busybox:2.1', ('', 'library', 'busybox', '2.1')),
+                  ('registry.access.redhat.com/rhel7:latest', ('registry.access.redhat.com', '', 'rhel7', 'latest')),
+                  ('registry.access.redhat.com/rhel7', ('registry.access.redhat.com', '', 'rhel7', 'latest'))
                   ]
 
         for image in images:


### PR DESCRIPTION
We now allow pulls from registries that are not in
the docker configuration file.  This altered our
decompose method a bit.  We now check the registry
in decompose to see if it resolves on the network.
If so, then we use it.