### PR TITLE
Atomic/delete.py: Use available backends proporty

### DIFF
--- a/Atomic/delete.py
+++ b/Atomic/delete.py
@@ -89,7 +89,8 @@ class Delete(Atomic):
         if self.args.debug:
             util.write_out(str(self.args))
 
-        for backend in BackendUtils.BACKENDS:
+        beu = BackendUtils()
+        for backend in beu.available_backends:
             be = backend()
             be.prune()
 


### PR DESCRIPTION
The prune method should run without dockerd.  We now switched
to using the available_backends property instead of the
backends property.

This fixes https://github.com/projectatomic/atomic/issues/869.