### PR TITLE
[merged] Atomic/atomic.py: Explore RepoTags for Fq name

### DIFF
--- a/Atomic/info.py
+++ b/Atomic/info.py
@@ -125,9 +125,6 @@ class Info(Atomic):
                     return buf
             # Check if the input is an image id associated with more than one
             # repotag.  If so, error out.
-            elif self.is_iid():
-                self.get_fq_name(self._inspect_image())
-            # The input is not an image id
             else:
                 try:
                     iid = self._is_image(self.image)


### PR DESCRIPTION
In cases where the input name is not fully-qualified and
the local image is tagged more than once, we iterate repotags
in an attempt to figure out the fq name.  If this fails, we
raise a ValueError like before.