### PR TITLE
[merged] Atomic/top.py: Fix options handling in top

### DIFF
--- a/Atomic/top.py
+++ b/Atomic/top.py
@@ -23,7 +23,8 @@ def cli(subparser):
                                 help=_("Show top-like stats about processes running in containers"))
     topp.set_defaults(_class=Top, func='atomic_top')
     topp.add_argument("-d", type=int, default=1, help=_("Interval (secs) to refresh process information"))
-    topp.add_argument("-o", "--optional", help=_("Additional fields to display"), nargs='?', choices=['time', 'stime', 'ppid', 'uid', 'gid', 'user', 'group'])
+    topp.add_argument("-o", "--optional", help=_("Additional fields to display"), nargs='?', action='append',
+                      choices=['time', 'stime', 'ppid', 'uid', 'gid', 'user', 'group'])
     topp.add_argument("-n", help=_("Number of iterations"), type=check_negative)
     topp.add_argument("containers", nargs="*", help=_("list of containers to monitor, leave blank for all"))
 

--- a/docs/atomic-top.1.md
+++ b/docs/atomic-top.1.md
@@ -34,6 +34,8 @@ Like top, you can exit the interactive view and return to the command line, use 
 **-o** **--optional**
   Add more fields of data to collect for each process.  The fields resemble fields commonly used by
   ps -o.  They currently are: [time, stime, ppid, uid, gid, user, group]
+  
+  Specify one option per -o flag to include the fields.
 
 # EXAMPLES
 Monitor processes with default fields.
@@ -46,7 +48,7 @@ Monitor processes with default fields on a 5 second interval for 3 iterations
 
 Monitor processes and add in the data for the parent PIDs and UID.
 
-    atomic top -o ppid uid
+    atomic top -o ppid -o uid
 
 # HISTORY
 December 2015, Originally written by Brent Baude (bbaude at redhat dot com)


### PR DESCRIPTION
Fix the behaviour for atomic top where if you want to include
additional fields to monitor, you now specificy one field per
-o switch.  For example:

atomic top -o ppid -o time