### PR TITLE
[merged] Atomic/mount.py: Handle self.options == None

### DIFF
--- a/Atomic/mount.py
+++ b/Atomic/mount.py
@@ -132,7 +132,7 @@ class Mount(Atomic):
             self.shared = args.shared
         if hasattr(args, "storage"):
             self.storage = args.storage
-        if hasattr(args, "options"):
+        if getattr(args, "options", None):
             self.options = [opt for opt in args.options.split(',') if opt]
         if hasattr(args, "image"):
             self.image = args.image


### PR DESCRIPTION
When using the dbus interface to perform a scan, self.options
was being set to None.  This tripped a condition with the
setting of args where it could not be iterated.  We now ensure
self.options is not None prior to the iteration.