### PR TITLE
[merged] Atomic storage reset does not work on docker-latest

### DIFF
--- a/Atomic/storage.py
+++ b/Atomic/storage.py
@@ -121,14 +121,14 @@ class Storage(Atomic):
             self.graphdir = self.args.graph
         else:
             if os.path.exists("/var/lib/docker") and os.path.exists("/var/lib/docker-latest"):
-                raise ValueError("You must select the graph storage path to reset: /var/lib/docker or /var/lib/docker-latest")
+                raise ValueError("You must specify the --graph storage path to reset /var/lib/docker or /var/lib/docker-latest")
             if os.path.exists("/var/lib/docker"):
                 self.graphdir = "/var/lib/docker"
             else:
                 if os.path.exists("/var/lib/docker-latest"):
                     self.graphdir = "/var/lib/docker-latest"
                 else:
-                    raise ValueError("You must select the graph storage path to reset")
+                    raise ValueError("Could not find any default graph storage path. Specify one using --graph option")
 
     def reset(self):
         root=self.graphdir

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -434,13 +434,20 @@ def get_scanners():
 def default_docker():
     if not default_docker.cache:
         atomic_config = get_atomic_config()
-        default_docker.cache = atomic_config.get('default_docker','docker')
+        if os.path.exists("/var/lib/docker"):
+            docker = "docker"
+        else:
+            docker = "docker-latest"
+
+        default_docker.cache = atomic_config.get('default_docker', docker)
     return default_docker.cache
 default_docker.cache = None
 
 def default_docker_lib():
     if not default_docker_lib.cache:
-        default_docker_lib.cache = "/var/lib/%s" % default_docker()
+        dockerlib_path = "/var/lib/%s" % default_docker()
+        if os.path.exists(dockerlib_path):
+            default_docker_lib.cache = dockerlib_path
     return default_docker_lib.cache
 default_docker_lib.cache = None
 

--- a/bash/atomic
+++ b/bash/atomic
@@ -1197,6 +1197,16 @@ _atomic_storage_storage() {
 }
 
 
+_atomic_storage_reset() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--graph -h --help" -- "$cur" ) )
+			;;
+		*)
+			;;
+	esac
+}
+
 _atomic_storage_export() {
 	case "$cur" in
 		-*)

--- a/docs/atomic-storage.1.md
+++ b/docs/atomic-storage.1.md
@@ -90,5 +90,15 @@ Drivers supported: devicemapper, overlay, overlay2
 **--vgroup**
 The name of the volume group for the storage pool.
 
+# reset OPTIONS
+**-h** **--help**
+  Print usage statement
+
+**--graph**
+Root of the docker runtime. If you are running docker at the default
+location (/var/lib/docker), you don't need to pass this flag. However
+if you are running docker at a custom location. This flag must be set.
+
+
 # HISTORY
 October 2015, Originally compiled by Shishir Mahajan (shishir dot mahajan at redhat dot com)

--- a/docs/atomic-storage.1.md
+++ b/docs/atomic-storage.1.md
@@ -95,10 +95,7 @@ The name of the volume group for the storage pool.
   Print usage statement
 
 **--graph**
-Root of the docker runtime. If you are running docker at the default
-location (/var/lib/docker), you don't need to pass this flag. However
-if you are running docker at a custom location. This flag must be set.
-
+Root of the docker runtime. atomic will search for either /var/lib/docker or /var/lib/docker-latest, if only one exists, atomic will select it as the default.  If both exists or you are running docker with a graph storage at a non default location, you need to pass this flag.
 
 # HISTORY
 October 2015, Originally compiled by Shishir Mahajan (shishir dot mahajan at redhat dot com)


### PR DESCRIPTION
This patch will allow user to specify the graphdriver on atomic reset

If /var/lib/docker or /var/lib/docker-latest is the only thing installed
it will reset the correct path.  If both exists or the user as chosen
a different location, the --graph option must be specified.