### PR TITLE
Improve pull error messaging

### DIFF
--- a/Atomic/pull.py
+++ b/Atomic/pull.py
@@ -41,7 +41,8 @@ class Pull(Atomic):
         try:
             be.pull_image(self.args.image, debug=self.args.debug)
         except ValueError as e:
-            write_out(str(e))
-            return 0
+            write_out("Failed: {}".format(e))
+            return 1
+        return 0
 
 

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -267,7 +267,8 @@ def skopeo_inspect(image, args=None, return_json=True, newline=False):
     except OSError:
         raise ValueError("skopeo must be installed to perform remote inspections")
     if results.return_code is not 0:
-        raise ValueError(results)
+        error = SkopeoError(results.stderr.decode('utf-8').rstrip()).msg #pylint: disable=no-member
+        raise ValueError(error)
     else:
         if return_json:
             return json.loads(results.stdout.decode('utf-8'))
@@ -885,3 +886,9 @@ class Decompose(object):
     def all(self):
         return self._registry, self._repo, self._image, self._tag, self._digest
 
+
+class SkopeoError(object):
+    def __init__(self, string_error):
+        for line in shlex.split(string_error):
+            key, _, msg = line.partition("=")
+            setattr(SkopeoError, key, msg)


### PR DESCRIPTION
When a fq image name is used, the error messages contained the full
stderr formed by skopeo.  It was preferable to only show the msg
portion of the error.