### PR TITLE
Atomic.run: allow atomic run to pull image without TLS authentication

### DIFF
--- a/Atomic/run.py
+++ b/Atomic/run.py
@@ -86,7 +86,7 @@ class Run(Atomic):
             if self.args.display:
                 return self.display("Need to pull %s" % self.image)
 
-            self.update()
+            self.pull()
             self.inspect = self._inspect_image()
 
         if self.spc:


### PR DESCRIPTION
At present, the atomic run uses update() to update image, but w/o passing
'--tls-verify=false' argument to update(), which directly call
util.skopeo_copy() and also w/o '--tls-verify=false' argument setting.

This patch is a simple fix, and only replace update() w/ pull(), it looks
like docker run command, if the image doesn't exist then pull the image
automatically.

BZ: 1401842
Signed-off-by: Alex Jia <ajia@redhat.com>