### PR TITLE
[merged] Use centos for all test images

### DIFF
--- a/Atomic/mount.py
+++ b/Atomic/mount.py
@@ -836,8 +836,10 @@ class OSTreeMount(Mount):
                     dirpath = os.path.join(root,d)
                     if os.path.islink(dirpath):
                         os.unlink(dirpath)
-                    else:
+                    elif os.path.isdir(dirpath):
                         shutil.rmtree(dirpath)
+                    else:
+                        os.remove(dirpath)
         else:
             Mount.unmount_path(self.mountpoint)
 
@@ -846,8 +848,10 @@ class OSTreeMount(Mount):
                 path = os.path.join(self.mountpoint, i)
                 if os.path.islink(path):
                     os.unlink(path)
-                else:
+                elif os.path.isdir(path):
                     shutil.rmtree(path)
+                else:
+                    os.remove(path)
         try:
             removexattr(self.mountpoint, "user.atomic.type") # pylint: disable=not-callable
         except IOError:

--- a/test.sh
+++ b/test.sh
@@ -50,9 +50,7 @@ _checksum () {
 make_docker_images () {
     echo "${SECRET}" > ${WORK_DIR}/secret
     echo "Pulling standard images from Docker Hub..." | tee -a ${LOG}
-    ${DOCKER} pull busybox >> ${LOG}
-    ${DOCKER} pull centos >> ${LOG}
-    ${DOCKER} pull fedora >> ${LOG}
+    ${DOCKER} pull centos>> ${LOG}
     echo "Building images from tests/test-images..." | tee -a ${LOG}
     for df in `find ./tests/test-images/ -name Dockerfile.*`; do
         # Don't include directories for dockerfile data

--- a/tests/integration/test_system_containers.sh
+++ b/tests/integration/test_system_containers.sh
@@ -236,7 +236,6 @@ mv ${ATOMIC_OSTREE_REPO}/refs/heads/ociimage/atomic-test-secret_3Alatest ${ATOMI
 ${ATOMIC} info atomic-test-secret-ostree > version.out
 assert_matches ${SECRET} version.out
 ${ATOMIC} --assumeyes images delete -f atomic-test-secret-ostree
-${ATOMIC} --assumeyes images delete -f busybox
 ${ATOMIC} pull --storage ostree docker.io/busybox
 ${ATOMIC} pull --storage ostree busybox
 ${ATOMIC} pull --storage ostree busybox > second.pull.out

--- a/tests/test-images/Dockerfile.3
+++ b/tests/test-images/Dockerfile.3
@@ -8,5 +8,5 @@ LABEL RUN "/usr/bin/docker run -t --user \${SUDO_UID}:\${SUDO_GID} \${OPT1}  -v 
 
 LABEL INSTALL "/usr/bin/docker \${OPT1} run  -v /etc/\${NAME}:/etc -v /var/log/\${NAME}:/var/log -v /var/lib/\${NAME}:/var/lib \$OPT2 --name \${NAME} \${IMAGE} \$OPT3 echo I am the install label."
 
-LABEL HELP "docker run --rm IMAGE /usr/bin/bash /help.sh"
+LABEL HELP "docker run --rm IMAGE /bin/bash /help.sh"
 COPY help.sh /

--- a/tests/test-images/Dockerfile.system
+++ b/tests/test-images/Dockerfile.system
@@ -1,5 +1,5 @@
-FROM fedora
-RUN dnf install -y nmap-ncat && dnf clean all
+FROM centos
+RUN yum -y install nmap-ncat && yum clean all
 
 LABEL "Name"="atomic-test-system"
 

--- a/tests/unit/test_pull.py
+++ b/tests/unit/test_pull.py
@@ -5,7 +5,7 @@ from Atomic.syscontainers import SystemContainers
 class TestAtomicPull(unittest.TestCase):
     class Args():
         def __init__(self):
-            self.image = "docker:fedora"
+            self.image = "docker:centos"
             self.user = False
 
     def test_pull_as_privileged_user(self):


### PR DESCRIPTION
To download less images, we now just used centos for the
base of all atomic-test images