### PR TITLE
Ignore sigstore trust delete when no sigstore config exists

### DIFF
--- a/Atomic/trust.py
+++ b/Atomic/trust.py
@@ -245,6 +245,8 @@ class Trust(Atomic):
         """
         with open(reg_file, mode) as f:
             d = yaml.load(f)
+            if not d:
+                return
             if not sigstore:
                 del d[sstype][registry]
             else:


### PR DESCRIPTION
Resolves #781 