### PR TITLE
dbus: Add convenience method for scan results lookup

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -790,6 +790,12 @@ def confirm_input(msg):
     return confirm.strip().lower() in ['y', 'yes']
 
 
+def load_scan_result_file(file_name):
+    """
+    Read a specific json file
+    """
+    return json.loads(open(os.path.join(file_name), "r").read())
+
 class Decompose(object):
     """
     Class for decomposing an input string in its respective parts like registry,

--- a/atomic_dbus_client.py
+++ b/atomic_dbus_client.py
@@ -196,6 +196,11 @@ class AtomicDBus (object):
     def vulnerable(self):
         return self.dbus_object.VulnerableInfo(dbus_interface="org.atomic")
 
+    @polkit.enable_proxy
+    def GetScanResultsById(self, iid):
+        return self.dbus_object.GetScanResultsById(iid, dbus_interface="org.atomic")
+
+
 #For outputting the list of scanners
 def print_scan_list(all_scanners):
     if len(all_scanners) == 0:


### PR DESCRIPTION
In the case of cockpit, it would be preferable to be able
to lookup scan results by a container or image's id.  If the
container or image has not been scanned, we throw an exception;
otherwise we return the resulting json file as a str.

One other possible exception can be thrown when attempting to read
the desired file from the filesystem.  If the file cannot be read,
an exception will be thrown.  Either way, it is a clear indicator
that the object needs to be scanned for fresh results.

The following is a simple *python* example:

from atomic_dbus_client import AtomicDBus
ad = AtomicDBus()
results = ad.get_scan_results_by_id('6858a846fb6b557331e068252fd910b5dc93f8e6341e641400bf4582dc34e10d')

Note the use of the full ID.  As of now, we only look up against the full id
as opposed to the short id form which is often used.