### PR TITLE
[merged] decompose: Add ability to decompose image w/digest

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -111,7 +111,7 @@ class Atomic(object):
         if self.force:
             self.force_delete_containers()
         fq_name = self.get_fq_image_name(self.image)
-        registry, _, _, _ = util.decompose(fq_name)
+        registry = util.Decompose(fq_name).registry
         return util.skopeo_copy("docker://{}".format(self.image),
                                 "docker-daemon:{}".format(fq_name),
                                 util.is_insecure_registry(self.d.info()['RegistryConfig'], util.strip_port(registry)))
@@ -706,7 +706,7 @@ class Atomic(object):
         return tokens
 
     def get_fq_image_name(self, input_image):
-        registry, repo, image, tag = util.decompose(input_image)
+        registry, repo, image, tag, _ = util.Decompose(input_image).all
         if not image:
             raise ValueError('Error parsing input: "{}" invalid'.format(input_image))
         if all([True if x else False for x in [registry, image, tag]]):

--- a/Atomic/install.py
+++ b/Atomic/install.py
@@ -105,7 +105,7 @@ class Install(Atomic):
             if self.args.display:
                 self.display("Need to pull %s" % self.image)
                 return
-            _, _, _, tag = util.decompose(self.image)
+            tag = util.Decompose(self.image).tag
             # skopeo requires the use of tags or it will fail
             # if not tag is found, use 'latest'
             if not tag:

--- a/Atomic/pull.py
+++ b/Atomic/pull.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     from atomic import Atomic  # pylint: disable=relative-import
 from .trust import Trust
-from .util import skopeo_copy, get_atomic_config, decompose, write_out, strip_port, is_insecure_registry
+from .util import skopeo_copy, get_atomic_config, Decompose, write_out, strip_port, is_insecure_registry
 
 ATOMIC_CONFIG = get_atomic_config()
 
@@ -39,7 +39,7 @@ class Pull(Atomic):
         # else:
         #     pull_uri = 'docker://'
         fq_name = self.get_fq_image_name(self.args.image)
-        registry, _, _, tag = decompose(fq_name)
+        registry, _, _, tag, _ = Decompose(fq_name).all
         image = "docker-daemon:{}".format(self.args.image)
         if not self.args.image.endswith(tag):
             image += ":{}".format(tag)

--- a/Atomic/push.py
+++ b/Atomic/push.py
@@ -160,7 +160,7 @@ class Push(Atomic):
                                                      self.args.debug)
 
         else:
-            reg, _, _, tag = util.decompose(self.image)
+            reg, _, _, tag, _ = util.Decompose(self.image).all
             # Check if any local tokens exist
             if reg not in [x for x in self.get_local_tokens()]:
                 # If we find a token for the registry, we don't

--- a/Atomic/sign.py
+++ b/Atomic/sign.py
@@ -75,7 +75,7 @@ class Sign(Atomic):
             os.environ['GNUPGHOME'] = self.args.gnupghome
 
         for sign_image in images:
-            registry, repo, image, tag = util.decompose(sign_image)
+            registry, repo, image, tag, _ = util.Decompose(sign_image).all
             ri = discovery.RegistryInspect(registry, repo, image, tag, debug=self.args.debug, orig_input=sign_image)
             manifest = ri.rc.manifest_json
 
@@ -93,7 +93,7 @@ class Sign(Atomic):
 
 
                 else:
-                    reg, repo, _, _ = util.decompose(expanded_image_name)
+                    reg, repo, _, _, _ = util.Decompose(expanded_image_name).all
                     if not registry_configs and not default_store:
                         raise ValueError(no_reg_no_default_error(sign_image, registry_config_path))
                     reg_info = util.have_match_registry("{}/{}".format(reg, repo), registry_configs)

--- a/Atomic/trust.py
+++ b/Atomic/trust.py
@@ -263,7 +263,7 @@ class Trust(Atomic):
         """
         if not util.get_atomic_config_item(['discover_sigstores'], util.get_atomic_config()):
             return True
-        (registry, repo, _, _) = util.decompose(pull_image)
+        registry, repo, _, _, _ = util.Decompose(pull_image).all
         repo = repo.split('/')
         registry_config_path = util.get_atomic_config_item(["registry_confdir"], self.atomic_config)
         registry_configs, _ = util.get_registry_configs(registry_config_path)

--- a/Atomic/verify.py
+++ b/Atomic/verify.py
@@ -239,7 +239,7 @@ class Verify(Atomic):
                                        if x['Id'] == iid] for _repo in repos]
         results = []
         for repo_ in similar:
-            (reg, _, _, _) = util.decompose(repo_)
+            reg  = util.Decompose(repo_).registry
             results.append(self.is_registry_local(reg))
         return all(results)
 

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -5,7 +5,7 @@ from Atomic import discovery
 
 class TestAtomicUtil(unittest.TestCase):
     IMAGE = 'docker.io/library/busybox:latest'
-    I_REGISTRY, I_REPO, I_IMAGE, I_TAG = util.decompose(IMAGE)
+    I_REGISTRY, I_REPO, I_IMAGE, I_TAG, _ = util.Decompose(IMAGE).all
 
     def test_ping(self):
         ri = discovery.RegistryInspect(registry=self.I_REGISTRY,
@@ -19,7 +19,7 @@ class TestAtomicUtil(unittest.TestCase):
     def test_find_image_on_registry(self):
         fq = 'docker.io/library/busybox:latest'
         for img in ['docker.io/library/busybox:latest', 'docker.io/library/busybox', 'docker.io/busybox', 'busybox']:
-            registry, repo, image, tag = util.decompose(img)
+            registry, repo, image, tag, _ = util.Decompose(img).all
             ri = discovery.RegistryInspect(registry=registry, repo=repo, image=image, tag=tag)
             self.assertEqual(ri.find_image_on_registry(), fq)
 

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -56,21 +56,24 @@ class TestAtomicUtil(unittest.TestCase):
         self.assertTrue(exception_raised)
 
     def test_decompose(self):
-        images = [('docker.io/library/busybox', ('docker.io', 'library','busybox', 'latest')),
-                  ('docker.io/library/foobar/busybox', ('docker.io', 'library/foobar', 'busybox', 'latest')),
-                  ('docker.io/library/foobar/busybox:2.1', ('docker.io', 'library/foobar', 'busybox', '2.1')),
-                  ('docker.io/busybox:2.1', ('docker.io', 'library', 'busybox', '2.1')),
-                  ('docker.io/busybox', ('docker.io', 'library', 'busybox', 'latest')),
-                  ('busybox', ('', '', 'busybox', 'latest')),
-                  ('busybox:2.1', ('', '', 'busybox', '2.1')),
-                  ('library/busybox', ('', 'library', 'busybox', 'latest')),
-                  ('library/busybox:2.1', ('', 'library', 'busybox', '2.1')),
-                  ('registry.access.redhat.com/rhel7:latest', ('registry.access.redhat.com', '', 'rhel7', 'latest')),
-                  ('registry.access.redhat.com/rhel7', ('registry.access.redhat.com', '', 'rhel7', 'latest'))
+        images = [('docker.io/library/busybox', ('docker.io', 'library','busybox', 'latest', '')),
+                  ('docker.io/library/foobar/busybox', ('docker.io', 'library/foobar', 'busybox', 'latest', '')),
+                  ('docker.io/library/foobar/busybox:2.1', ('docker.io', 'library/foobar', 'busybox', '2.1', '')),
+                  ('docker.io/busybox:2.1', ('docker.io', 'library', 'busybox', '2.1', '')),
+                  ('docker.io/busybox', ('docker.io', 'library', 'busybox', 'latest', '')),
+                  ('busybox', ('', '', 'busybox', 'latest', '')),
+                  ('busybox:2.1', ('', '', 'busybox', '2.1', '')),
+                  ('library/busybox', ('', 'library', 'busybox', 'latest', '')),
+                  ('library/busybox:2.1', ('', 'library', 'busybox', '2.1', '')),
+                  ('registry.access.redhat.com/rhel7:latest', ('registry.access.redhat.com', '', 'rhel7', 'latest', '')),
+                  ('registry.access.redhat.com/rhel7', ('registry.access.redhat.com', '', 'rhel7', 'latest', '')),
+                  ('fedora@sha256:64a02df6aac27d1200c2572fe4b9949f1970d05f74d367ce4af994ba5dc3669e', ('', '', 'fedora', '', 'sha256:64a02df6aac27d1200c2572fe4b9949f1970d05f74d367ce4af994ba5dc3669e')),
+                  ('docker.io/library/fedora@sha256:64a02df6aac27d1200c2572fe4b9949f1970d05f74d367ce4af994ba5dc3669e', ('docker.io', 'library', 'fedora', '', 'sha256:64a02df6aac27d1200c2572fe4b9949f1970d05f74d367ce4af994ba5dc3669e')),
+                  ('docker.io/fedora@sha256:64a02df6aac27d1200c2572fe4b9949f1970d05f74d367ce4af994ba5dc3669e', ('docker.io', 'library', 'fedora', '', 'sha256:64a02df6aac27d1200c2572fe4b9949f1970d05f74d367ce4af994ba5dc3669e'))
                   ]
 
         for image in images:
-            self.assertEqual(util.decompose(image[0]), image[1])
+            self.assertEqual(util.Decompose(image[0]).all, image[1])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adding the ability to decompose an input image "name" that
includes a digest. For example:

docker.io/library/fedora@sha256:64a02df6aac27d1200c2572fe4b9949f1970d05f74d367ce4af994ba5dc3669e

Also, reword the decompose method in a Decompose class.  This simplifies the use of
decomposition and allows for growth.

Example usage:
   registry, repo, image, tag, digest = Decompose("docker.io/library/busybox:latest").all
   repo = Decompose("docker.io/library/busybox:latest").repo
   digest = Decompose("docker.io/fedora@sha256:64a02df6aac27d1200c2...67ce4af994ba5dc3669e").digest