### PR TITLE
Detect and install systemcontainer images

### DIFF
--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -236,18 +236,20 @@ class DockerBackend(Backend):
     def stop_container(self, con_obj):
         return self.d.stop(con_obj.id)
 
-    def pull_image(self, image, **kwargs):
+
+    def pull_image(self, image, remote_image_obj, **kwargs):
+        assert(isinstance(remote_image_obj, Image))
         debug = kwargs.get('debug', False)
         if image.startswith("dockertar:"):
             path = image.replace("dockertar:", "", 1)
             with open(path, 'rb') as f:
                 self.d.load_image(data=f)
             return 0
-        remote_image = self.make_remote_image(image)
-        fq_name = remote_image.fq_name
+#        remote_image_obj = self.make_remote_image(image)
+        fq_name = remote_image_obj.fq_name
         local_image = self.has_image(image)
         if local_image is not None:
-            if self.already_has_image(local_image, remote_image):
+            if self.already_has_image(local_image, remote_image_obj):
                 raise ValueError("Latest version of {} already present.".format(image))
         registry, _, _, tag, _ = util.Decompose(fq_name).all
         image = "docker-daemon:{}".format(image)
@@ -295,9 +297,10 @@ class DockerBackend(Backend):
 
     def update(self, name, force=False, **kwargs):
         debug = kwargs.get('debug', False)
+        remote_image_obj = self.make_remote_image(name)
         try:
             # pull_image will raise a ValueError if the "latest" image is already present
-            self.pull_image(name, debug=debug)
+            self.pull_image(name, remote_image_obj, debug=debug)
         except ValueError:
             return
         # Only delete containers if a new image is actually pulled.

--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -245,7 +245,6 @@ class DockerBackend(Backend):
             with open(path, 'rb') as f:
                 self.d.load_image(data=f)
             return 0
-#        remote_image_obj = self.make_remote_image(image)
         fq_name = remote_image_obj.fq_name
         local_image = self.has_image(image)
         if local_image is not None:

--- a/Atomic/backends/_ostree.py
+++ b/Atomic/backends/_ostree.py
@@ -111,7 +111,7 @@ class OSTreeBackend(Backend):
     def get_containers(self):
         return [self._make_container(x) for x in self.syscontainers.get_containers()]
 
-    def pull_image(self, image, **kwargs):
+    def pull_image(self, image, remote_image_obj=None, **kwargs):
         return self.syscontainers.pull_image(image)
 
     def delete_image(self, image, force=False):

--- a/Atomic/backends/backend.py
+++ b/Atomic/backends/backend.py
@@ -28,7 +28,7 @@ class Backend(object): #pylint: disable=metaclass-assignment
         pass
 
     @abstractmethod
-    def pull_image(self, image, **kwargs):
+    def pull_image(self, image, remote_image_obj, **kwargs):
         """
         Pulls an image to the backend
         :param image:

--- a/Atomic/backendutils.py
+++ b/Atomic/backendutils.py
@@ -159,3 +159,4 @@ class BackendUtils(object):
     def message_backend_change(previous, new):
         write_out("\nNote: Switching from the '{}' backend to the '{}' backend based on the 'atomic.type' label in the "
                   "image.  You can use --storage to override this behaviour.\n".format(previous, new))
+

--- a/Atomic/backendutils.py
+++ b/Atomic/backendutils.py
@@ -155,4 +155,7 @@ class BackendUtils(object):
     def get_container_obj_by_image_name(self, image_name, str_preferred_backend):
         pass
 
-
+    @staticmethod
+    def message_backend_change(previous, new):
+        write_out("\nNote: Switching from the '{}' backend to the '{}' backend based on the 'atomic.type' label in the "
+                  "image.  You can use --storage to override this behaviour.\n".format(previous, new))

--- a/Atomic/objects/image.py
+++ b/Atomic/objects/image.py
@@ -295,7 +295,11 @@ class Image(object):
     def command(self, value):
         self._command = value
 
-
+    @property
+    def is_system_type(self):
+        if self.get_label('atomic.type') == 'system':
+            return True
+        return False
 
 def convert_size(size):
     if size > 0:

--- a/Atomic/pull.py
+++ b/Atomic/pull.py
@@ -8,16 +8,17 @@ from Atomic.backendutils import BackendUtils
 ATOMIC_CONFIG = get_atomic_config()
 
 
+_storage = ATOMIC_CONFIG.get('default_storage', "docker")
+
 def cli(subparser):
     # atomic pull
-    storage = ATOMIC_CONFIG.get('default_storage', "docker")
     pullp = subparser.add_parser("pull", help=_("pull latest image from a repository"),
                                  epilog="pull the latest specified image from a repository.")
     pullp.set_defaults(_class=Pull, func='pull_image')
-    pullp.add_argument("--storage", dest="storage", default=storage,
+    pullp.add_argument("--storage", dest="storage", default=None,
                        help=_("Specify the storage. Default is currently '%s'.  You can"
                               " change the default by editing /etc/atomic.conf and changing"
-                              " the 'default_storage' field." % storage))
+                              " the 'default_storage' field." % _storage))
     pullp.add_argument("-t", "--type", dest="reg_type", default=None,
                        help=_("Pull from an alternative registry type."))
     pullp.add_argument("image", help=_("image id"))
@@ -33,13 +34,23 @@ class Pull(Atomic):
         self.be_utils = BackendUtils()
 
     def pull_image(self):
+        storage_set = False if self.args.storage is None else True
+        storage = _storage if not storage_set else self.args.storage
         if self.args.debug:
             write_out(str(self.args))
 
-        be = self.be_utils.get_backend_from_string(self.args.storage)
+        be_utils = BackendUtils()
+        be = be_utils.get_backend_from_string(storage)
         self.args.policy_filename = self.policy_filename
         try:
-            be.pull_image(self.args.image, debug=self.args.debug)
+            if be.backend == 'docker':
+                remote_image_obj = be.make_remote_image(self.args.image)
+                if remote_image_obj.is_system_type and not storage_set:
+                    be = be_utils.get_backend_from_string('ostree')
+                    be_utils.message_backend_change('docker', 'ostree')
+            else:
+                remote_image_obj = None
+            be.pull_image(self.args.image, remote_image_obj, debug=self.args.debug)
         except ValueError as e:
             write_out(str(e))
             return 0

--- a/Atomic/run.py
+++ b/Atomic/run.py
@@ -29,6 +29,10 @@ RUN_ARGS = ["-i",
             "--name", "${NAME}",
             "${IMAGE}"]
 
+ATOMIC_CONFIG = util.get_atomic_config()
+_storage = ATOMIC_CONFIG.get('default_storage', "docker")
+
+
 def cli(subparser):
     # atomic run
     runp = subparser.add_parser(
@@ -40,6 +44,10 @@ def cli(subparser):
     runp.set_defaults(_class=Run, func='run')
     run_group = runp.add_mutually_exclusive_group()
     util.add_opt(runp)
+    runp.add_argument("--storage", dest="storage", default=None,
+                          help=_("Specify the storage. Default is currently '%s'.  You can"
+                                 " change the default by editing /etc/atomic.conf and changing"
+                                 " the 'default_storage' field." % _storage))
     runp.add_argument("-n", "--name", dest="name", default=None,
                       help=_("name of container"))
     runp.add_argument("--spc", default=False, action="store_true",
@@ -70,23 +78,26 @@ class Run(Atomic):
         self.SPC_ARGS = SPC_ARGS
 
     def run(self):
+        storage_set = False if self.args.storage is None else True
+        storage = _storage if not storage_set else self.args.storage
+        be_utils = BackendUtils()
         if self.name:
-            be_utils = BackendUtils()
             try:
                 be, con_obj = be_utils.get_backend_and_container_obj(self.name)
                 return be.run(con_obj, atomic=self, args=self.args)
             except ValueError:
                 pass
 
+        be = be_utils.get_backend_from_string(storage)
         db = DockerBackend()
-        img_object = db.has_image(self.image)
-        if img_object is None:
+        img_object = be.has_image(self.image)
+        if img_object is None and storage == 'docker':
             self.display("Need to pull %s" % self.image)
             remote_image_obj = db.make_remote_image(self.args.image)
             # If the image has a atomic.type of system, then we need to land
             # this in the ostree backend.  Install it and then start it
             # because this is run
-            if remote_image_obj.is_system_type:
+            if remote_image_obj.is_system_type and not storage_set:
                 be = be_utils.get_backend_from_string('ostree')
                 be_utils.message_backend_change('docker', 'ostree')
                 be.install(self.image, self.name)
@@ -99,8 +110,15 @@ class Run(Atomic):
                 img_object = db.has_image(self.image)
             except RegistryInspectError:
                 raise ValueError("Unable to find image {}".format(self.image))
-
-        db.run(img_object, atomic=self, args=self.args)
+        if storage == 'ostree':
+            if img_object is None:
+                be.pull_image(self.args.image, None)
+            # For system containers, the run method really needs a container obj
+            con_obj = be.has_container(self.name)
+            if con_obj is None:
+                be.install(self.image, self.name)
+            img_object = be.has_container(self.name)
+        be.run(img_object, atomic=self, args=self.args)
 
     @staticmethod
     def print_run():

--- a/bash/atomic
+++ b/bash/atomic
@@ -489,6 +489,13 @@ _atomic_containers_delete() {
 
 	local options_with_args_glob=$(__atomic_to_extglob "$options_with_args")
 
+	case "$prev" in
+		--storage)
+			COMPREPLY=( $( compgen -W "docker ostree" -- "$cur" ) )
+			return 0
+			;;
+	esac
+
 	case "$cur" in
 		-*)
 			COMPREPLY=( $( compgen -W "$all_options" -- "$cur" ) )
@@ -654,11 +661,19 @@ _atomic_run() {
 		--spc
 	       --display
 	--quiet
+	    --storage
 	"
 
 	[ "$command" = "run" ] && all_options="$all_options"
 
 	local options_with_args_glob=$(__atomic_to_extglob "$options_with_args")
+
+	case "$prev" in
+		--storage)
+			COMPREPLY=( $( compgen -W "docker ostree" -- "$cur" ) )
+			return 0
+			;;
+	esac
 
 	case "$prev" in
 		$options_with_args_glob )
@@ -688,12 +703,20 @@ _atomic_install() {
 		--help
 	       --display
 	       --rootfs
+	       --storage
 	       --system
 	       --set
 	       --user
 	"
 
 	local options_with_args_glob=$(__atomic_to_extglob "$options_with_args")
+
+	case "$prev" in
+		--storage)
+			COMPREPLY=( $( compgen -W "docker ostree" -- "$cur" ) )
+			return 0
+			;;
+	esac
 
 	case "$prev" in
 		$options_with_args_glob )

--- a/docs/atomic-install.1.md
+++ b/docs/atomic-install.1.md
@@ -11,6 +11,7 @@ atomic-install - Execute Image Install Method
 [**-n**][**--name**[=*NAME*]]
 [**--rootfs**=*ROOTFS*]
 [**--set**=*NAME*=*VALUE*]
+[**--storage**]
 [**--system**]
 IMAGE [ARG...]
 
@@ -73,6 +74,12 @@ Set a value that is going to be used by a system container for its
 configuration and can be specified multiple times.  It is used only
 by --system.  OSTree is required for this feature to be available.
 
+**--storage**
+Allows you to override the default definition for the storage backend
+where your image will reside if pulled.  If the image is already local,
+the --storage option will dictate where atomic should look for the image
+prior to installing. Valid options are `docker` and `ostree`.
+
 **--system**
 Install a system container.  A system container is a container that
 is executed out of an systemd unit file early in boot, using runc.
@@ -84,6 +91,10 @@ Installing a system container consists of checking it the image by
 default under /var/lib/containers/atomic/ and generating the
 configuration files for runc and systemd.
 OSTree and runc are required for this feature to be available.
+
+Note: If the image being pulled contains a label of `system.type=ostree`,
+atomic will automatically substitute the storage backend to be ostree. This
+can be overridden with the --storage option.
 
 **--user**
 If running as non-root, specify to install the image from the current

--- a/docs/atomic-run.1.md
+++ b/docs/atomic-run.1.md
@@ -10,6 +10,7 @@ atomic-run - Execute container image run method
 [**--display**]
 [**-n**][**--name**[=*NAME*]]
 [**--spc**]
+[**--storage**]
 [**--quiet**]
 IMAGE [COMMAND] [ARG...]
 
@@ -69,6 +70,11 @@ NAME will default to the IMAGENAME if it is not specified.
   Run container in super privileged container mode.  The image will run with the following command:
 
 `/usr/bin/docker run -t -i --rm --privileged -v /:/host -v /run:/run --net=host --ipc=host --pid=host -e HOST=/host -e NAME=${NAME} -e IMAGE=${IMAGE} --name ${NAME} ${IMAGE}`
+
+**-storage**
+   Allows you to override the default definition for the storage backend where your image will reside if pulled.  If the image is already local,
+the --storage option will dictate where atomic should look for the image prior to running. Valid options are `docker` and `ostree`.
+
 
 **--quiet**
   Run without verbose messaging (i.e. security warnings).


### PR DESCRIPTION
If an image from a registry has a label like:

    atomic.type=system

the Atomic CLI will now detect that prior to pulling
the image.  It will then switch the backend storage
to ostree.  In the case of install, it will both
pull to ostree and install it.

If the backend is switched, a message informing the user
as such will be shown.

The detection and switch of the backend can be overriden
 with the --storage option.

The following is an example of install:
```
$ sudo atomic install atomic-registry.usersys.redhat.com:5000/brentbaude/helloworld:latest

Note: Switching from the 'docker' backend to the 'ostree' backend based on the 'atomic.type' label in the image.  You can use --storage to override this behaviour.

Extracting to /var/lib/containers/atomic/helloworld.0
systemctl daemon-reload
systemctl enable helloworld

$ sudo ./atomic images list
   REPOSITORY                                                      TAG      IMAGE ID       CREATED            VIRTUAL SIZE   TYPE
   atomic-registry.usersys.redhat.com:5000/brentbaude/helloworld   latest   0056366e4ebd   2017-02-01 18:04                  ostree

$ sudo ./atomic containers list -a
   CONTAINER ID IMAGE                COMMAND              CREATED          STATE     BACKEND    RUNTIME
   helloworld   atomic-registry.user /usr/bin/run.sh      2017-02-01 18:04 failed    ostree     runc
```