### PR TITLE
Inline pubkeys in policy.json

### DIFF
--- a/Atomic/pull.py
+++ b/Atomic/pull.py
@@ -50,7 +50,7 @@ class Pull(Atomic):
                     be_utils.message_backend_change('docker', 'ostree')
             else:
                 remote_image_obj = None
-            be.pull_image(self.args.image, remote_image_obj, debug=self.args.debug)
+            be.pull_image(self.args.image, remote_image_obj, debug=self.args.debug, assumeyes=self.args.assumeyes)
         except ValueError as e:
             write_out("Failed: {}".format(e))
             return 1

--- a/atomic.conf
+++ b/atomic.conf
@@ -5,7 +5,6 @@ default_docker: docker
 registry_confdir: /etc/containers/registries.d/
 discover_sigstores: true
 sigstore_metadata_image: sigstore
-pubkeys_dir: /etc/pki/containers
 
 
 # Default storage backend [ostree, docker]

--- a/bash/atomic
+++ b/bash/atomic
@@ -951,6 +951,7 @@ _atomic_trust_default() {
 _atomic_trust_add() {
 	local options_with_args="
 		--pubkeys -k
+		--pubkeysfile -f
 		--sigstoretype
 		--type -t
 		--keytype

--- a/docs/atomic-trust.1.md
+++ b/docs/atomic-trust.1.md
@@ -11,6 +11,7 @@ atomic-trust - Manage system container trust policy
 [**-j**|**--json**]
 [**--raw**]
 [**-k**|**--pubkeys** KEY1 [**-k**|**--pubkeys** KEY2,...]]
+[**-f**|**--pubkeysfile** KEY1 [**f**|**--pubkeysfile** KEY2,...]]
 [**--keytype** GPGKeys]
 [**-t**|**--type** signedBy|insecureAcceptAnything|reject]
 [**-s**|**--sigstore** https://URL[:PORT][/PATH]|file:///PATH]
@@ -49,8 +50,18 @@ testing.
   Print usage statement.
 
 **-k** **--pubkeys**
-  An absolute path to installed public key. May be used multiple times. Required
-  for **signedBy** type.
+  A reference to a local file or download URL to an exported public key. Keys
+  will be parsed and encoded inline with policy.json. Option may be used
+  multiple times to require an image be sigend by multiple keys. One of
+  **--pubkeys** or **--pubkeysfile** is required for **signedBy** type. This
+  option is recommended over **--pubkeysfile**.
+
+**-f** **--pubkeysfile**
+  A path to an exported public key on the local system. Key paths
+  will be referenced in policy.json. Any path may be used but path
+  **/etc/pki/containers** is recommended. Option may be used multiple times to
+  require an image be sigend by multiple keys. One of **--pubkeys** or
+  **--pubkeysfile** is required for **signedBy** type.
 
 **--keytype**
   The public key type. Default: GPGKeys (only supported value)
@@ -107,8 +118,8 @@ Modify a trust scope, adding a second public key and changing
 the sigstore web server
 
     atomic trust add \
+           --pubkeys https://example.com/keys/example.pub \
            --pubkeys /etc/pki/containers/foo@example.com \
-           --pubkeys /etc/pki/containers/bar@example.com \
            --sigstore https://server.example.com/foobar/sigstore/ \
            docker.io/foobar
 

--- a/tests/unit/test_pull.py
+++ b/tests/unit/test_pull.py
@@ -44,6 +44,7 @@ class TestAtomicPullByDigest(unittest.TestCase):
     class Args():
         def __init__(self):
             self.debug = None
+            self.assumeyes = None
 
     def test_pull_by_digest(self):
         image_name = "docker.io/busybox@sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912"

--- a/tests/unit/test_trust.py
+++ b/tests/unit/test_trust.py
@@ -27,7 +27,8 @@ class TestAtomicTrust(unittest.TestCase):
         def __init__(self):
             self.sigstoretype = "atomic"
             self.registry = "docker.io"
-            self.pubkeys = [os.path.join(FIXTURE_DIR, "key1.pub")]
+            self.pubkeys = []
+            self.pubkeysfile = [os.path.join(FIXTURE_DIR, "key1.pub")]
             self.sigstore = "https://sigstore.example.com/sigs"
             self.trust_type = "signedBy"
             self.keytype = "GPGKeys"
@@ -103,7 +104,7 @@ class TestAtomicTrust(unittest.TestCase):
     def test_modify_trust_2_keys(self):
         args = self.Args()
         args.sigstore = None
-        args.pubkeys = [os.path.join(FIXTURE_DIR, "key1.pub"), os.path.join(FIXTURE_DIR, "key2.pub")]
+        args.pubkeysfile = [os.path.join(FIXTURE_DIR, "key1.pub"), os.path.join(FIXTURE_DIR, "key2.pub")]
         testobj = Trust(policy_filename = TEST_POLICY)
         testobj.atomic_config = util.get_atomic_config(atomic_config = os.path.join(FIXTURE_DIR, "atomic.conf"))
         testobj.set_args(args)
@@ -184,7 +185,7 @@ class TestAtomicTrust(unittest.TestCase):
         testobj = Trust(policy_filename = os.path.join(FIXTURE_DIR, "show_policy.json"))
         testobj.atomic_config = util.get_atomic_config(atomic_config = os.path.join(FIXTURE_DIR, "atomic.conf"))
         testobj.set_args(args)
-        actual = testobj.get_gpg_id(args.pubkeys)
+        actual = testobj.get_gpg_id(args.pubkeysfile)
         self.assertEqual("security@redhat.com", actual)
 
     def test_trust_gpg_noemail_id(self):


### PR DESCRIPTION
Default is now to inline pubkeys as "[keyData](https://godoc.org/github.com/containers/image/signature#NewPRSignedByKeyData)" strings inside policy.json, with option to reference as installed files ("[keyPath](https://godoc.org/github.com/containers/image/signature#NewPRSignedByKeyPath)") on host system, the previous behavior.

We also now support passing in a URL to a public key.