### PR TITLE
[merged] Revert atomic host dbus support

### DIFF
--- a/Atomic/host.py
+++ b/Atomic/host.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-from Atomic import util
 
 try:
     from . import Atomic
@@ -109,9 +108,8 @@ def cli(subparser):
     _add_remainder_arg(p)
 
 class Host(Atomic):
-    def __init__(self, tty=True):
+    def __init__(self):
         super(Host, self).__init__()
-        self.tty=tty
 
     def host_status(self):
         argv = ["status"]
@@ -119,7 +117,7 @@ class Host(Atomic):
             argv.append("--pretty")
         if self.args.json:
             argv.append("--json")
-        return self._rpmostree(argv)
+        self._rpmostree(argv)
 
     def host_upgrade(self):
         argv = ["upgrade"]
@@ -131,19 +129,19 @@ class Host(Atomic):
             argv.append("--check-diff")
         if self.args.downgrade:
             argv.append("--allow-downgrade")
-        return self._rpmostree(argv)
+        self._rpmostree(argv)
 
     def host_rollback(self):
         argv = ["rollback"]
         if self.args.reboot:
             argv.append("--reboot")
-        return self._rpmostree(argv)
+        self._rpmostree(argv)
 
     def host_rebase(self):
         argv = ["rebase", self.args.refspec]
         if self.args.os:
             argv.append("--os=" % self.args.os )
-        return self._rpmostree(argv)
+        self._rpmostree(argv)
 
     def host_deploy(self):
         argv = ["deploy", self.args.revision]
@@ -153,34 +151,31 @@ class Host(Atomic):
             argv.append("--os=" % self.args.os)
         if self.args.preview:
             argv.append("--preview")
-        return self._rpmostree(argv)
+        self._rpmostree(argv)
 
     def host_unlock(self):
         argv = ['unlock']
         if self.args.hotfix:
             argv.append("--hotfix")
-        return self._ostreeadmin(argv)
+        self._ostreeadmin(argv)
 
     def host_install(self):
         argv = ['install']
-        return self._rpmostree(argv)
+        self._rpmostree(argv)
 
     def host_uninstall(self):
         argv = ['uninstall']
-        return self._rpmostree(argv)
+        self._rpmostree(argv)
 
     def _passthrough(self, args):
         cmd = args[0]
         aargs = self.args.args
         if len(aargs) > 0 and aargs[0] == "--":
             aargs = aargs[1:]
-        if self.tty:
-            os.execl("/usr/bin/" + cmd, *(args + aargs))
-        else:
-            return util.check_output([ "/usr/bin/" + cmd ] + args[1:] + aargs)
+        os.execl("/usr/bin/" + cmd, *(args + aargs))
 
     def _rpmostree(self, args):
-        return self._passthrough(['rpm-ostree'] + args)
+        self._passthrough(['rpm-ostree'] + args)
 
     def _ostreeadmin(self, args):
-        return self._passthrough(['ostree', 'admin'] + args)
+        self._passthrough(['ostree', 'admin'] + args)

--- a/atomic_client.py
+++ b/atomic_client.py
@@ -31,50 +31,6 @@ class AtomicDBus (object):
         return self.dbus_object.Diff(first, second, rpms, no_files, names_only, dbus_interface="org.atomic", timeout = 2147400)
 
     @polkit.enable_proxy
-    def HostDeploy(self, revision, reboot=False, os=None):
-        return self.dbus_object.HostDeploy(revision, reboot, os, dbus_interface="org.atomic")
-
-    @polkit.enable_proxy
-    def HostDeployPreview(self, revision, os=None):
-        return self.dbus_object.HostDeployPreview(revision, os, dbus_interface="org.atomic")
-
-    @polkit.enable_proxy
-    def HostInstall(self, rpms):
-        if not isinstance(rpms, (list, tuple)):
-            rpms = [ rpms ]
-        return self.dbus_object.HostInstall(rpms, dbus_interface="org.atomic")
-
-    @polkit.enable_proxy
-    def HostRebase(self, refspec, os=None):
-        return self.dbus_object.HostRebase(refspec, os, dbus_interface="org.atomic")
-
-    @polkit.enable_proxy
-    def HostRollBack(self, reboot=False):
-        return self.dbus_object.HostRollBack(reboot, dbus_interface="org.atomic")
-
-    @polkit.enable_proxy
-    def HostStatus(self):
-        return self.dbus_object.HostStatus(dbus_interface="org.atomic")
-
-    @polkit.enable_proxy
-    def HostUninstall(self, rpms):
-        if not isinstance(rpms, (list, tuple)):
-            rpms = [ rpms ]
-        return self.dbus_object.HostUninstall(rpms, dbus_interface="org.atomic")
-
-    @polkit.enable_proxy
-    def HostUnlock(self, hotfix=False):
-        return self.dbus_object.HostUnlock(hotfix, dbus_interface="org.atomic")
-
-    @polkit.enable_proxy
-    def HostUpgrade(self, reboot=False, downgrade=False, os=None):
-        return self.dbus_object.HostUpgrade(reboot, downgrade, os, dbus_interface="org.atomic")
-
-    @polkit.enable_proxy
-    def HostUpgradeDiff(self, os=None):
-        return self.dbus_object.HostUpgradeDiff(os, dbus_interface="org.atomic")
-
-    @polkit.enable_proxy
     def Stop(self, image, name=None, extra_args=None):
         if not name:
             name = image

--- a/atomic_dbus.py
+++ b/atomic_dbus.py
@@ -13,7 +13,6 @@ from Atomic.containers import Containers
 from Atomic.delete import Delete
 from Atomic.diff import Diff
 from Atomic.help import AtomicHelp
-from Atomic.host import Host
 from Atomic.info import Info
 from Atomic.install import Install
 from Atomic.images import Images
@@ -147,115 +146,6 @@ class atomic_dbus(slip.dbus.service.Object):
         args.rpms = rpms
         diff.set_args(args)
         return json.dumps(diff.diff())
-
-    # atomic host section
-    # The HostRollback switch to alternate installed tree at next boot
-    @slip.dbus.polkit.require_auth("org.atomic.readwrite")
-    @dbus.service.method("org.atomic", in_signature='b', out_signature='')
-    def HostRollBack(self, reboot=False):
-        host=Host(False)
-        args=self.Args()
-        args.reboot=reboot
-        host.set_args(args)
-        return host.host_rollback()
-
-    # The HostStatus list information about all deployments
-    @slip.dbus.polkit.require_auth("org.atomic.read")
-    @dbus.service.method("org.atomic", in_signature='', out_signature='s')
-    def HostStatus(self):
-        host=Host(False)
-        args=self.Args()
-        args.json=True
-        host.set_args(args)
-        return host.host_status()
-
-    # The HostUpgrade upgrade to the latest Atomic tree if one is available
-    @slip.dbus.polkit.require_auth("org.atomic.readwrite")
-    @dbus.service.method("org.atomic", in_signature='bbs', out_signature='')
-    def HostUpgrade(self, reboot=False, downgrade=False, os=None):
-        host=Host(False)
-        args=self.Args()
-        args.reboot=reboot
-        args.downgrade=downgrade
-        args.os=os
-        host.set_args(args)
-        return host.host_upgrade()
-
-    # The HostUpgradeDiff checks for upgrades and print package diff only
-    @slip.dbus.polkit.require_auth("org.atomic.read")
-    @dbus.service.method("org.atomic", in_signature='s', out_signature='s')
-    def HostUpgradeDiff(self, os=None):
-        host=Host(False)
-        args=self.Args()
-        args.diff=True
-        args.os=os
-        host.set_args(args)
-        return host.host_upgrade()
-
-    # The HostRebase - download and deploy a new origin refspec
-    @slip.dbus.polkit.require_auth("org.atomic.readwrite")
-    @dbus.service.method("org.atomic", in_signature='sb', out_signature='')
-    def HostRebase(self, refspec, os=None):
-        host=Host(False)
-        args=self.Args()
-        args.refspec=refspec
-        args.os=os
-        host.set_args(args)
-        return host.host_rebase()
-
-    # The HostDeployPreview - download and deploy a new origin refspec
-    @slip.dbus.polkit.require_auth("org.atomic.readwrite")
-    @dbus.service.method("org.atomic", in_signature='sbs', out_signature='')
-    def HostDeploy(self, revision, reboot, os):
-        host=Host(False)
-        args=self.Args()
-        args.revision=revision
-        args.reboot=reboot
-        args.os=os
-        host.set_args(args)
-        return host.host_deploy()
-
-    # The HostDeployPreview - download and deploy a new origin refspec
-    @slip.dbus.polkit.require_auth("org.atomic.read")
-    @dbus.service.method("org.atomic", in_signature='ss', out_signature='s')
-    def HostDeployPreview(self, revision, os=None):
-        host=Host(False)
-        args=self.Args()
-        args.revision=revision
-        args.preview=True
-        args.os=os
-        host.set_args(args)
-        return host.host_deploy()
-
-    # The HostUnlock - Make the current deployment mutable (for development or a hotfix)
-    @slip.dbus.polkit.require_auth("org.atomic.readwrite")
-    @dbus.service.method("org.atomic", in_signature='b', out_signature='')
-    def HostUnlock(self, hotfix=False):
-        host=Host(False)
-        args=self.Args()
-        args.hotfix=hotfix
-        host.set_args(args)
-        return host.host_install()
-
-    # The HostInstall - Install a (layered) RPM package
-    @slip.dbus.polkit.require_auth("org.atomic.readwrite")
-    @dbus.service.method("org.atomic", in_signature='as', out_signature='')
-    def HostInstall(self, rpms):
-        host=Host(False)
-        args=self.Args()
-        args.args=rpms
-        host.set_args(args)
-        return host.host_install()
-
-    # The HostUninstall - Remove a layered RPM package
-    @slip.dbus.polkit.require_auth("org.atomic.readwrite")
-    @dbus.service.method("org.atomic", in_signature='as', out_signature='')
-    def HostUninstall(self, rpms):
-        host=Host(False)
-        args=self.Args()
-        args.args=rpms
-        host.set_args(args)
-        return host.host_uninstall()
 
     # atomic containers section
     # The ContainersList method will list all containers on the system.


### PR DESCRIPTION
OSTree commands already have Cockpit/dbus support.  Users should
call them directly.