### PR TITLE
[merged] Atomic/diff.py: Use go-mtree for file comparisons

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -509,7 +509,7 @@ def find_remote_image(client, image):
 def is_user_mode():
     return os.geteuid() != 0
 
-def generate_validation_manifest(img_rootfs=None, img_tar=None, keywords=""):
+def generate_validation_manifest(img_rootfs=None, img_tar=None, keywords="", debug=False):
     """
     Executes the gomtree validation manifest creation command
     :param img_rootfs: path to directory
@@ -525,14 +525,18 @@ def generate_validation_manifest(img_rootfs=None, img_tar=None, keywords=""):
         cmd = [GOMTREE_PATH,'-c','-T',img_tar]
     if keywords:
         cmd += ['-k',keywords]
+    if debug:
+        write_out(" ".join(cmd))
     return subp(cmd)
 
-def validate_manifest(spec, img_rootfs=None, img_tar=None, keywords=""):
+def validate_manifest(spec, img_rootfs=None, img_tar=None, keywords="", json_out=False, debug=False):
     """
     Executes the gomtree validation manife  st validation command
+    :param spec: path to spec file
     :param img_rootfs: path to directory
     :param img_tar: path to tar file (or tgz file)
     :param keywords: use only the keywords specified to validate the manifest
+    :param json_out: Return the validation in JSON form
     :return: output of gomtree validation manifest validation
     """
     if img_rootfs == None and img_tar == None:
@@ -543,6 +547,10 @@ def validate_manifest(spec, img_rootfs=None, img_tar=None, keywords=""):
         cmd = [GOMTREE_PATH,'-T',img_tar, '-f', spec]
     if keywords:
         cmd += ['-k',keywords]
+    if json_out:
+        cmd += ['-result-format', 'json']
+    if debug:
+        write_out(" ".join(cmd))
     return subp(cmd)
 
 # This is copied from the upstream python os.path.expandvars

--- a/bash/atomic
+++ b/bash/atomic
@@ -554,6 +554,7 @@ _atomic_diff() {
 		--help
 		--json
 	--display
+	--keywords, -k
 	--metadata, -m
 	--names-only
 	--no-files -n

--- a/docs/atomic-diff.1.md
+++ b/docs/atomic-diff.1.md
@@ -25,6 +25,13 @@ but there are switches for comparing RPMs and metadata as well.
 **--json**
   Output in the form of JSON.
 
+**-k** **--keywords**
+  Use the following keywords for comparison of files.  You must select at least one but multiple can
+  be used as well. Keywords that are used for this option are exclusive, which means that any only those
+  keywords will be used.
+  
+  Keywords currently defined are: **all**, **link**, **nlink**, **mode**, **type**, **time**, **uid**, **gid**, **size**, **sha256digest**
+
 **-m** **--metadata**
   Show the differences in the metadata for the two images or containers.
   
@@ -41,6 +48,7 @@ but there are switches for comparing RPMs and metadata as well.
 **-v** **--verbose**
   Be verbose in showing the differences in RPMs.  The default will only show the differences in RPMs, whereas
   with **verbose** it will show all the RPMS in each object.
+  
 
 
 # EXAMPLES
@@ -63,6 +71,10 @@ Compare the files and RPMs (without versions) in images 'foo1' and 'foo2' and ou
 Compare only the metadata between images 'foo1' and 'foo2'
 
     atomic diff -m foo1 foo2
+    
+Compare files by 'sha256digests' and 'time' between images 'foo1' and 'foo2'
+
+    atomic diff foo1 foo2 --keywords sha256digest time
 
 # HISTORY
 Updated by Brent Baude (bbaude at redhat dot com) Nov 2016

--- a/tests/integration/test_diff.sh
+++ b/tests/integration/test_diff.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -x
 set -euo pipefail
 IFS=$'\n\t'
+GOMTREE='/usr/bin/gomtree'
 
 # Test scripts run with PWD=tests/..
 
@@ -34,6 +35,9 @@ teardown () {
 # logic can be added to a "cleanup stack", by cascading function calls
 # within traps. See tests/integration/test_mount.sh for an example.
 trap teardown EXIT
+if [ ! -e ${GOMTREE} ]; then
+	exit 77
+fi
 
 setup
 


### PR DESCRIPTION
The previous algorithm for comparing files used python's
dircmp and is considered to be a shallow comparision.  This
allowed distinctly small possibilities that two files being
compared could be different but not caught.

We now use go-mtree to do the comparison.  This can emulate the
shallow comparison we had before but we can also adding a
sha256digest as part of the comparison using the new --keywords
option.

Also, made slight tweaks to gomtree functions in Atomic.util
so we debug and influence the return of JSON data.

This solves https://github.com/projectatomic/atomic/issues/761