### PR TITLE
Use secondary disks for storage integration tests

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -42,6 +42,7 @@ host:
   distro: centos/7/atomic/continuous
   specs:
     secondary-disk: 10
+    secondary-disk: 10
 
 context: centos/7/atomic
 

--- a/Atomic/storage.py
+++ b/Atomic/storage.py
@@ -78,13 +78,13 @@ def cli(subparser):
     resetp.set_defaults(_class=Storage, func='reset')
 
 def query_pvs(pv, fields):
-    return util.check_output([ "pvs", "--noheadings", "-o",  fields, "--unit", "b", pv ]).split()
+    return util.check_output([ "pvs", "--noheadings", "-o",  fields, "--unit", "b", pv ]).decode('utf-8').split()
 
 def list_pvs(vgroup):
     res = [ ]
     if vgroup:
         for l in util.check_output([ "pvs", "--noheadings", "-o",  "vg_name,pv_name" ]).splitlines():
-            fields = l.split()
+            fields = l.decode('utf-8').split()
             if len(fields) == 2 and fields[0] == vgroup:
                 res.append(fields[1])
     return res
@@ -92,15 +92,15 @@ def list_pvs(vgroup):
 def list_lvs(vgroup):
     if vgroup:
         return map(lambda s: s.strip(), # pylint: disable=deprecated-lambda, map-builtin-not-iterating
-                   util.check_output([ "lvs", "--noheadings", "-o", "name", vgroup ]).splitlines())
+                   util.check_output([ "lvs", "--noheadings", "-o", "name", vgroup ]).decode('utf-8').splitlines())
     else:
         return [ ]
 
 def list_parents(dev):
-    return util.check_output([ "lsblk", "-snlp", "-o", "NAME", dev ]).splitlines()[1:]
+    return util.check_output([ "lsblk", "-snlp", "-o", "NAME", dev ]).decode('utf-8').splitlines()[1:]
 
 def list_children(dev):
-    return util.check_output([ "lsblk", "-nlp", "-o", "NAME", dev ]).splitlines()[1:]
+    return util.check_output([ "lsblk", "-nlp", "-o", "NAME", dev ]).decode('utf-8').splitlines()[1:]
 
 def get_dss_vgroup(conf):
     vgroup = util.sh_get_var_in_file(conf, "VG", "")
@@ -108,7 +108,7 @@ def get_dss_vgroup(conf):
         for l in open("/proc/mounts", "r").readlines():
             fields = l.split()
             if fields[1] == "/" and fields[0].startswith("/dev"):
-                vgroup = util.check_output([ "lvs", "--noheadings", "-o",  "vg_name", fields[0]]).strip()
+                vgroup = util.check_output([ "lvs", "--noheadings", "-o",  "vg_name", fields[0]]).decode('utf-8').strip()
     return vgroup
 
 def get_dss_devs(conf):

--- a/Atomic/storage.py
+++ b/Atomic/storage.py
@@ -7,6 +7,7 @@ from . import util
 from .Export import export_docker
 from .Import import import_docker
 from .util import NoDockerDaemon, default_docker_lib
+import subprocess
 
 try:
     from subprocess import DEVNULL  # pylint: disable=no-name-in-module
@@ -168,7 +169,11 @@ class Storage(Atomic):
                 self._vgroup(self.args.vgroup)
             if len(self.args.devices) > 0:
                 self._add_device(self.args.devices)
-            if util.call(["docker-storage-setup"]) != 0:
+            try:
+                util.check_output(["docker-storage-setup"], stderr=subprocess.STDOUT)
+            except subprocess.CalledProcessError as e:
+                util.write_out("Return Code: {}".format(e.returncode))
+                util.write_out("Failure: {}".format(e.output))
                 os.rename(self.dss_conf_bak, self.dss_conf)
                 util.call(["docker-storage-setup"])
                 raise ValueError("docker-storage-setup failed")

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,8 @@ Vagrant.configure(2) do |config|
     config.vm.provider "libvirt" do |libvirt, override|
         libvirt.memory = 2048
         libvirt.cpus = 3
+	libvirt.storage :file,
+		:type => 'qcow2'
     end
     config.vm.synced_folder ".", "/vagrant", disabled: true
     config.vm.synced_folder ".", "/home/vagrant/atomic", type: "rsync",

--- a/tests/integration/test_storage.sh
+++ b/tests/integration/test_storage.sh
@@ -30,14 +30,11 @@ setup () {
     # Perform setup routines here.
     smarter_copy /etc/sysconfig/docker-storage-setup /etc/sysconfig/docker-storage-setup.atomic-tests-backup
     TEST_DEV_1=/dev/vdb
-    mount
-    #MNT=$(mount | grep vdb | awk '{print $3}')
     MNT=$(mount | awk '$1 ~/vdb/' | awk '{print $3}')
     if [ ${MNT} ]; then
 	    umount $MNT
     fi
     wipefs -a "$TEST_DEV_1"
-    fdisk -l
     TEST_DEV_1_pvs=${TEST_DEV_1}1
 
     ROOT_DEV=$( awk '$2 ~ /^\/$/ && $1 !~ /rootfs/ { print $1 }' /proc/mounts )


### PR DESCRIPTION
Due to a couple of bugs related to loopback and sfdisk, we should
be using available secondary disks for testing atomic storage.  This
is part of the destructive testing we now do.

Also, configured vagrant to dispatch two disks so the tests can be done
there too.