### PR TITLE
Fix Delete errors with images and containers

### DIFF
--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -12,6 +12,7 @@ from dateutil.parser import parse as dateparse
 from Atomic import Atomic
 import argparse
 import os
+from requests.exceptions import HTTPError
 
 try:
     from subprocess import DEVNULL  # pylint: disable=no-name-in-module
@@ -291,7 +292,12 @@ class DockerBackend(Backend):
             raise util.NoDockerDaemon()
 
     def delete_image(self, image, force=False):
-        return self.d.remove_image(image, force=force)
+        try:
+            return self.d.remove_image(image, force=force)
+        except errors.NotFound:
+            pass
+        except HTTPError:
+            pass
 
     def update(self, name, force=False, **kwargs):
         debug = kwargs.get('debug', False)

--- a/Atomic/delete.py
+++ b/Atomic/delete.py
@@ -9,6 +9,7 @@ storage = ATOMIC_CONFIG.get('default_storage', "docker")
 class Delete(Atomic):
     def __init__(self):
         super(Delete, self).__init__()
+        self.be = None
 
     def delete_image(self):
         """
@@ -18,7 +19,7 @@ class Delete(Atomic):
         if self.args.debug:
             util.write_out(str(self.args))
 
-        if len(self.args.delete_targets) > 0 and self.args.all:
+        if (len(self.args.delete_targets) > 0 and self.args.all) or (len(self.args.delete_targets) < 1 and not self.args.all):
             raise ValueError("You must select --all or provide a list of images to delete.")
 
         beu = BackendUtils()
@@ -31,7 +32,11 @@ class Delete(Atomic):
         # The failure here is basically that it couldnt verify/find the image.
 
         if self.args.all:
-            delete_objects = beu.get_images(get_all=True)
+            if self.args.storage:
+                self.be = beu.get_backend_from_string(self.args.storage)
+                delete_objects = self.be.get_images(get_all=True)
+            else:
+                delete_objects = beu.get_images(get_all=True)
         else:
             for image in self.args.delete_targets:
                 _, img_obj = beu.get_backend_and_image_obj(image, str_preferred_backend=self.args.storage or storage, required=True if self.args.storage else False)
@@ -39,7 +44,8 @@ class Delete(Atomic):
 
         if self.args.remote:
             return self._delete_remote(self.args.delete_targets)
-
+        if len(delete_objects) == 0:
+            raise ValueError("No images to delete.")
         _image_names = []
         for del_obj in delete_objects:
             if del_obj.repotags:
@@ -50,17 +56,21 @@ class Delete(Atomic):
 
         if not self.args.assumeyes:
             util.write_out("Do you wish to delete the following images?\n")
-            two_col = "   {0:" + str(max_img_name) + "} {1}"
-            util.write_out(two_col.format("IMAGE", "STORAGE"))
-            for del_obj in delete_objects:
-                image = None if not del_obj.repotags else del_obj.repotags[0]
-                if image is None or "<none>" in image:
-                    image = del_obj.id[0:12]
-                util.write_out(two_col.format(image, del_obj.backend.backend))
+        else:
+            util.write_out("The following images will be deleted.\n")
+
+        two_col = "   {0:" + str(max_img_name) + "} {1}"
+        util.write_out(two_col.format("IMAGE", "STORAGE"))
+        for del_obj in delete_objects:
+            image = None if not del_obj.repotags else del_obj.repotags[0]
+            if image is None or "<none>" in image:
+                image = del_obj.id[0:12]
+            util.write_out(two_col.format(image, del_obj.backend.backend))
+        if not self.args.assumeyes:
             confirm = util.input("\nConfirm (y/N) ")
             confirm = confirm.strip().lower()
             if not confirm in ['y', 'yes']:
-                util.write_err("User aborted delete operation for {}".format(self.args.delete_targets))
+                util.write_err("User aborted delete operation for {}".format(self.args.delete_targets or "all images"))
                 sys.exit(2)
 
         # Perform the delete
@@ -68,7 +78,7 @@ class Delete(Atomic):
             del_obj.backend.delete_image(del_obj.input_name, force=self.args.force)
 
         # We need to return something here for dbus
-        return
+        return 0
 
     def prune_images(self):
         """

--- a/tests/unit/test_delete.py
+++ b/tests/unit/test_delete.py
@@ -1,0 +1,111 @@
+#pylint: skip-file
+import unittest
+from Atomic.backendutils import BackendUtils
+from Atomic.backends._docker import DockerBackend
+from Atomic.backends._ostree import OSTreeBackend
+from Atomic.syscontainers import SystemContainers
+from Atomic.info import Info
+from Atomic.images import Images
+from Atomic.delete import Delete
+
+no_mock = True
+try:
+    from unittest.mock import MagicMock, patch
+    no_mock = False
+except ImportError:
+    try:
+        from mock import MagicMock, patch
+        no_mock = False
+    except ImportError:
+        # Mock is already set to False
+        pass
+
+docker_images = [{'Id': '7968321274dc6b6171697c33df7815310468e694ac5be0ec03ff053bb135e768', 'Size': 1109996, 'ParentId': '', 'Created': 1484345634, 'RepoTags': ['docker.io/busybox:latest'], 'VirtualSize': 1109996, 'RepoDigests': ['docker.io/busybox@sha256:817a12c32a39bbe394944ba49de563e085f1d3c5266eb8e9723256bc4448680e'], 'Labels': {}}, {'Id': '88e169ea8f46ff0d0df784b1b254a15ecfaf045aee1856dca1ec242fdd231ddd', 'Size': 3979756, 'ParentId': '', 'Created': 1482862645, 'RepoTags': ['docker.io/alpine:latest'], 'VirtualSize': 3979756, 'RepoDigests': ['docker.io/alpine@sha256:dfbd4a3a8ebca874ebd2474f044a0b33600d4523d03b0df76e5c5986cb02d7e8'], 'Labels': None}]
+ostree_images = [{'Id': '5040bd2983909aa8896b9932438c3f1479d25ae837a5f6220242a264d0221f2d', 'Labels': {}, 'ImageType': 'system', 'Version': '<none>', 'ImageId': '5040bd2983909aa8896b9932438c3f1479d25ae837a5f6220242a264d0221f2d', 'RepoTags': ['<none>'], 'OSTree-rev': 'fe2619a941bff9f323d1f5eef7fc3e05f2c82d421c4ba383ec646c888231752b', 'Created': 1486143371, 'Names': []}, {'Id': 'e5599115b6a67e08278d176b05a3defb30e5564f5be6d73264ec560b484514a2', 'Labels': {}, 'ImageType': 'system', 'Version': 'debian:latest', 'ImageId': 'e5599115b6a67e08278d176b05a3defb30e5564f5be6d73264ec560b484514a2', 'RepoTags': ['debian:latest'], 'OSTree-rev': '8d4551074942f65080a613d68a21f131fdebc0bf8ce437dd676bb4dbfa50fa08', 'Created': 1486143371, 'Names': []}, {'Id': '45a2e645736c4c66ef34acce2407ded21f7a9b231199d3b92d6c9776df264729', 'Labels': {}, 'ImageType': 'system', 'Version': '<none>', 'ImageId': '45a2e645736c4c66ef34acce2407ded21f7a9b231199d3b92d6c9776df264729', 'RepoTags': ['<none>'], 'OSTree-rev': 'a2512de2d19ab0916f9acce1ebd731203a336c366a1d002126c198ceff280375', 'Created': 1486143486, 'Names': []}, {'Id': '67591570dd29de0e124ee89d50458b098dbd83b12d73e5fdaf8b4dcbd4ea50f8', 'Labels': {}, 'ImageType': 'system', 'Version': 'centos:latest', 'ImageId': '67591570dd29de0e124ee89d50458b098dbd83b12d73e5fdaf8b4dcbd4ea50f8', 'RepoTags': ['centos:latest'], 'OSTree-rev': '1ce1d5393d4c1d4e04d70576be95ca598b26dff14aa9deacc92e06df5f71c470', 'Created': 1486143486, 'Names': []}]
+
+
+@unittest.skipIf(no_mock, "Mock not found")
+class TestInfo(unittest.TestCase):
+    class Args():
+        def __init__(self):
+            self.storage = None
+            self.force = False
+            self.all = False
+            self.assumeyes = True
+            self.debug = False
+            self.delete_targets = []
+            self.remote = False
+
+    def test_delete_no_images(self):
+        with patch('Atomic.backendutils.BackendUtils.get_images') as mockobj:
+            args = self.Args()
+            args.all = True
+            del_ = Delete()
+            del_.set_args(args)
+            mockobj.return_value([])
+            with self.assertRaises(ValueError):
+                del_.delete_image()
+
+    def test_delete_no_images_ostree(self):
+        with patch('Atomic.backends._ostree.OSTreeBackend.get_images') as mockobj:
+            args = self.Args()
+            args.all = True
+            args.storage = 'ostree'
+            del_ = Delete()
+            del_.set_args(args)
+            mockobj.return_value([])
+            with self.assertRaises(ValueError):
+                del_.delete_image()
+
+    def test_delete_no_images_docker(self):
+        with patch('Atomic.backends._docker.DockerBackend.get_images') as mockobj:
+            args = self.Args()
+            args.all = True
+            args.storage = 'docker'
+            del_ = Delete()
+            del_.set_args(args)
+            mockobj.return_value([])
+            with self.assertRaises(ValueError):
+                del_.delete_image()
+
+    def test_delete_all_and_images(self):
+        args = self.Args()
+        args.all = True
+        args.delete_targets = 'foobar'
+        del_ = Delete()
+        del_.set_args(args)
+        with self.assertRaises(ValueError):
+            del_.delete_image()
+
+    def test_delete_not_all_and_not_images(self):
+        args = self.Args()
+        args.delete_targets = []
+        del_ = Delete()
+        del_.set_args(args)
+        with self.assertRaises(ValueError):
+            del_.delete_image()
+
+
+    def test_delete_all_docker(self):
+        with patch('Atomic.backends._docker.DockerBackend.delete_image') as deleteobj:
+            with patch('Atomic.backends._docker.DockerBackend._get_images') as imageobj:
+                args = self.Args()
+                args.all = True
+                args.storage = 'docker'
+                del_ = Delete()
+                del_.set_args(args)
+                deleteobj.return_value = None
+                imageobj.return_value = docker_images
+                self.assertEqual(del_.delete_image(), 0)
+
+    def test_delete_all_ostree(self):
+        with patch('Atomic.backends._ostree.OSTreeBackend.delete_image') as deleteobj:
+            with patch('Atomic.syscontainers.SystemContainers.get_system_images') as imageobj:
+                args = self.Args()
+                args.all = True
+                args.storage = 'ostree'
+                del_ = Delete()
+                del_.set_args(args)
+                deleteobj.return_value = None
+                imageobj.return_value = ostree_images
+                self.assertEqual(del_.delete_image(), 0)


### PR DESCRIPTION
Fix a slew of issues related to deletion of images and containers.  Also
added --assume_yes to be consistent with other commands.  This will benefit
dbus interaction as well given that we do not want confirmation occuring
over dbus.

Issues that were fixed:
 * Proper catch and error for trying to delete all images|containers when no images|containers exist
 * Catch and error when no image|container is given by user and no --all
 * when --storage and --all are used, only images|containers in that backend are now deleted
 * when --all is given but not --storage, all images|containers from all backends are now deleted.
 * Fixed logical error when deleting containers
 * Deletion of images|containers now is consistent in its confirm and abort messages.

Added unittests.