### PR TITLE
Atomic/update.py: Bug fix and enable dbus

### DIFF
--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -302,6 +302,8 @@ class DockerBackend(Backend):
 
     def update(self, name, force=False, **kwargs):
         debug = kwargs.get('debug', False)
+        # A TypeError is thrown if the force keywords is passed in addition to kwargs
+        force = kwargs.get('force', False)
         remote_image_obj = self.make_remote_image(name)
         try:
             # pull_image will raise a ValueError if the "latest" image is already present

--- a/Atomic/update.py
+++ b/Atomic/update.py
@@ -42,5 +42,4 @@ class Update(Atomic):
             input_name = img_obj.input_name
         except ValueError:
             raise ValueError("{} not found locally.  Unable to update".format(self.image))
-
-        be.update(input_name, self.args, force=self.args.force)
+        be.update(input_name, self.args)

--- a/atomic_dbus.py
+++ b/atomic_dbus.py
@@ -257,10 +257,11 @@ class atomic_dbus(slip.dbus.service.Object):
     # The ImagesUpdate method downloads the latest container image.
     @slip.dbus.polkit.require_auth("org.atomic.readwrite")
     @dbus.service.method("org.atomic", in_signature='sb', out_signature='')
-    def ImagesUpdate(self, image, force):
+    def ImageUpdate(self, image, force):
         u = Update()
         args = self.Args()
         args.image = image
+        args.name = image
         args.force = force
         u.set_args(args)
         return u.update()

--- a/atomic_dbus_client.py
+++ b/atomic_dbus_client.py
@@ -94,10 +94,8 @@ class AtomicDBus (object):
     def ImagePull(self, image, storage="docker", reg_type=""):
         return self.dbus_object.ImagePull(image, storage, reg_type, dbus_interface="org.atomic", timeout = 2147400)
 
-    def ImagesUpdate(self, images, force=False):
-        if not isinstance(images, (list, tuple)):
-            images = [ images ]
-        return self.dbus_object.ImagesInfo(images, force, dbus_interface="org.atomic")
+    def ImageUpdate(self, image, force=False):
+        return self.dbus_object.ImageUpdate(image, force, dbus_interface="org.atomic")
 
     @polkit.enable_proxy
     def ImageVersion(self, image, recurse=False):


### PR DESCRIPTION
There was a bug in the update code where passing the
kwargs and the named variable force resulted in a TypeError
for multiple values existing.

Fixed by not passing the force keyword to _docker.py and
extracting the keyword from the kwargs.