### PR TITLE
[merged] Unify and refactor atomic verify

### DIFF
--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -76,9 +76,10 @@ class DockerBackend(Backend):
 
     def _make_image(self, image, img_struct, deep=False, remote=False):
         img_obj = Image(image, remote=remote)
+        img_obj.backend = self
+
         if not remote:
             img_obj.id = img_struct['Id']
-            img_obj.backend = self
             img_obj.repotags = img_struct['RepoTags']
             img_obj.created = img_struct['Created']
             img_obj.size = img_struct['Size']
@@ -262,7 +263,9 @@ class DockerBackend(Backend):
         return self.get_layers(image)
 
     def get_layer(self, image):
-        return Layer(self.inspect_image(image))
+        _layer = Layer(self.inspect_image(image))
+        _layer.remote = image.remote
+        return _layer
 
     def get_layers(self, image):
         layers = []

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -828,6 +828,14 @@ class Decompose(object):
         return self._digest
 
     @property
+    def no_tag(self):
+        result = self._registry
+        if self._repo:
+            result += "/{}".format(self._repo)
+        result += "/{}".format(self._image)
+        return result
+
+    @property
     def all(self):
         return self._registry, self._repo, self._image, self._tag, self._digest
 

--- a/atomic_dbus.py
+++ b/atomic_dbus.py
@@ -553,7 +553,7 @@ class atomic_dbus(slip.dbus.service.Object):
             args.image = image
             verify.set_args(args)
             verifications.append({"Image": image,
-                                  "Verification": verify.verify()}) #pylint: disable=no-member
+                                  "Verification": verify.verify_dbus()}) #pylint: disable=no-member
         return json.dumps(verifications)
 
     # atomic version section

--- a/docs/atomic-images.1.md
+++ b/docs/atomic-images.1.md
@@ -45,11 +45,11 @@ You can also use any of the many options to create the help file including using
   Prune/delete all **dangling** images, freeing wasted disk space.
 
 **verify**
-  Checks whether there is a newer image available and scans through all layers to see if any of the layers, which are  base  images themselves,  have a new version available.  If the tool finds an out of date image, it will report as such. If the image is a system image,  it will  also look through the layers and validate each layer to determine if it has been tampered with and output details of these changes (if at all).
+  Checks whether there is a newer image available.   If the image differs, it will capture any of its relevant information like version (where applicable).
 
-  If the image or any of its layers are pulled from a repository, it will attempt to check the repository to see if there is a new image and capture any of its relevant information like version (where applicable).
-
-  Any  images  that do not possess a Version LABEL cannot be compared for available updates.  If an image lacks the version information, it  will still be part of the layer descriptions but will be cited as not having the version information.
+  Verify will always attempt to use the **Version** and **Release** labels to determine if there is a newer version.  If that information is not
+  available, then for 'ostree' images, verify will compare using the manifest digests.  In the case of docker images, it will use the image's ID
+  for comparison.
 
 **version**
   Display image 'Id Name:Version:Release RepoTag' label

--- a/tests/integration/test_info.sh
+++ b/tests/integration/test_info.sh
@@ -2,6 +2,12 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+# The debug information will cause test failures because
+# the force arg will be different.  This messes up the
+# equality testing between a remote and local image.
+# Removing the --debug 
+ATOMIC=$(grep -v -- --debug <<< "$ATOMIC")
+
 EXPECTED_T1="Checksum: $(sha256sum ./tests/test-images/Dockerfile.1)"
 
 validTest1 () {
@@ -26,7 +32,7 @@ set -e
 echo $TEST_1
 
 if [[ "${HAS_REMOTE}" -eq 0 ]]; then
-    if [[ "${TEST_CENTOS_REMOTE}" != "${TEST_CENTOS}" ]]; then
+    if [[ ${TEST_CENTOS_REMOTE} != ${TEST_CENTOS} ]]; then
         exit 1
     fi
 fi

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -49,7 +49,7 @@ class TestDockerBackend(unittest.TestCase):
         db = DockerBackend()
         db._inspect_image = MagicMock(return_value=_rsyslog_image_inspect)
         img_obj = db.inspect_image('registry.access.redhat.com/rhel7/rsyslog:latest')
-        self.assertEqual(img_obj.long_version, "rhel7/rsyslog-7.3-8")
+        self.assertEqual(img_obj.long_version, "7.3-8")
 
     def test_inspect_container(self):
         db = DockerBackend()

--- a/tests/unit/test_images.py
+++ b/tests/unit/test_images.py
@@ -5,6 +5,8 @@ from Atomic.backends._docker import DockerBackend
 from Atomic.backends._ostree import OSTreeBackend
 from Atomic.info import Info
 from Atomic.images import Images
+from Atomic.verify import Verify
+from Atomic.objects.image import Image
 
 no_mock = True
 try:
@@ -25,10 +27,10 @@ _ostree_centos_result = 'Image Name: docker.io/library/centos:latest\nbuild-date
 _centos_ostree_inspect = {'Version': 'centos', 'Labels': {u'build-date': u'20161102', u'vendor': u'CentOS', u'name': u'CentOS Base Image', u'license': u'GPLv2'}, 'Names': [], 'Created': 1480352808, 'OSTree-rev': 'd2122127d30f94ae12ebe5afa542abdb1870201b0b9750bae3ceb74aa6ed18e6', 'RepoTags': ['centos'], 'Id': u'b2f9d1c0ff5f87a4743104d099a3d561002ac500db1b9bfa02a783a46e0d366c', 'ImageType': 'system', 'ImageId': u'b2f9d1c0ff5f87a4743104d099a3d561002ac500db1b9bfa02a783a46e0d366c'}
 _rhel_docker_inspect = {u'Comment': u'', u'Container': u'', u'DockerVersion': u'1.9.1', u'Parent': u'', u'Created': u'2016-10-26T12:02:33.368772Z', u'Config': {u'Tty': False, u'Cmd': [u'/bin/bash'], u'Volumes': None, u'Domainname': u'', u'WorkingDir': u'', u'Image': u'f6f6121b053b2312688c87d3a1d32d06a984dc01d2ea7738508a50581cddb6b4', u'Hostname': u'', u'StdinOnce': False, u'Labels': {u'com.redhat.component': u'rhel-server-docker', u'authoritative-source-url': u'registry.access.redhat.com', u'distribution-scope': u'public', u'Vendor': u'Red Hat, Inc.', u'Name': u'rhel7/rhel', u'Build_Host': u'rcm-img01.build.eng.bos.redhat.com', u'vcs-type': u'git', u'name': u'rhel7/rhel', u'vcs-ref': u'7eeaf203cf909c2c056fba7066db9c1073a28d97', u'release': u'45', u'Version': u'7.3', u'Architecture': u'x86_64', u'version': u'7.3', u'Release': u'45', u'vendor': u'Red Hat, Inc.', u'BZComponent': u'rhel-server-docker', u'build-date': u'2016-10-26T07:54:17.037911Z', u'com.redhat.build-host': u'ip-10-29-120-48.ec2.internal', u'architecture': u'x86_64'}, u'AttachStdin': False, u'User': u'', u'Env': [u'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', u'container=docker'], u'Entrypoint': None, u'OnBuild': [], u'AttachStderr': False, u'AttachStdout': False, u'OpenStdin': False}, u'Author': u'Red Hat, Inc.', u'GraphDriver': {u'Data': {u'DeviceName': u'docker-253:2-5900125-a2bce97a4fd7ea12dce9865caa461ead8d1caf51ef452aba2f1b9d98efdf968f', u'DeviceSize': u'10737418240', u'DeviceId': u'623'}, u'Name': u'devicemapper'}, u'VirtualSize': 192508958, u'Os': u'linux', u'Architecture': u'amd64', u'RootFS': {u'Layers': [u'34d3e0e77091d9d51c6f70a7a7a4f7536aab214a55e02a8923af8f80cbe60d30', u'ccd6fc81ec49bd45f04db699401eb149b1945bb7292476b390ebdcdd7d975697'], u'Type': u'layers'}, u'ContainerConfig': {u'Tty': False, u'Cmd': None, u'Volumes': None, u'Domainname': u'', u'WorkingDir': u'', u'Image': u'', u'Hostname': u'', u'StdinOnce': False, u'Labels': None, u'AttachStdin': False, u'User': u'', u'Env': None, u'Entrypoint': None, u'OnBuild': None, u'AttachStderr': False, u'AttachStdout': False, u'OpenStdin': False}, u'Size': 192508958, u'RepoDigests': [u'registry.access.redhat.com/rhel7@sha256:da8a3e9297da7ccd1948366103d13c45b7e77489382351a777a7326004b63a21'], u'Id': u'f98706e16e41e56c4beaeea9fa77cd00fe35693635ed274f128876713afc0a1e', u'RepoTags': [u'registry.access.redhat.com/rhel7:latest']}
 _rhel_version_result = 'IMAGE NAME                                       VERSION           IMAGE ID  \nregistry.access.redhat.com/rhel7:latest          rhel7/rhel-7.3-45 f98706e16e41\n'
-_rhel_version_json = [{'Image': ['registry.access.redhat.com/rhel7:latest'], 'iid': 'f98706e16e41e56c4beaeea9fa77cd00fe35693635ed274f128876713afc0a1e', 'Version': 'rhel7/rhel-7.3-45'}]
+_rhel_version_json = [{'Image': ['registry.access.redhat.com/rhel7:latest'], 'iid': 'f98706e16e41e56c4beaeea9fa77cd00fe35693635ed274f128876713afc0a1e', 'Version': '7.3-45'}]
 _rhel_ostree_inspect = {'Created': 1480459483, 'RepoTags': ['registry.access.redhat.com/rhel7'], 'ImageId': 'da8a3e9297da7ccd1948366103d13c45b7e77489382351a777a7326004b63a21', 'OSTree-rev': 'a5840a53b233fdb936de8bcd35c77007b9af2d446ebabce6a2716772d6f089bd', 'Names': [], 'Id': 'da8a3e9297da7ccd1948366103d13c45b7e77489382351a777a7326004b63a21', 'Labels': {'name': 'rhel7/rhel', 'vendor': 'Red Hat, Inc.', 'authoritative-source-url': 'registry.access.redhat.com', 'version': '7.3', 'com.redhat.component': 'rhel-server-docker', 'distribution-scope': 'public', 'Name': 'rhel7/rhel', 'Architecture': 'x86_64', 'Version': '7.3', 'Vendor': 'Red Hat, Inc.', 'build-date': '2016-10-26T07:54:17.037911Z', 'com.redhat.build-host': 'ip-10-29-120-48.ec2.internal', 'Release': '45', 'BZComponent': 'rhel-server-docker', 'release': '45', 'vcs-type': 'git', 'Build_Host': 'rcm-img01.build.eng.bos.redhat.com', 'vcs-ref': '7eeaf203cf909c2c056fba7066db9c1073a28d97', 'architecture': 'x86_64'}, 'Version': 'registry.access.redhat.com/rhel7', 'ImageType': 'system'}
 _rhel_ostree_version_result = 'IMAGE NAME                                VERSION                                 IMAGE ID  \nregistry.access.redhat.com/rhel7          registry.access.redhat.com/rhel7-7.3-45 da8a3e9297da\n'
-_rhel_ostree_json = [{'iid': 'da8a3e9297da7ccd1948366103d13c45b7e77489382351a777a7326004b63a21', 'Image': ['registry.access.redhat.com/rhel7'], 'Version': 'registry.access.redhat.com/rhel7-7.3-45'}]
+_rhel_ostree_json = [{'Image': ['registry.access.redhat.com/rhel7'], 'iid': 'da8a3e9297da7ccd1948366103d13c45b7e77489382351a777a7326004b63a21', 'Version': '7.3-45'}]
 
 
 
@@ -122,3 +124,50 @@ class TestImages(unittest.TestCase):
         return_value = images.display_all_image_info()
         self.assertEqual(return_value, 0)
 
+
+remote_centos_inspect_latest = {'Layers': [u'sha256:08d48e6f1cff259389732d35307bb877215fa28867cdaff50c1dbd6e0b993c1f'], 'Name': 'docker.io/library/centos', 'Created': u'2016-11-02T19:52:09.463959047Z', 'Architecture': u'amd64', 'Os': u'linux', 'id': u'sha256:0584b3d2cf6d235ee310cf14b54667d889887b838d3f3d3033acd70fc3c48b8a', 'RepoTags': [u'5.11', u'5', u'6.6', u'6.7', u'6.8', u'6', u'7.0.1406', u'7.1.1503', u'7.2.1511', u'7', u'centos5.11', u'centos5', u'centos6.6', u'centos6.7', u'centos6.8', u'centos6', u'centos7.0.1406', u'centos7.1.1503', u'centos7.2.1511', u'centos7', u'latest'], 'DockerVersion': u'1.12.1', 'Labels': {u'build-date': u'20161102', u'vendor': u'CentOS', u'name': u'CentOS Base Image', u'license': u'GPLv2'}, 'Tag': 'latest', 'Digest': 'sha256:b2f9d1c0ff5f87a4743104d099a3d561002ac500db1b9bfa02a783a46e0d366c'}
+local_centos_inspect_old = {'Id': '16e9fdecc1febc87fb1ca09271009cf5f28eb8d4aec5515922ef298c145a6726', 'RepoDigests': ['docker.io/centos@sha256:7793b39617b28c6cd35774c00383b89a1265f3abf6efcaf0b8f4aafe4e0662d2'], 'Parent': '', 'GraphDriver': {'Name': 'devicemapper', 'Data': {'DeviceSize': '10737418240', 'DeviceName': 'docker-253:2-5900125-3fb5b406e6a53142129237c9e2c3a1ce8b6cf269b5f8071fcd62107c41544cd2', 'DeviceId': '779'}}, 'Created': '2016-08-30T18:20:19.39890162Z', 'Comment': '', 'DockerVersion': '1.12.1', 'VirtualSize': 210208812, 'Author': 'The CentOS Project <cloud-ops@centos.org> - ami_creator', 'Os': 'linux', 'RootFS': {'Type': 'layers', 'Layers': ['5fa0fa02637842ab1ddc8b3a17b86691c87c87d20800e6a95a113343f6ffd84c']}, 'Container': 'a5b0819aa82c224095e1a18e9df0776a7b38d32bacca073f054723b65fb54f0e', 'Architecture': 'amd64', 'RepoTags': ['docker.io/centos:centos7.0.1406'], 'Config': {'Labels': {}, 'Entrypoint': None, 'StdinOnce': False, 'OnBuild': None, 'Env': ['PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'], 'Volumes': None, 'Cmd': None, 'User': '', 'AttachStdin': False, 'AttachStderr': False, 'AttachStdout': False, 'WorkingDir': '', 'Tty': False, 'Image': '20ae10d641a0af6f25ceaa75fdcf591d171e3c521a54a3f3a2868b602d735e11', 'Hostname': 'a5b0819aa82c', 'Domainname': '', 'OpenStdin': False}, 'Size': 210208812, 'ContainerConfig': {'Labels': {}, 'Entrypoint': None, 'StdinOnce': False, 'OnBuild': None, 'Env': ['PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'], 'Volumes': None, 'Cmd': ['/bin/sh', '-c', '#(nop) ADD file:6a409eac27f0c7e04393da096dbeff01b929405e79b15222a0dc06a2084d3df3 in / '], 'User': '', 'AttachStdin': False, 'AttachStderr': False, 'AttachStdout': False, 'WorkingDir': '', 'Tty': False, 'Image': '20ae10d641a0af6f25ceaa75fdcf591d171e3c521a54a3f3a2868b602d735e11', 'Hostname': 'a5b0819aa82c', 'Domainname': '', 'OpenStdin': False}}
+docker_dbus_result = [{'differs': False, 'local_version': '0584b3d2cf6d235ee310cf14b54667d889887b838d3f3d3033acd70fc3c48b8a', 'name': 'centos', 'remote_version': '0584b3d2cf6d235ee310cf14b54667d889887b838d3f3d3033acd70fc3c48b8a'}]
+
+
+@unittest.skipIf(no_mock, "Mock not found")
+class TestVerify(unittest.TestCase):
+    class Args():
+        def __init__(self):
+            self.storage = None
+            self.debug = False
+            self.name = None
+            self.image = None
+
+    def test_verify_docker_same(self):
+        with patch('Atomic.backendutils.BackendUtils.get_backend_and_image') as mockobj:
+            args = self.Args()
+            args.storage = 'docker'
+            args.image = 'docker.io/library/centos:latest'
+            db = DockerBackend()
+            db._inspect_image = MagicMock(return_value=_centos_inspect_image)
+            local_image_object = db.inspect_image(args.image)
+            mockobj.return_value = (db, local_image_object)
+            v = Verify()
+            v.set_args(args)
+            Image.remote_inspect = MagicMock(return_value=remote_centos_inspect_latest)
+            self.assertEqual(v.verify_dbus(), docker_dbus_result)
+
+    def test_verify_docker_diff(self):
+        with patch('Atomic.backendutils.BackendUtils.get_backend_and_image') as mockobj:
+            args = self.Args()
+            args.storage = 'docker'
+            args.image = 'docker.io/library/centos:centos7.0.1406'
+            db = DockerBackend()
+            db._inspect_image = MagicMock(return_value=local_centos_inspect_old)
+            local_image_object = db.inspect_image(args.image)
+            mockobj.return_value = (db, local_image_object)
+            v = Verify()
+            v.set_args(args)
+            Image.remote_inspect = MagicMock(return_value=remote_centos_inspect_latest)
+            self.assertNotEqual(v.verify_dbus(), docker_dbus_result)
+
+    def test_verify_ostree_same(self):
+        # I hit some issue with syscontainers here.  Will leave until that issue
+        # can be resolved with guiseppe
+        pass


### PR DESCRIPTION
Using our refactoring model, verify is now streamlined. We no longer
compare base images as that is not currently possible for both
V1 and V2 schemas.

Verify will now always look at the release and version labels for
comparison.  Should those labels not exist, it will use the
manifest digest for ostree; and it will use the image IDs for
docker.