### PR TITLE
[merged] syscontainers: fix tarfile import with no RepoTags

### DIFF
--- a/Atomic/backends/_ostree.py
+++ b/Atomic/backends/_ostree.py
@@ -64,7 +64,9 @@ class OSTreeBackend(Backend):
         img_obj.version = img_obj.get_label("Version")
         img_obj.release = img_obj.get_label("Release")
         ostree_manifest = self.syscontainers.get_manifest(image)
-        img_obj.digest = None if ostree_manifest is None else json_loads(ostree_manifest).get('Digest', None)
+        if ostree_manifest:
+            ostree_manifest = json_loads(ostree_manifest)
+        img_obj.digest = None if ostree_manifest is None else ostree_manifest.get('Digest') or ostree_manifest.get('digest')
         img_obj.os = img_obj.get_label("Os")
         img_obj.arch = img_obj.get_label("Arch")
         img_obj.graph_driver = None

--- a/Atomic/objects/layer.py
+++ b/Atomic/objects/layer.py
@@ -60,8 +60,6 @@ class Layer(object):
             if self.version:
                 _version += "-"
             _version += "{}".format(self.release)
-        if not _version and self.backend.backend == 'ostree':
-            return no_shaw(self.digest)
-        if not _version and self.backend.backend == 'docker':
-            return no_shaw(self.id)
+        if not _version:
+            return no_shaw(self.id or self.digest)
         return _version

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -956,6 +956,7 @@ class SystemContainers(object):
                 ref = OSTree.parse_refspec(k)
                 util.write_out("Deleting %s" % k)
                 repo.set_ref_immediate(ref[1], ref[2], None)
+        repo.prune(OSTree.RepoPruneFlags.NONE, -1)
 
     @staticmethod
     def get_default_system_name(image):

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -665,6 +665,8 @@ class SystemContainers(object):
         if containers is None:
             containers = os.listdir(checkouts)
         for x in containers:
+            if x[0] == ".":
+                continue
             fullpath = os.path.join(checkouts, x)
             if not os.path.islink(fullpath):
                 continue
@@ -1021,8 +1023,7 @@ class SystemContainers(object):
             layers = manifest.get("Layers")
         return layers
 
-    @staticmethod
-    def _import_layers_into_ostree(repo, imagebranch, manifest, layers):
+    def _import_layers_into_ostree(self, repo, imagebranch, manifest, layers):
         repo.prepare_transaction()
         for layer, tar in layers.items():
             mtree = OSTree.MutableTree()
@@ -1049,8 +1050,10 @@ class SystemContainers(object):
                     raise e  #pylint: disable=raising-non-exception
 
             if not imported:
+                checkout = self._get_system_checkout_path()
+                destdir = checkout if os.path.exists(checkout) else None
                 try:
-                    temp_dir = tempfile.mkdtemp()
+                    temp_dir = tempfile.mkdtemp(prefix=".", dir=destdir)
                     with tarfile.open(tar, 'r') as t:
                         t.extractall(temp_dir)
                     repo.write_directory_to_mtree(Gio.File.new_for_path(temp_dir), mtree, modifier)
@@ -1161,7 +1164,7 @@ class SystemContainers(object):
                             layer = f.replace(".tar", "")
                             if not repo.resolve_rev("%s%s" % (OSTREE_OCIIMAGE_PREFIX, layer), True)[1]:
                                 layers_to_import[layer] = layer_file
-            SystemContainers._import_layers_into_ostree(repo, imagebranch, manifest, layers_to_import)
+            self._import_layers_into_ostree(repo, imagebranch, manifest, layers_to_import)
         finally:
             if layers_dir:
                 shutil.rmtree(layers_dir)
@@ -1273,7 +1276,7 @@ class SystemContainers(object):
         layers_to_import = {}
         for k, v in layers.items():
             layers_to_import[layers_map[k]] = v
-        SystemContainers._import_layers_into_ostree(repo, imagebranch, manifest, layers_to_import)
+        self._import_layers_into_ostree(repo, imagebranch, manifest, layers_to_import)
 
     def validate_layer(self, layer):
         ret = []

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -279,28 +279,32 @@ class SystemContainers(object):
             raise e
 
     # Accept both name and version Id, and return the ostree rev
-    def _resolve_image(self, repo, img):
+    def _resolve_image(self, repo, img, allow_multiple=False):
         imagebranch = SystemContainers._get_ostree_image_branch(img)
         rev = repo.resolve_rev(imagebranch, True)[1]
         if rev:
-            return imagebranch, rev
+            return [(imagebranch, rev)]
 
         # if we could not find an image with the specified name, check if it is the prefix
         # of an ID, and allow it only for tagged images.
         if not str.isalnum(str(img)):
-            return None, None
+            return None
 
         tagged_images = [i for i in self.get_system_images(get_all=True, repo=repo) if i['RepoTags']]
         matches = [i for i in tagged_images if i['Id'].startswith(img)]
-        if len(matches) == 1:
-            # only one image, use it
-            i = matches[0]
-            imagebranch = "%s%s" % (OSTREE_OCIIMAGE_PREFIX, SystemContainers._encode_to_ostree_ref(i['RepoTags'][0]))
-            return imagebranch, i['OSTree-rev']
-        elif len(matches) > 1:
+
+        if len(matches) == 0:
+            return None
+
+        if len(matches) > 1 and not allow_multiple:
             # more than one match, error out
             raise ValueError("more images matching prefix `%s`" % img)
-        return None, None
+
+        # only one image, use it
+        def get_image(i):
+            imagebranch = "%s%s" % (OSTREE_OCIIMAGE_PREFIX, SystemContainers._encode_to_ostree_ref(i['RepoTags'][0]))
+            return imagebranch, i['OSTree-rev']
+        return [get_image(i) for i in matches]
 
     def _do_checkout(self, repo, name, img, upgrade, values, destination, unitfileout, tmpfilesout, extract_only, remote):
         if not values:
@@ -308,9 +312,11 @@ class SystemContainers(object):
 
         remote_path = self._resolve_remote_path(remote)
 
-        _, rev = self._resolve_image(repo, img)
-        if rev is None:
+        imgs = self._resolve_image(repo, img)
+        if imgs is None:
             raise ValueError("Image %s not found" % img)
+
+        _, rev = imgs[0]
 
         if remote_path:
             remote_rootfs = os.path.join(remote_path, "rootfs")
@@ -688,10 +694,10 @@ class SystemContainers(object):
 
     def get_template_variables(self, image):
         repo = self._get_ostree_repo()
-        _, commit_rev = self._resolve_image(repo, image)
-        if not commit_rev:
+        imgs = self._resolve_image(repo, image)
+        if not imgs:
             return
-
+        _, commit_rev = imgs[0]
         manifest = self._image_manifest(repo, commit_rev)
         layers = SystemContainers.get_layers_from_manifest(json.loads(manifest))
         templates = {}
@@ -753,11 +759,12 @@ class SystemContainers(object):
         repo = self._get_ostree_repo()
         if not repo:
             return
-        imagebranch, commit_rev = self._resolve_image(repo, image)
-        if not commit_rev:
+        imgs = self._resolve_image(repo, image, allow_multiple=True)
+        if not imgs:
             return
-        ref = OSTree.parse_refspec(imagebranch)
-        repo.set_ref_immediate(ref[1], ref[2], None)
+        for imagebranch, _ in imgs:
+            ref = OSTree.parse_refspec(imagebranch)
+            repo.set_ref_immediate(ref[1], ref[2], None)
 
     def inspect_system_image(self, image):
         repo = self._get_ostree_repo()
@@ -769,9 +776,10 @@ class SystemContainers(object):
         if imagebranch.startswith(OSTREE_OCIIMAGE_PREFIX):
             commit_rev = repo.resolve_rev(imagebranch, False)[1]
         else:
-            _, commit_rev = self._resolve_image(repo, imagebranch)
-            if commit_rev is None:
+            imgs = self._resolve_image(repo, imagebranch, allow_multiple=True)
+            if imgs is None:
                 raise ValueError("Image %s not found" % imagebranch)
+            _, commit_rev = imgs[0]
         commit = repo.load_commit(commit_rev)[1]
 
         branch_id = SystemContainers._decode_from_ostree_ref(imagebranch.replace(OSTREE_OCIIMAGE_PREFIX, ""))
@@ -1245,8 +1253,7 @@ class SystemContainers(object):
         repo = self._get_ostree_repo()
         if not repo:
             return False
-        _, rev = self._resolve_image(repo, img)
-        return True if rev else False
+        return bool(self._resolve_image(repo, img, allow_multiple=True))
 
     def _pull_dockertar_layers(self, repo, imagebranch, temp_dir, input_layers, labels=None):
         layers = {}

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -139,7 +139,8 @@ class SystemContainers(object):
         elif image.startswith("docker:"):
             image = self._pull_docker_image(repo, image.replace("docker:", "", 1))
         elif image.startswith("dockertar:"):
-            image = self._pull_docker_tar(repo, image.replace("dockertar:", "", 1))
+            tarpath = image.replace("dockertar:", "", 1)
+            image = self._pull_docker_tar(repo, tarpath, os.path.basename(tarpath).replace(".tar", ""))
         else: # Assume "oci:"
             self._check_system_oci_image(repo, image, upgrade)
         return image
@@ -1086,12 +1087,12 @@ class SystemContainers(object):
     def _pull_docker_image(self, repo, image):
         with tempfile.NamedTemporaryFile(mode="w") as temptar:
             util.check_call(["docker", "save", "-o", temptar.name, image])
-            return self._pull_docker_tar(repo, temptar.name)
+            return self._pull_docker_tar(repo, temptar.name, image)
 
-    def _pull_docker_tar(self, repo, image):
+    def _pull_docker_tar(self, repo, tarpath, image):
         temp_dir = tempfile.mkdtemp()
         try:
-            with tarfile.open(image, 'r') as t:
+            with tarfile.open(tarpath, 'r') as t:
                 t.extractall(temp_dir)
                 manifest_file = os.path.join(temp_dir, "manifest.json")
                 if os.path.exists(manifest_file):
@@ -1104,7 +1105,7 @@ class SystemContainers(object):
                             with open(config_file, 'r') as config:
                                 config = json.loads(config.read())
                                 labels = config['config']['Labels']
-                        imagename = m["RepoTags"][0]
+                        imagename = m["RepoTags"][0] if m.get("RepoTags") else image
                         imagebranch = "%s%s" % (OSTREE_OCIIMAGE_PREFIX, SystemContainers._encode_to_ostree_ref(imagename))
                         input_layers = m["Layers"]
                         self._pull_dockertar_layers(repo, imagebranch, temp_dir, input_layers, labels=labels)

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -791,6 +791,8 @@ class SystemContainers(object):
             if 'Labels' in manifest:
                 labels = manifest['Labels']
 
+            if 'config' in manifest:
+                image_id = manifest['config']['digest'].replace("sha256:", "")
             if 'Digest' in manifest:
                 image_id = manifest['Digest'].replace("sha256:", "")
 
@@ -981,17 +983,17 @@ class SystemContainers(object):
         with AtomicDocker() as client:
             fqn_image = util.find_remote_image(client, image) or image
             if insecure:
-                return ["--insecure"], "docker://" + fqn_image
+                return ["--insecure", "--raw"], "docker://" + fqn_image
             else:
-                return [], "docker://" + fqn_image
+                return ["--raw"], "docker://" + fqn_image
 
     def _skopeo_get_manifest(self, image):
         args, img = self._convert_to_skopeo(image)
         return util.skopeo_inspect(img, args)
 
     def _skopeo_get_layers(self, image, layers):
-        args, img = self._convert_to_skopeo(image)
-        return util.skopeo_layers(img, args, layers)
+        _, img = self._convert_to_skopeo(image)
+        return util.skopeo_layers(img, [], layers)
 
     def _image_manifest(self, repo, rev):
         return SystemContainers._get_commit_metadata(repo, rev, "docker.manifest")
@@ -1019,6 +1021,8 @@ class SystemContainers(object):
         if fs_layers:
             layers = list(i["blobSum"] for i in fs_layers)
             layers.reverse()
+        elif "layers" in manifest:
+            layers = [x['digest'] for x in manifest.get("layers")]
         else:
             layers = manifest.get("Layers")
         return layers

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 PREFIX ?= $(DESTDIR)/usr
 SYSCONFDIR ?= $(DESTDIR)/etc/sysconfig
 PROFILEDIR ?= $(DESTDIR)/etc/profile.d
-PYTHON ?= /usr/bin/python
-PYTHON3 ?= /usr/bin/python3
+export PYTHON ?= /usr/bin/python
+export PYTHON3 ?= /usr/bin/python3
 PYLINT ?= $(PYTHON) -m pylint
 PYTHON3_PYLINT ?= $(PYTHON3) -m pylint
 GO_MD2MAN ?= /usr/bin/go-md2man

--- a/tests/integration/test_system_containers.sh
+++ b/tests/integration/test_system_containers.sh
@@ -266,7 +266,8 @@ ostree --repo=${ATOMIC_OSTREE_REPO} refs | grep busybox
 ${ATOMIC} verify --storage ostree busybox > verify.out
 assert_not_matches "contains images or layers that have updates" verify.out
 
-image_digest=$(ostree --repo=${ATOMIC_OSTREE_REPO} show --print-metadata-key=docker.manifest ociimage/busybox_3Alatest | sed -e"s|.*digest\": \"sha256:\([a-z0-9]\+\).*|\1|" | head -c 12)
+image_digest=$(ostree --repo=${ATOMIC_OSTREE_REPO} show --print-metadata-key=docker.manifest ociimage/busybox_3Alatest | \
+                   $PYTHON -c 'import json, sys; print(json.loads(sys.stdin.read().strip()[1:-1])["config"]["digest"].replace("sha256:", "")[:12])')
 ${ATOMIC} images list > images.out
 grep "busybox.*$image_digest" images.out
 

--- a/tests/integration/test_system_containers.sh
+++ b/tests/integration/test_system_containers.sh
@@ -253,7 +253,7 @@ assert_matches busybox refs
 ${ATOMIC} --assumeyes images delete -f --storage ostree docker.io/busybox
 
 BUSYBOX_IMAGE_ID=$(${ATOMIC} images list -f type=ostree | grep busybox | awk '{print $3}')
-${ATOMIC} --assumeyes images delete -f ${BUSYBOX_IMAGE_ID}
+${ATOMIC} --assumeyes images delete -f --storage=ostree ${BUSYBOX_IMAGE_ID}
 
 ostree --repo=${ATOMIC_OSTREE_REPO} refs > refs
 OUTPUT=$(! grep -c busybox refs)
@@ -266,7 +266,7 @@ ostree --repo=${ATOMIC_OSTREE_REPO} refs | grep busybox
 ${ATOMIC} verify --storage ostree busybox > verify.out
 assert_not_matches "contains images or layers that have updates" verify.out
 
-image_digest=$(ostree --repo=${ATOMIC_OSTREE_REPO} show --print-metadata-key=docker.manifest ociimage/busybox_3Alatest | sed -e"s|.*Digest\": \"sha256:\([a-z0-9]\+\).*|\1|" | head -c 12)
+image_digest=$(ostree --repo=${ATOMIC_OSTREE_REPO} show --print-metadata-key=docker.manifest ociimage/busybox_3Alatest | sed -e"s|.*digest\": \"sha256:\([a-z0-9]\+\).*|\1|" | head -c 12)
 ${ATOMIC} images list > images.out
 grep "busybox.*$image_digest" images.out
 


### PR DESCRIPTION
Fix import from a tarball when the manifest from Skopeo does not
specify the RepoTags.  In that case use the name given as input by
the user.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>