### PR TITLE
[merged] redhat-ci: make testsuites required

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -8,6 +8,8 @@ host:
 
 context: fedora/24/atomic
 
+required: true
+
 tests:
   - ./.redhat-ci.sh
 


### PR DESCRIPTION
In preparation for switching Homu over to using the Red Hat CI statuses,
we define all the current testsuites as required. This means that they
will all have to pass before Homu accepts to merge the PR.