### PR TITLE
Backend missing

### DIFF
--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -22,7 +22,14 @@ class DockerBackend(Backend):
     def __init__(self):
         self.input = None
         self._d = None
-        self._ping()
+
+    @property
+    def available(self):
+        try:
+            _ = self.d
+            return True
+        except util.NoDockerDaemon:
+            return False
 
     @property
     def d(self):

--- a/Atomic/backends/_ostree.py
+++ b/Atomic/backends/_ostree.py
@@ -24,6 +24,9 @@ class OSTreeBackend(Backend):
     def backend(self):
         return "ostree"
 
+    def available(self):
+        return self.syscontainers.available
+
     def _make_container(self, info):
         container_id = info['Id']
         runtime = self.syscontainers.get_container_runtime_info(container_id)

--- a/Atomic/backends/backend.py
+++ b/Atomic/backends/backend.py
@@ -144,3 +144,8 @@ class Backend(object): #pylint: disable=metaclass-assignment
         pass
 
 
+    @abstractproperty
+    def available(self):
+        pass
+
+

--- a/Atomic/delete.py
+++ b/Atomic/delete.py
@@ -3,6 +3,9 @@ from . import util
 import sys
 from Atomic.backendutils import BackendUtils
 
+ATOMIC_CONFIG = util.get_atomic_config()
+storage = ATOMIC_CONFIG.get('default_storage', "docker")
+
 class Delete(Atomic):
     def __init__(self):
         super(Delete, self).__init__()
@@ -31,7 +34,7 @@ class Delete(Atomic):
             delete_objects = beu.get_images(get_all=True)
         else:
             for image in self.args.delete_targets:
-                _, img_obj = beu.get_backend_and_image_obj(image, str_preferred_backend=self.args.storage)
+                _, img_obj = beu.get_backend_and_image_obj(image, str_preferred_backend=self.args.storage or storage, required=True if self.args.storage else False)
                 delete_objects.append(img_obj)
 
         if self.args.remote:

--- a/Atomic/discovery.py
+++ b/Atomic/discovery.py
@@ -55,7 +55,7 @@ class RegistryInspect():
             fqdn += ":{}".format(self.tag)
         return fqdn
 
-    def find_image_on_registry(self):
+    def find_image_on_registry(self, quiet=False):
         """
         Find the fully qualified image name for given input when
         registry is unknown
@@ -68,13 +68,15 @@ class RegistryInspect():
         registries = [i['name'] for i in [x for x in self.registries if x['search']]]
         for registry in registries:
             fqdn = self.assemble_fqdn(registry=registry, include_tag=True)
-            util.write_out("Trying {}...".format(fqdn))
+            if not quiet:
+                util.write_out("Trying {}...".format(fqdn))
             try:
                 result = util.skopeo_inspect("docker://{}".format(fqdn), return_json=True)
                 self._remote_inspect = result
                 return fqdn
             except ValueError as e:
-                util.write_err("Failed: {}".format(e))
+                if not quiet:
+                    util.write_err("Failed: {}".format(e))
                 continue
         raise RegistryInspectError("Unable to resolve {}".format(self.orig_input))
 

--- a/Atomic/images.py
+++ b/Atomic/images.py
@@ -49,7 +49,7 @@ def cli(subparser):
                              action="store_true",
                              help=_("Delete image from remote repository"))
 
-    delete_parser.add_argument("--storage", default=storage, dest="storage",
+    delete_parser.add_argument("--storage", default=None, dest="storage",
                                help=_("Specify the storage from which to delete the image from. "
                                       "If not specified and there are images with the same name in "
                                       "different storages, you will be prompted to specify."))
@@ -137,6 +137,7 @@ class Images(Atomic):
 
         if self.args.debug:
             util.write_out(str(self.args))
+            self.be_utils.dump_backends()
 
         _images = self._get_images()
         for i in _images:

--- a/Atomic/objects/image.py
+++ b/Atomic/objects/image.py
@@ -117,7 +117,7 @@ class Image(object):
         if not self.registry:
             ri = RegistryInspect(registry=self.registry, repo=self.repo, image=self.image,
                                  tag=self.tag, orig_input=self.input_name)
-            self._fq_name = ri.find_image_on_registry()
+            self._fq_name = ri.find_image_on_registry(quiet=True)
             propagate(self._fq_name)
             return self._fq_name
 

--- a/Atomic/run.py
+++ b/Atomic/run.py
@@ -89,7 +89,7 @@ class Run(Atomic):
                 db.pull_image(self.image)
                 img_object = db.has_image(self.image)
             except RegistryInspectError:
-                util.write_err("Unable to find image {}".format(self.image))
+                raise ValueError("Unable to find image {}".format(self.image))
 
         db.run(img_object, atomic=self, args=self.args)
 

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -84,6 +84,10 @@ class SystemContainers(object):
                         stdout=DEVNULL,
                         stderr=DEVNULL)
 
+    @property
+    def available(self):
+        return OSTREE_PRESENT
+
     def _checkout_layer(self, repo, rootfs_fd, rootfs, rev):
         # ostree 2016.8 has a glib introspection safe API for checkout, use it
         # when available.

--- a/Atomic/update.py
+++ b/Atomic/update.py
@@ -25,7 +25,7 @@ def cli(subparser, hidden=False):
     updatep.add_argument("-f", "--force", default=False, dest="force",
                          action="store_true",
                          help=_("remove all containers based on this image"))
-    updatep.add_argument("--storage", default=storage, dest="storage",
+    updatep.add_argument("--storage", default=None, dest="storage",
                          help=_("Specify the storage of the image. Defaults to: %s" % storage))
     updatep.add_argument("image", help=_("container image"))
 
@@ -38,7 +38,7 @@ class Update(Atomic):
             write_out(str(self.args))
         beu = BackendUtils()
         try:
-            be, img_obj = beu.get_backend_and_image_obj(self.image, str_preferred_backend=self.args.storage)
+            be, img_obj = beu.get_backend_and_image_obj(self.image, str_preferred_backend=self.args.storage or storage, required=True if self.args.storage else False)
             input_name = img_obj.input_name
         except ValueError:
             raise ValueError("{} not found locally.  Unable to update".format(self.image))

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -57,7 +57,10 @@ input, is_python2 = check_if_python2() # pylint: disable=redefined-builtin
 def get_registries():
     registries = []
     with AtomicDocker() as c:
-        dconf = c.info()
+        try:
+            dconf = c.info()
+        except requests.exceptions.ConnectionError:
+            raise ValueError("This Atomic function requires an active docker daemon.")
     search_regs = [x['Name'] for x in dconf['Registries']]
     rconf = dconf['RegistryConfig']['IndexConfigs']
     # docker.io is special

--- a/Atomic/verify.py
+++ b/Atomic/verify.py
@@ -33,7 +33,7 @@ def cli(subparser, hidden=False):
     verifyp.add_argument("--no-validate", default=False, dest="no_validate",
                                 action="store_true",
                                 help=_("disable validating system images"))
-    verifyp.add_argument("--storage", default=storage, dest="storage",
+    verifyp.add_argument("--storage", default=None, dest="storage",
                          help=_("Specify the storage of the image. "
                                 "If not specified and there are images with the same name in "
                                 "different storages, you will be prompted to specify."))
@@ -86,7 +86,7 @@ class Verify(Atomic):
         return layers
 
     def _verify(self):
-        be, img_obj = self.backend_utils.get_backend_and_image_obj(self.image, self.args.storage)
+        be, img_obj = self.backend_utils.get_backend_and_image_obj(self.image, str_preferred_backend=self.args.storage or storage, required=True if self.args.storage else False)
         remote_img_name  = "{}:latest".format(util.Decompose(img_obj.fq_name).no_tag)
         remote_img_obj = be.make_remote_image(remote_img_name)
         return img_obj.layers, remote_img_obj.layers

--- a/bash/atomic
+++ b/bash/atomic
@@ -483,6 +483,7 @@ _atomic_containers_delete() {
 	local all_options="$options_with_args
 		--all -a
 		--force -f
+		--storage
 		--help
 	"
 


### PR DESCRIPTION
    Disconnect backends
    
    Ideally, the atomic CLI should be able to operate independently
    of the backends it supports.  For example, if dockerd is inactive,
    the ostree backend and atomic cli should still work.
    
    This requires some tweaking to the backendutils code and the work
    flow.  We also need to specifically know if the user passes
    --storage so that we treat that as an explicit override.  The work
    flow is now roughly:
    
    * a default storage can be defined in atomic.conf (was always this way)
    * if not defined, defaults to docker.
    * if --storage is passed, treat explictly and fail if cannot execute
    * if no --storage is specified, use default.  if default is not available, move
     onto the next backend