### PR TITLE
[merged] Atomic/sign.py: Ensure image tag is included in signing.

### DIFF
--- a/Atomic/sign.py
+++ b/Atomic/sign.py
@@ -85,7 +85,7 @@ class Sign(Atomic):
                 manifest_file.write(manifest)
                 manifest_file.close()
                 manifest_hash = str(util.skopeo_manifest_digest(manifest_file.name))
-                expanded_image_name = ri.assemble_fqdn(include_tag=False)
+                expanded_image_name = ri.assemble_fqdn(include_tag=True)
 
                 if in_signature_path:
                     if not os.path.exists(in_signature_path):
@@ -116,8 +116,7 @@ class Sign(Atomic):
                     if not os.path.exists(signature_path):
                         raise ValueError("The signature path {} does not exist".format(signature_path))
 
-                sigstore_path = "{}/{}/{}@{}".format(signature_path, os.path.dirname(expanded_image_name),
-                                                     os.path.basename(expanded_image_name), manifest_hash)
+                sigstore_path = "{}/{}@{}".format(signature_path, expanded_image_name.rsplit(':', 1)[0], manifest_hash)
                 self.make_sig_dirs(sigstore_path)
                 sig_name = self.get_sig_name(sigstore_path)
                 fq_sig_path = os.path.join(sigstore_path, sig_name)
@@ -126,7 +125,7 @@ class Sign(Atomic):
                                      "overwrite it, please delete this file first")
 
                 util.skopeo_standalone_sign(expanded_image_name, manifest_file.name,
-                                            self.get_fingerprint(signer), fq_sig_path)
+                                            self.get_fingerprint(signer), fq_sig_path, debug=self.args.debug)
                 util.write_out("Created: {}".format(fq_sig_path))
 
             finally:

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -323,6 +323,8 @@ def skopeo_standalone_sign(image, manifest_file_name, fingerprint, signature_pat
         cmd = cmd + ['--debug']
     cmd = cmd + ['standalone-sign', manifest_file_name, image,
                  fingerprint, "-o", signature_path]
+    if debug:
+        write_out("Executing: {}".format(" ".join(cmd)))
     return check_call(cmd)
 
 def skopeo_manifest_digest(manifest_file, debug=False):


### PR DESCRIPTION
The previous change where we removed the tag from the write
file location impacted the signing because the tag was also
being omitted. This ensures the tag is omitted from the file
path but included in the call skopeo standalone-sign.