### PR TITLE
Fixup trust tests

### DIFF
--- a/tests/unit/test_trust.py
+++ b/tests/unit/test_trust.py
@@ -13,6 +13,14 @@ FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
 REGISTRIESD = "etc/containers/registries.d"
 TEST_POLICY = os.path.join(os.path.join(FIXTURE_DIR, "etc/containers"), "policy.json")
 
+def _new_enough():
+    py_version = sys.version_info
+    if (py_version.major, py_version.minor, py_version.micro) >= (2, 7, 6):
+        return True
+    return False
+
+new_enough = _new_enough()
+
 class TestAtomicTrust(unittest.TestCase):
 
     class Args():
@@ -78,6 +86,7 @@ class TestAtomicTrust(unittest.TestCase):
             conf_modified = yaml.load(f)
         self.assertEqual(conf_expected, conf_modified)
 
+    @unittest.skipUnless(new_enough, "Requires 2.7.6 or newer")
     def test_add_trust_keys(self):
         args = self.Args()
         args.sigstore = None
@@ -90,6 +99,7 @@ class TestAtomicTrust(unittest.TestCase):
             self.assertEqual(d["transports"]["atomic"]["docker.io"][0]["keyPath"], 
                              os.path.join(FIXTURE_DIR, "key1.pub"))
 
+    @unittest.skipUnless(new_enough, "Requires 2.7.6 or newer")
     def test_modify_trust_2_keys(self):
         args = self.Args()
         args.sigstore = None
@@ -103,6 +113,7 @@ class TestAtomicTrust(unittest.TestCase):
             self.assertEqual(d["transports"]["atomic"]["docker.io"][1]["keyPath"], 
                              os.path.join(FIXTURE_DIR, "key2.pub"))
 
+    @unittest.skipUnless(new_enough, "Requires 2.7.6 or newer")
     def test_add_reject_type(self):
         args = self.Args()
         args.trust_type = "reject"
@@ -118,6 +129,7 @@ class TestAtomicTrust(unittest.TestCase):
             self.assertEqual(d["transports"]["docker"][args.registry][0]["type"], 
                              args.trust_type)
 
+    @unittest.skipUnless(new_enough, "Requires 2.7.6 or newer")
     def test_delete_trust(self):
         args = self.Args()
         args.pubkeys = []
@@ -197,6 +209,8 @@ class TestAtomicTrust(unittest.TestCase):
         reset test policy.json
         """
         shutil.copyfile(os.path.join(FIXTURE_DIR, "default_policy.json"), TEST_POLICY)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,8 +1,15 @@
 import unittest
 import selinux
-
+import sys
 from Atomic import util
 
+def _new_enough():
+    py_version = sys.version_info
+    if (py_version.major, py_version.minor, py_version.micro) >= (2, 7, 6):
+        return True
+    return False
+
+new_enough = _new_enough()
 
 class TestAtomicUtil(unittest.TestCase):
 
@@ -80,6 +87,7 @@ class TestAtomicUtil(unittest.TestCase):
         for image in images:
             self.assertEqual(util.Decompose(image[0]).all, image[1])
 
+    @unittest.skipUnless(new_enough, "Requires 2.7.6 or newer")
     def test_valid_uri(self):
         valid_uris = ['example.com', 'example.com:5000', 'example.US.com', 'example.com/image/name:version1', 'example.com:5000/foo/bar/image:tag', 'example_inc.com']
         invalid_uris = ['example.com/Image/name', 'example.com/image(name):latest', 'example.com/foo_bar', 'example.com:5000:8888', 'example.com:foo', 'example[us].com', 'example.com#foo/bar']


### PR DESCRIPTION
There is a python bug that in 2.7.5 that is causing
the unittest failures on centos_atomic.  The bug
is related to how regex is compiled and used.

Adding a simple decorator to skip tests that fail
because of that in the trust tests.