### PR TITLE
Atomic/pull.py: Pull by Digest

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -596,7 +596,7 @@ class Atomic(object):
         return tokens
 
     def get_fq_image_name(self, input_image):
-        registry, repo, image, tag, _ = util.Decompose(input_image).all
+        registry, repo, image, tag, digest = util.Decompose(input_image).all
         if not image:
             raise ValueError('Error parsing input: "{}" invalid'.format(input_image))
         if all([True if x else False for x in [registry, image, tag]]):
@@ -606,7 +606,7 @@ class Atomic(object):
             img += "/{}:{}".format(image, tag)
             return img
         if not registry:
-            ri = RegistryInspect(registry, repo, image, tag, debug=self.args.debug, orig_input=self.image)
+            ri = RegistryInspect(registry, repo, image, tag, digest=digest, debug=self.args.debug, orig_input=self.image)
             return ri.find_image_on_registry()
 
 

--- a/Atomic/discovery.py
+++ b/Atomic/discovery.py
@@ -11,13 +11,14 @@ class RegistryAuthError(Exception):
 
 class RegistryInspect():
 
-    def __init__(self, registry=None, repo=None, image=None, tag=None, orig_input=None, debug=False):
+    def __init__(self, registry=None, repo=None, image=None, tag=None, digest=None, orig_input=None, debug=False):
         self.debug = debug
         self.registries = util.get_registries()
         self.registry = registry
         self.repo = repo
         self.image = image
         self.tag = tag
+        self.digest = digest
         self.orig_input = orig_input
         self._remote_inspect = None
         self.fqdn = None
@@ -52,7 +53,10 @@ class RegistryInspect():
         fqdn = fqdn if not self.repo else "{}/{}".format(fqdn, self.repo)
         fqdn += "/{}".format(self.image)
         if include_tag:
-            fqdn += ":{}".format(self.tag)
+            if self.tag:
+                fqdn += ":{}".format(self.tag)
+            elif self.digest:
+                fqdn += "@{}".format(self.digest)
         return fqdn
 
     def find_image_on_registry(self, quiet=False):

--- a/Atomic/pull.py
+++ b/Atomic/pull.py
@@ -30,13 +30,13 @@ class Pull(Atomic):
         """
         super(Pull, self).__init__()
         self.policy_filename=policy_filename
+        self.be_utils = BackendUtils()
 
     def pull_image(self):
         if self.args.debug:
             write_out(str(self.args))
 
-        be_utils = BackendUtils()
-        be = be_utils.get_backend_from_string(self.args.storage)
+        be = self.be_utils.get_backend_from_string(self.args.storage)
         self.args.policy_filename = self.policy_filename
         try:
             be.pull_image(self.args.image, debug=self.args.debug)

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -850,6 +850,9 @@ class Decompose(object):
         self._tag = str(tag) if tag else ''
         self._digest = str(digest) if digest else ''
 
+        if self._tag and self._digest:
+            raise ValueError("An image name cannot have both a tag and manifest digest in its name")
+
     @property
     def registry(self):
         return self._registry

--- a/Atomic/verify.py
+++ b/Atomic/verify.py
@@ -101,9 +101,9 @@ class Verify(Atomic):
         base_images = []
         for name in names:
             _match = next((x for x in layers if x['Name'] == name and x['RepoTags'] is not ''), None)
-            registry, repo, image, tag, _ = util.Decompose(self.get_fq_image_name(_match['RepoTags'][0])).all
+            registry, repo, image, tag, digest = util.Decompose(self.get_fq_image_name(_match['RepoTags'][0])).all
             tag = "latest"
-            ri = RegistryInspect(registry=registry, repo=repo, image=image, tag=tag, debug=self.debug)
+            ri = RegistryInspect(registry=registry, repo=repo, image=image, tag=tag, digest=digest, debug=self.debug)
             remote_inspect = ri.inspect()
             release = remote_inspect.get("Labels", None).get("Release", None)
             version = remote_inspect.get("Labels", None).get("Version", None)

--- a/tests/unit/test_pull.py
+++ b/tests/unit/test_pull.py
@@ -1,6 +1,21 @@
+#pylint: skip-file
 import unittest
-
+from Atomic.pull import Pull
 from Atomic.syscontainers import SystemContainers
+from Atomic.backends._docker import DockerBackend
+from Atomic import util
+
+no_mock = True
+try:
+    from unittest.mock import MagicMock, patch
+    no_mock = False
+except ImportError:
+    try:
+        from mock import MagicMock, patch
+        no_mock = False
+    except ImportError:
+        # Mock is already set to False
+        pass
 
 class TestAtomicPull(unittest.TestCase):
     class Args():
@@ -20,6 +35,53 @@ class TestAtomicPull(unittest.TestCase):
         testobj = SystemContainers()
         testobj.set_args(args)
         testobj.pull_image()
+
+remote_inspect_info = {'Layers': ['sha256:56bec22e355981d8ba0878c6c2f23b21f422f30ab0aba188b54f1ffeff59c190'], 'Labels': {}, 'Created': '2016-10-07T21:03:58.469866982Z', 'Tag': '', 'Name': 'docker.io/library/busybox', 'Os': 'linux', 'id': 'sha256:e02e811dd08fd49e7f6032625495118e63f597eb150403d02e3238af1df240ba', 'Architecture': 'amd64', 'Digest': 'sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912', 'RepoTags': ['1-glibc', '1-musl', '1-ubuntu', '1-uclibc', '1.21-ubuntu', '1.21.0-ubuntu', '1.23.2', '1.23', '1.24-glibc', '1.24-musl', '1.24-uclibc', '1.24.0', '1.24.1-glibc', '1.24.1-musl', '1.24.1-uclibc', '1.24.1', '1.24.2-glibc', '1.24.2-musl', '1.24.2-uclibc', '1.24.2', '1.24', '1.25-glibc', '1.25-musl', '1.25-uclibc', '1.25.0-glibc', '1.25.0-musl', '1.25.0-uclibc', '1.25.0', '1.25.1-glibc', '1.25.1-musl', '1.25.1-uclibc', '1.25.1', '1.25', '1.26-glibc', '1.26-musl', '1.26-uclibc', '1.26.0-glibc', '1.26.0-musl', '1.26.0-uclibc', '1.26.0', '1.26.1-glibc', '1.26.1-musl', '1.26.1-uclibc', '1.26.1', '1.26.2-glibc', '1.26.2-musl', '1.26.2-uclibc', '1.26.2', '1.26', '1', 'buildroot-2013.08.1', 'buildroot-2014.02', 'glibc', 'latest', 'musl', 'ubuntu-12.04', 'ubuntu-14.04', 'ubuntu', 'uclibc'], 'DockerVersion': '1.12.1'}
+local_inspect_info = {'RepoDigests': ['docker.io/busybox@sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912'], 'ContainerConfig': {'StdinOnce': False, 'Cmd': ['/bin/sh', '-c', '#(nop) ', 'CMD ["sh"]'], 'OnBuild': None, 'Env': ['PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'], 'AttachStdout': False, 'User': '', 'Labels': {}, 'Image': '1679bae2167496818312013654f5c66a16e185d0a0f6b762b53c8558014457c6', 'OpenStdin': False, 'AttachStderr': False, 'AttachStdin': False, 'Domainname': '', 'Entrypoint': None, 'Hostname': '4a74292706a0', 'Volumes': None, 'WorkingDir': '', 'Tty': False}, 'DockerVersion': '1.12.1', 'RepoTags': [], 'RootFS': {'Type': 'layers', 'Layers': ['e88b3f82283bc59d5e0df427c824e9f95557e661fcb0ea15fb0fb6f97760f9d9']}, 'Created': '2016-10-07T21:03:58.469866982Z', 'Architecture': 'amd64', 'Id': 'e02e811dd08fd49e7f6032625495118e63f597eb150403d02e3238af1df240ba', 'GraphDriver': {'Data': {'DeviceName': 'docker-253:2-5900125-83ca47b12d877ce22ea1c633d2425fb245902a5db0a0039f010d0a7d4ee10b91', 'DeviceId': '2611', 'DeviceSize': '10737418240'}, 'Name': 'devicemapper'}, 'Size': 1093484, 'Config': {'StdinOnce': False, 'Cmd': ['sh'], 'OnBuild': None, 'Env': ['PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'], 'AttachStdout': False, 'User': '', 'Labels': {}, 'Image': '1679bae2167496818312013654f5c66a16e185d0a0f6b762b53c8558014457c6', 'OpenStdin': False, 'AttachStderr': False, 'AttachStdin': False, 'Domainname': '', 'Entrypoint': None, 'Hostname': '4a74292706a0', 'Volumes': None, 'WorkingDir': '', 'Tty': False}, 'Comment': '', 'Os': 'linux', 'Author': '', 'Container': '8bb318a3b4672c53a1747991c95fff3306eea13ec308740ebe0c81b56ece530f', 'Parent': '', 'VirtualSize': 1093484}
+
+@unittest.skipIf(no_mock, "Mock not found")
+class TestAtomicPullByDigest(unittest.TestCase):
+    class Args():
+        def __init__(self):
+            self.debug = None
+
+    def test_pull_by_digest(self):
+        image_name = "docker.io/busybox@sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912"
+        db = DockerBackend()
+        img_obj = db._make_remote_image(image_name)
+        img_obj.remote_inspect = MagicMock(return_value=remote_inspect_info)
+        img_obj.populate_remote_inspect_info()
+        db.make_remote_image = MagicMock(return_value=img_obj)
+        db.has_image = MagicMock(return_value=None)
+        util.skopeo_inspect = MagicMock(return_value=[])
+        args = self.Args()
+        args.image = image_name
+        args.storage = 'docker'
+        pull = Pull()
+        pull.set_args(args)
+        pull.be_utils.get_backend_from_string = MagicMock(return_value=db)
+        util.skopeo_copy = MagicMock(return_value=None)
+        pull.pull_image()
+
+
+    def test_pull_by_digest_already_present(self):
+        image_name = "docker.io/busybox@sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912"
+        db = DockerBackend()
+        remote_img_obj = db._make_remote_image(image_name)
+        remote_img_obj.remote_inspect = MagicMock(return_value=remote_inspect_info)
+        remote_img_obj.populate_remote_inspect_info()
+        db.make_remote_image = MagicMock(return_value=remote_img_obj)
+        db._inspect_image = MagicMock(return_value=local_inspect_info)
+        local_image_obj = db.inspect_image(image_name)
+        db.has_image = MagicMock(return_value=local_image_obj)
+        args = self.Args()
+        args.image = image_name
+        args.storage = 'docker'
+        pull = Pull()
+        pull.set_args(args)
+        pull.be_utils.get_backend_from_string = MagicMock(return_value=db)
+        pull.pull_image()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Users wish to be able to pull images by digest.  This can be
done by docker and therefore parity is preferred.  The request
is described in https://github.com/projectatomic/atomic/issues/691.

```
$ atomic pull busybox@sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912
Pulling docker.io/busybox@sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912 ...
Copying blob sha256:56bec22e355981d8ba0878c6c2f23b21f422f30ab0aba188b54f1ffeff59c190
 495.23 KB / 652.49 KB [=========================================>-------------]
Copying config sha256:e02e811dd08fd49e7f6032625495118e63f597eb150403d02e3238af1df240ba
 0 B / 1.43 KB [---------------------------------------------------------------]
Writing manifest to image destination
Storing signatures
 1.43 KB / 1.43 KB [===========================================================]
$ docker images
REPOSITORY                         TAG                                                                IMAGE ID            CREATED             SIZE
docker.io/busybox                  29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912   e02e811dd08f        3 months ago        1.093 MB
```
Note how the tag is populated with the digest.  Docker's default behaviour is
to populate the tag with nothing.  We cannot currently replicate that exactly.