### PR TITLE
[merged] Atomic/util.py: Strip port in Decompose class

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -754,7 +754,7 @@ class Decompose(object):
     def _decompose(self, input_name):
         def is_network_address(_input):
             try:
-                socket.gethostbyname(_input)  # Remember to add in strip port here!
+                socket.gethostbyname(strip_port(_input))
             except socket.gaierror:
                 return False
             return True


### PR DESCRIPTION
When determining if a registry name is a registry name, you have to strip
the port or it will fail.  For example:

```
python -c 'from Atomic.util import Decompose; print(Decompose("localhost:5000/somethingibuilt:latest").all)'
('', 'localhost:5000', 'somethingibuilt', 'latest', '')
```

Note how the localhost:5000 ends up in the repo "field".  With this fix:

```
python -c 'from Atomic.util import Decompose; print(Decompose("localhost:5000/somethingibuilt:latest").all)'
('localhost:5000', '', 'somethingibuilt', 'latest', '')
```

Now ends up in the registry field.