### PR TITLE
[merged] The HELP label by default should be "help"

### DIFF
--- a/Atomic/help.py
+++ b/Atomic/help.py
@@ -32,7 +32,6 @@ class AtomicHelp(Atomic):
         self.docker_object = None
         self.is_container = True
         self.use_pager = True
-        self.alt_help_cmd = None
         self.image = None
         self.inspect = None
 
@@ -61,12 +60,11 @@ class AtomicHelp(Atomic):
             # its image
             self.image = self.inspect['Image']
 
-        # Check if an alternate help command is provided
-        labels = self._get_labels()
-        self.alt_help_cmd = None if len(labels) == 0 else labels.get('HELP')
+        # Check if an help command label is provided
+        help_cmd = self._get_args('HELP')
 
-        if self.alt_help_cmd is not None:
-            return self.alt_help()
+        if help_cmd:
+            return self.alt_help(help_cmd)
         else:
             return self.man_help(docker_id)
 
@@ -103,12 +101,12 @@ class AtomicHelp(Atomic):
         dm.unmount(path=mnt_path)
         return result
 
-    def alt_help(self):
+    def alt_help(self, help_cmd):
         """
         Returns help when the HELP LABEL override is being used.
         :return: None
         """
-        cmd = self.gen_cmd(self.alt_help_cmd.split(" "))
+        cmd = self.gen_cmd(help_cmd)
         cmd = self.sub_env_strings(cmd)
         self.display(cmd)
         return util.check_output(cmd, env=self.cmd_env())

--- a/test.sh
+++ b/test.sh
@@ -90,7 +90,7 @@ make_docker_images () {
         fi
 
         # Copy help.sh into atomic-test-3
-        if [[ ${iname} = "atomic-test-3" ]]; then
+	if [ ${iname} = "atomic-test-3" -o ${iname} = "atomic-test-4" ]; then
             cp ./tests/test-images/help.sh ${WORK_DIR}
         fi
 

--- a/tests/integration/test_help.sh
+++ b/tests/integration/test_help.sh
@@ -21,8 +21,11 @@ if [ -x /usr/bin/groff ]; then
     ${ATOMIC} help atomic-test-1 1>/dev/null
 fi
 
-# Test override label
+# Test override label - uppercase help
 ${ATOMIC} help atomic-test-3 1>/dev/null
+
+# Test override label - lowercase help
+${ATOMIC} help atomic-test-4 1>/dev/null
 
 rc=0
 ${ATOMIC} help centos:latest 1>/dev/null || rc=$?
@@ -31,4 +34,3 @@ if [[ ${rc} != 1 ]]; then
     echo "This test should result in a return code of 1"
     exit 1
 fi
-

--- a/tests/test-images/Dockerfile.4
+++ b/tests/test-images/Dockerfile.4
@@ -7,3 +7,6 @@ LABEL "Name"="atomic-test-4"
 LABEL RUN "/usr/bin/docker run -t --user \${SUDO_UID}:\${SUDO_GID} \${OPT1}  -v /var/log/\${NAME}:/var/log -v /var/lib/\${NAME}:/var/lib \$OPT2 --name \${NAME} \${IMAGE} \$OPT3 echo I am the run label."
 
 LABEL INSTALL "/usr/bin/docker \${OPT1} run  -v /etc/\${NAME}:/etc -v /var/log/\${NAME}:/var/log -v /var/lib/\${NAME}:/var/lib \$OPT2 --name \${NAME} \${IMAGE} \$OPT3 echo I am the install label."
+
+LABEL help "docker run --rm IMAGE /usr/bin/bash /help.sh"
+COPY help.sh /


### PR DESCRIPTION
But we want to check for all cases.  Currently if a image uses the
standard help label, atomic will fail to find it.