### PR TITLE
Add git to atomic-tester

### DIFF
--- a/.redhat-ci.Dockerfile
+++ b/.redhat-ci.Dockerfile
@@ -8,6 +8,7 @@ MAINTAINER Jonathan Lebon <jlebon@redhat.com>
 # two separate images.
 
 RUN dnf install -y \
+	git \
         make \
         python3-pylint \
         python3-slip-dbus \


### PR DESCRIPTION
With the addition of git to the atomic-test image we can
script pulling and building the atomic cli on an
atomic host which lacks these tools.  It appears to add
about 12MB to the image.