### PR TITLE
[merged] Atomic/backends/_docker.py: Throw better error when dockerd not running

### DIFF
--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -22,6 +22,7 @@ class DockerBackend(Backend):
     def __init__(self):
         self.input = None
         self._d = None
+        self._ping()
 
     @property
     def d(self):


### PR DESCRIPTION
When using the Atomic CLI and dockerd wasn't running, the error was
not informative enough.

https://github.com/projectatomic/atomic/issues/831