### PR TITLE
[merged] Atomic/mount.py: Re-Add _clean_temp_container_by_path (BZ 1397839)

### DIFF
--- a/Atomic/mount.py
+++ b/Atomic/mount.py
@@ -705,6 +705,15 @@ class DockerMount(Mount):
         Mount.unmount_path(mountpoint)
         self._cleanup_container(self.d.inspect_container(cid))
 
+    def _clean_temp_container_by_path(self, path):
+        """
+        Do not remove this method.  It is used by openscap.
+        """
+        short_cid = os.path.basename(path)
+        if not self.live:
+            self.d.remove_container(short_cid)
+        self._clean_tmp_image()
+        
 def getxattrfuncs():
     # Python 3 has support for extended attributes in the os module, while
     # Python 2 needs the xattr library.  Detect if any is available.


### PR DESCRIPTION
Commit 9a0114c2845beba372116b2fdcb605a3f59b445b removed several
methods not used by Atomic CLI.  Unfortunately, one of the methods
was being called by openscap.  This is reported in bz# 1397839.

Reverted the removal of the method.