### PR TITLE
[merged] Add  SYSTEMD_IGNORE_CHROOT=1 to environment of SPCs

### DIFF
--- a/Atomic/install.py
+++ b/Atomic/install.py
@@ -24,6 +24,7 @@ INSTALL_ARGS = ["run",
                 "-e", "CONFDIR=/host/etc/${NAME}",
                 "-e", "LOGDIR=/host/var/log/${NAME}",
                 "-e", "DATADIR=/host/var/lib/${NAME}",
+                "-e", "SYSTEMD_IGNORE_CHROOT=1", 
                 "--name", "${NAME}",
                 "${IMAGE}"]
 

--- a/Atomic/run.py
+++ b/Atomic/run.py
@@ -21,6 +21,7 @@ SPC_ARGS = ["run",
             "-e", "HOST=/host",
             "-e", "NAME=${NAME}",
             "-e", "IMAGE=${IMAGE}",
+            "-e", "SYSTEMD_IGNORE_CHROOT=1", 
             "--name", "${NAME}",
             "${IMAGE}"]
 


### PR DESCRIPTION
Systemd currently blocks apps from executing systemctl commands
from inside of a container effecting the host system.

If you set the  SYSTEMD_IGNORE_CHROOT=1  environment variable this
will turn off this behaviour, allowing a SPC to manage the hosts
systemd.