### PR TITLE
[merged] Atomic.delete: fix typos in delete_image()

### DIFF
--- a/Atomic/delete.py
+++ b/Atomic/delete.py
@@ -56,7 +56,7 @@ class Delete(Atomic):
 
         # Perform the delete
         for del_obj in delete_objects:
-            img_obj.backend.delete_image(img_obj.input_name, force=self.args.force)
+            del_obj.backend.delete_image(del_obj.input_name, force=self.args.force)
 
         # We need to return something here for dbus
         return


### PR DESCRIPTION
To try to delete all of images, we will hit error like this
"local variable 'img_obj' referenced before assignment", in
fact, the variable should be 'del_obj', it's a typo.

Signed-off-by: Alex Jia <ajia@redhat.com>


$ atomic images delete -a
Do you wish to delete the following images?

   IMAGE                      STORAGE
   systemd_inside:latest      docker
   e1dc8e08c83b               docker
   aa12bb74b8f6               docker
   docker.io/busybox:latest   docker
   docker.io/fedora:latest    docker

Confirm (y/N) y
local variable 'img_obj' referenced before assignment