### PR TITLE
Generate RPM and support arbitrary files copied to the host

### DIFF
--- a/Atomic/containers.py
+++ b/Atomic/containers.py
@@ -151,7 +151,7 @@ class Containers(Atomic):
         max_container_id = 12 if self.args.truncate else max([len(x.id) for x in container_objects])
         max_image_name = 20 if self.args.truncate else max([len(x.image_name) for x in container_objects])
         max_command = 20 if self.args.truncate else max([len(x.command) for x in container_objects])
-        col_out = "{0:2} {1:%s} {2:%s} {3:%s} {4:16} {5:9} {6:10} {7:10}" % (max_container_id, max_image_name, max_command)
+        col_out = "{0:2} {1:%s} {2:%s} {3:%s} {4:16} {5:10} {6:10} {7:10}" % (max_container_id, max_image_name, max_command)
         if self.args.heading:
             util.write_out(col_out.format(" ",
                                           "CONTAINER ID",
@@ -173,7 +173,7 @@ class Containers(Atomic):
                                           con_obj.image_name[0:max_image_name],
                                           con_obj.command[0:max_command],
                                           con_obj.created[0:16],
-                                          con_obj.state[0:9],
+                                          con_obj.state[0:10],
                                           con_obj.backend.backend[0:10],
                                           con_obj.runtime[0:10]))
 

--- a/Atomic/install.py
+++ b/Atomic/install.py
@@ -62,6 +62,9 @@ def cli(subparser):
         system_xor_user.add_argument("--system", dest="system",
                                      action='store_true', default=False,
                                      help=_('install a system container'))
+        installp.add_argument("---generate-rpm", dest="generate_rpm",
+                              action='store_true', default=False,
+                              help=_('generate an rpm instead of installing the container'))
         installp.add_argument("--rootfs", dest="remote",
                               help=_("choose an existing exploded container/image to use "
                                      "its rootfs as a remote, read-only rootfs for the "

--- a/Atomic/install.py
+++ b/Atomic/install.py
@@ -62,9 +62,8 @@ def cli(subparser):
         system_xor_user.add_argument("--system", dest="system",
                                      action='store_true', default=False,
                                      help=_('install a system container'))
-        installp.add_argument("---generate-rpm", dest="generate_rpm",
-                              action='store_true', default=False,
-                              help=_('generate an rpm instead of installing the container'))
+        installp.add_argument("--system-package", dest="system_package", default="auto",
+                              help=_('control how to install the package.  It accepts `auto`, `yes`, `no`, `build`'))
         installp.add_argument("--rootfs", dest="remote",
                               help=_("choose an existing exploded container/image to use "
                                      "its rootfs as a remote, read-only rootfs for the "

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -653,7 +653,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             with open(tmpfiles, 'r') as infile:
                 tmpfiles_template = infile.read()
         else:
-            tmpfiles_template = SystemContainers._generate_tmpfiles_data(missing_bind_paths, values["STATE_DIRECTORY"])
+            tmpfiles_template = SystemContainers._generate_tmpfiles_data(missing_bind_paths)
 
         if has_container_service:
             SystemContainers._write_template(unitfile, systemd_template, values, unitfileout)
@@ -1486,16 +1486,12 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         return True
 
     @staticmethod
-    def _generate_tmpfiles_data(missing_bind_paths, state_directory):
+    def _generate_tmpfiles_data(missing_bind_paths):
         def _generate_line(x, state):
             return "%s    %s   0700 %i %i - -\n" % (state, x, os.getuid(), os.getgid())
         lines = []
         for x in missing_bind_paths:
-            if os.path.commonprefix([x, state_directory]) == state_directory:
-                lines.append(_generate_line(x, "d"))
-            else:
-                lines.append(_generate_line(x, "D"))
-                lines.append(_generate_line(x, "R"))
+            lines.append(_generate_line(x, "d"))
         return "".join(lines)
 
     @staticmethod

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1644,6 +1644,10 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             if self.display:
                 return None
 
+            included_rpm = os.path.join(rootfs, "rootfs", "exports", "container.rpm")
+            if os.path.exists(included_rpm):
+                return included_rpm
+
             installed_files = None
             with open(os.path.join(rootfs, "info"), "r") as info_file:
                 info = json.loads(info_file.read())

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -189,6 +189,14 @@ class SystemContainers(object):
         else:
             util.check_call(["yum", "install", "-y", rpm_file])
 
+    def _uninstall_rpm(self, rpm):
+        if os.path.exists("/run/ostree-booted"):
+            raise ValueError("This doesn't work on Atomic Host yet")
+        elif os.path.exists("/usr/bin/dnf"):
+            util.check_call(["dnf", "remove", "-y", rpm])
+        else:
+            util.check_call(["yum", "remove", "-y", rpm])
+
     def install(self, image, name):
         repo = self._get_ostree_repo()
         if not repo:
@@ -1163,7 +1171,8 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
 
     def uninstall(self, name):
         if self._is_preinstalled_container(name):
-            raise ValueError("Cannot uninstall a preinstalled container")
+            self._uninstall_rpm("%s-%s" % (RPM_NAME_PREFIX, name))
+            return
 
         with open(os.path.join(self._get_system_checkout_path(), name, "info"), "r") as info_file:
             info = json.loads(info_file.read())

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -59,7 +59,7 @@ WorkingDirectory=$DESTDIR
 WantedBy=multi-user.target
 """
 TEMPLATE_FORCED_VARIABLES = ["DESTDIR", "NAME", "EXEC_START", "EXEC_STOP",
-                             "HOST_UID", "HOST_GID", "IMAGE_ID"]
+                             "HOST_UID", "HOST_GID", "IMAGE_ID", "IMAGE_NAME"]
 TEMPLATE_OVERRIDABLE_VARIABLES = ["RUN_DIRECTORY", "STATE_DIRECTORY", "UUID"]
 
 class SystemContainers(object):
@@ -239,7 +239,7 @@ class SystemContainers(object):
             for k, v in setvalues.items():
                 values[k] = v
 
-        return self._checkout(repo, name, image, 0, False, values=values, remote=self.args.remote)
+        self._checkout(repo, name, image, 0, False, values=values, remote=self.args.remote)
 
     def _check_oci_configuration_file(self, conf_path, remote=None, include_all=False):
         with open(conf_path, 'r') as conf:
@@ -556,6 +556,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         values["EXEC_START"], values["EXEC_STOP"] = self._generate_systemd_startstop_directives(name)
         values["HOST_UID"] = os.getuid()
         values["HOST_GID"] = os.getgid()
+        values["IMAGE_NAME"] = img
         values["IMAGE_ID"] = image_id
 
         src = os.path.join(exports, "config.json")

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -217,7 +217,10 @@ class SystemContainers(object):
         rpm_preinstalled = None
         tmp_dir = None
         try:
-            if self.args.system_package in ['build', 'yes', 'auto']:
+            if self.args.system_package == 'auto' and self.args.system:
+                self.args.system_package = 'no'
+
+            if self.args.system_package in ['build', 'yes']:
                 if not self.args.system:
                     raise ValueError("Only --system can generate rpms")
 

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -155,12 +155,12 @@ class SystemContainers(object):
     def _pull_image_to_ostree(self, repo, image, upgrade):
         if not repo:
             raise ValueError("Cannot find a configured OSTree repo")
-        if image.startswith("ostree:"):
+        if image.startswith("ostree:") and image.count(':') > 1:
             self._check_system_ostree_image(repo, image, upgrade)
-        elif image.startswith("docker:"):
+        elif image.startswith("docker:") and image.count(':') > 1:
             image = self._pull_docker_image(repo, image.replace("docker:", "", 1))
-        elif image.startswith("dockertar:"):
-            tarpath = image.replace("dockertar:", "", 1)
+        elif image.startswith("dockertar:/"):
+            tarpath = image.replace("dockertar:/", "", 1)
             image = self._pull_docker_tar(repo, tarpath, os.path.basename(tarpath).replace(".tar", ""))
         else: # Assume "oci:"
             self._check_system_oci_image(repo, image, upgrade)

--- a/bash/atomic
+++ b/bash/atomic
@@ -718,6 +718,7 @@ _atomic_install() {
 	       --rootfs
 	       --storage
 	       --system
+	       --system-package
 	       --set
 	       --user
 	"

--- a/docs/atomic-install.1.md
+++ b/docs/atomic-install.1.md
@@ -12,6 +12,7 @@ atomic-install - Execute Image Install Method
 [**--rootfs**=*ROOTFS*]
 [**--set**=*NAME*=*VALUE*]
 [**--storage**]
+[**--system-package=auto|build|yes|no**]
 [**--system**]
 IMAGE [ARG...]
 
@@ -95,6 +96,18 @@ OSTree and runc are required for this feature to be available.
 Note: If the image being pulled contains a label of `system.type=ostree`,
 atomic will automatically substitute the storage backend to be ostree. This
 can be overridden with the --storage option.
+
+**--system-package=auto|build|no|yes**
+Control how the container will be installed to the system.
+
+*auto* generates an rpm and install it to the system when the
+image defines a .spec file.  This is the default.
+
+*build* build only the software package, without installing it.
+
+*no* do not generate an rpm package to install the container.
+
+*yes* generate an rpm package and install it to the system.
 
 **--user**
 If running as non-root, specify to install the image from the current

--- a/tests/integration/test_system_containers.sh
+++ b/tests/integration/test_system_containers.sh
@@ -255,7 +255,7 @@ test \! -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}
 test \! -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.0
 test \! -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.1
 
-${ATOMIC} pull --storage ostree docker:atomic-test-secret
+${ATOMIC} pull --storage ostree docker:atomic-test-secret:latest
 # Move directly the OSTree reference to a new one, so that we have different names and info doesn't error out
 mv ${ATOMIC_OSTREE_REPO}/refs/heads/ociimage/atomic-test-secret_3Alatest ${ATOMIC_OSTREE_REPO}/refs/heads/ociimage/atomic-test-secret-ostree_3Alatest
 ${ATOMIC} info atomic-test-secret-ostree > version.out
@@ -332,7 +332,7 @@ teardown
 
 # Install from a docker local docker image
 export NAME="test-docker-system-container-$$"
-${ATOMIC} install --name=${NAME} --set=RECEIVER=${SECRET} --system docker:atomic-test-system
+${ATOMIC} install --name=${NAME} --set=RECEIVER=${SECRET} --system docker:atomic-test-system:latest
 test -e /etc/tmpfiles.d/${NAME}.conf
 
 test -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.0/${NAME}.service

--- a/tests/unit/test_pull.py
+++ b/tests/unit/test_pull.py
@@ -20,7 +20,7 @@ except ImportError:
 class TestAtomicPull(unittest.TestCase):
     class Args():
         def __init__(self):
-            self.image = "docker:centos"
+            self.image = "docker:centos:latest"
             self.user = False
 
     def test_pull_as_privileged_user(self):


### PR DESCRIPTION
this is a prototype to add "pre installed" system containers.  The idea is to have another deployment tree under `/usr/lib/containers/atomic` that is not handled by "atomic install/uninstall/update", where '/var/lib/containers/atomic' is fully handled by atomic.  The systemd files are also copied under '/usr/lib'.

The second patch adds the possibility to install a system container into a rpm.  The `---generate-rpm` (three dashes) option is hidden for now.   The spec file is auto generated, and stuff like `Requires`, `Provides`, `Conflicts` can be specified through labels.  So in the Dockerfile something like: `LABEL Provides="etcd"`, will be translated directly to the specfile.

Example:
```
# atomic --debug install --system ---generate-rpm gscrivano/etcd  
# rpm -i x86_64/atomic-container-etcd-1.0-1.0.x86_64.rpm
```

