### PR TITLE
[merged] Atomic/objects/image.py : Fix run when RUN label is present

### DIFF
--- a/Atomic/objects/image.py
+++ b/Atomic/objects/image.py
@@ -278,11 +278,16 @@ class Image(object):
 
     @property
     def command(self):
-        # If self._command has been set, return that value
-        if self._command:
-            return self._command
         run_label = self.get_label('RUN')
-        return run_label if run_label else self.cmd
+        run_command = ''
+        if run_label:
+            run_command += run_label
+        if self._command:
+            try:
+                run_command = run_command.split() + self._command
+            except TypeError:
+                run_command += " {}".format(" ".join(self._command))
+        return run_command
 
     @command.setter
     def command(self, value):


### PR DESCRIPTION
The RUN label was not being used correctly by Atomic CLI and therefore
resulted in incorrect runargs being used. We should be leaning on using
the cmd and entry points as defined and not mess with those in the
building of the command itself.

This was reported in
issue https://github.com/projectatomic/atomic/issues/838.