### PR TITLE
atomic.d/openscap: Change image name to be fully qualified

### DIFF
--- a/atomic.d/openscap
+++ b/atomic.d/openscap
@@ -1,6 +1,6 @@
 type: scanner
 scanner_name: openscap
-image_name: rhel7/openscap
+image_name: registry.access.redhat.com/rhel7/openscap
 default_scan: cve
 custom_args: ['-v', '/etc/oscapd:/etc/oscapd:ro']
 scans: [ 


### PR DESCRIPTION
If the openscap file that defines the scanner image name uses the
short-name, i.e. rhel7/openscap, the on first use of atomic scan,
atomic will pull the scanning image.  However, atomic will name
the image with its fully qualified name, because it had to look it
up.  Therefore, in the local dockerd, the scanner will be named
with its full name.  The next time the scanner is run, it will
again attempt to pull down the short-named version.

We should just switch to the fq name to avoid this mess. This issue
was reported in https://github.com/projectatomic/atomic/issues/797.