### PR TITLE
[merged] Add fedora25_cloud target for vagrant

### DIFF
--- a/.redhat-ci.sh
+++ b/.redhat-ci.sh
@@ -4,13 +4,16 @@ set -xeuo pipefail
 # https://bugzilla.redhat.com/show_bug.cgi?id=1318547#c7
 mount --make-rshared /
 
-systemctl start docker
 
 if [ -f /run/ostree-booted ]; then
     if [ ! -e /var/tmp/ostree-unlock-ovl.* ]; then
         ostree admin unlock
     fi
+else
+    dnf install -y atomic python3-coverage
 fi
+
+systemctl start docker
 
 # somewhat mimic the spec conditional
 source /etc/os-release

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,4 +28,7 @@ Vagrant.configure(2) do |config|
         centos_atomic.vm.box =  "centos_atomic"
         centos_atomic.vm.box_url = "https://ci.centos.org/artifacts/sig-atomic/centos-continuous/images/cloud/latest/images/centos-atomic-host-7-vagrant-libvirt.box"
     end
+    config.vm.define "fedora_cloud" do |fedora_cloud|
+        fedora_cloud.vm.box =  "fedora/25-cloud-base"
+    end
 end

--- a/vagrant.sh
+++ b/vagrant.sh
@@ -23,7 +23,7 @@ _FINISH(){
 # out in _FINISH
 trap _FINISH EXIT
 
-BOXES="fedora_atomic centos_atomic"
+BOXES="fedora_atomic centos_atomic fedora_cloud"
 
 is_running() {
     status=$(vagrant status | grep ${BOX} | awk '{print $2}')


### PR DESCRIPTION
This allows us to test on Fedora 25 cloud images via make vagrant-check.