### PR TITLE
Atomic/discovery.py: Use login credentials if available to obtain token

### DIFF
--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -97,6 +97,9 @@ class DockerBackend(Backend):
         img_obj = Image(image, remote=remote)
         img_obj.backend = self
 
+        if img_struct is None:
+            return img_obj
+
         if not remote:
             img_obj.id = img_struct['Id']
             img_obj.repotags = img_struct['RepoTags']


### PR DESCRIPTION
In the case of an Atomic registry, we need to obtain a token by using
basic auth.  The login credentials are the same as what is used for
docker login.