### PR TITLE
Unify 404/unable to find image messages

### DIFF
--- a/Atomic/discovery.py
+++ b/Atomic/discovery.py
@@ -78,5 +78,5 @@ class RegistryInspect():
                 if not quiet:
                     util.write_err("Failed: {}".format(e))
                 continue
-        raise RegistryInspectError("Unable to resolve {}".format(self.orig_input))
+        raise RegistryInspectError("Unable to find {}".format(self.orig_input))
 

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1160,8 +1160,10 @@ class SystemContainers(object):
         current_rev = repo.resolve_rev(imagebranch, True)
         if not upgrade and current_rev[1]:
             return False
-
-        manifest = self._skopeo_get_manifest(img)
+        try:
+            manifest = self._skopeo_get_manifest(img)
+        except ValueError:
+            raise ValueError("Unable to find {}".format(img))
         layers = SystemContainers.get_layers_from_manifest(manifest)
         missing_layers = []
         for i in layers:


### PR DESCRIPTION
When looking for an image on a docker registry, atomic pull should
display similar error messages when unable to find an image
regardless of the storage backend.  We now currently do this:

$ sudo atomic pull foobar123
Unable to find foobar123
$ sudo atomic pull --storage ostree foobar123
Unable to find foobar123

This should satify https://github.com/projectatomic/atomic/issues/832 and
https://github.com/projectatomic/atomic/issues/636.