### PR TITLE
syscontainers: support update containers with --rebase

### DIFF
--- a/Atomic/containers.py
+++ b/Atomic/containers.py
@@ -73,6 +73,8 @@ def cli(subparser):
     updatep.set_defaults(_class=Containers, func='update')
     updatep.add_argument("container",
                          help=_("Specify one or more containers. Must be final arguments."))
+    updatep.add_argument("--rebase", dest="rebase", default=None,
+                         help=_("Update to a different image (useful for upgrading to a different tag)"))
     if OSTREE_PRESENT:
         updatep.add_argument("--set", dest="setvalues",
                              action='append',
@@ -263,9 +265,9 @@ class Containers(Atomic):
             if con.id in vulnerable_uuids:
                 con.vulnerable = True
 
-    def update(self, to=None):
+    def update(self):
         if self.syscontainers.get_checkout(self.args.container):
-            return self.syscontainers.update_container(self.args.container, self.args.setvalues)
+            return self.syscontainers.update_container(self.args.container, self.args.setvalues, self.args.rebase)
         raise ValueError("System container '%s' is not installed" % self.args.container)
 
     def rollback(self):

--- a/Atomic/containers.py
+++ b/Atomic/containers.py
@@ -263,9 +263,9 @@ class Containers(Atomic):
             if con.id in vulnerable_uuids:
                 con.vulnerable = True
 
-    def update(self):
+    def update(self, to=None):
         if self.syscontainers.get_checkout(self.args.container):
-            return self.syscontainers.update_container(self.args.container)
+            return self.syscontainers.update_container(self.args.container, self.args.setvalues)
         raise ValueError("System container '%s' is not installed" % self.args.container)
 
     def rollback(self):

--- a/Atomic/containers.py
+++ b/Atomic/containers.py
@@ -74,7 +74,7 @@ def cli(subparser):
     updatep.add_argument("container",
                          help=_("Specify one or more containers. Must be final arguments."))
     updatep.add_argument("--rebase", dest="rebase", default=None,
-                         help=_("Update to a different image (useful for upgrading to a different tag)"))
+                         help=_("Rebase to a different image (useful for upgrading to a different tag)"))
     if OSTREE_PRESENT:
         updatep.add_argument("--set", dest="setvalues",
                              action='append',

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -586,7 +586,7 @@ class SystemContainers(object):
             return [image_inspect]
         return None
 
-    def update_container(self, name, setvalues=None):
+    def update_container(self, name, setvalues=None, rebase=None):
         repo = self._get_ostree_repo()
         if not repo:
             raise ValueError("Cannot find a configured OSTree repo")
@@ -605,7 +605,7 @@ class SystemContainers(object):
         with open(os.path.join(self._get_system_checkout_path(), name, "info"), "r") as info_file:
             info = json.loads(info_file.read())
 
-        image = info["image"]
+        image = rebase or info["image"]
         values = info["values"]
         revision = info["revision"] if "revision" in info else None
 

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -502,6 +502,8 @@ class SystemContainers(object):
             image_manifest = json.loads(image_manifest)
             if 'Digest' in image_manifest:
                 image_id = image_manifest['Digest'].replace("sha256:", "")
+            if 'config' in image_manifest and 'digest' in image_manifest['config']:
+                image_id = image_manifest['config']['digest'].replace("sha256:", "")
 
         with open(os.path.join(destination, "info"), 'w') as info_file:
             info = {"image" : img,

--- a/bash/atomic
+++ b/bash/atomic
@@ -578,7 +578,7 @@ _atomic_containers_trim() {
 _atomic_containers_update() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help --set" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help --set --rebase" -- "$cur" ) )
 			;;
 		*)
 		    __atomic_system_containers_containers

--- a/docs/atomic-containers.1.md
+++ b/docs/atomic-containers.1.md
@@ -87,6 +87,9 @@ Can use --set to update environment variables.
   Only display container IDs
 
 # update OPTIONS:
+**--rebase=IMAGE**
+  Override the image to update to.  if not specified, the same image used to install the container will be used.
+
 **--set=NAME=VALUE**
   Set a value that is going to be used by a system container for its configuration and can be specified multiple times.  OSTree is required for this feature to be available.
 

--- a/docs/atomic-containers.1.md
+++ b/docs/atomic-containers.1.md
@@ -88,7 +88,7 @@ Can use --set to update environment variables.
 
 # update OPTIONS:
 **--rebase=IMAGE**
-  Override the image to update to.  if not specified, the same image used to install the container will be used.
+  Rebase to a different image.  If not specified, the same image used to install the container will be used.
 
 **--set=NAME=VALUE**
   Set a value that is going to be used by a system container for its configuration and can be specified multiple times.  OSTree is required for this feature to be available.

--- a/tests/integration/test_system_containers.sh
+++ b/tests/integration/test_system_containers.sh
@@ -176,6 +176,9 @@ assert_matches 8081 ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.0/config.json
 ${ATOMIC} containers update ${NAME} > update.out
 assert_matches "Latest version already installed" update.out
 
+${ATOMIC} containers update ${NAME} --rebase oci:atomic-test-system > update.out
+assert_matches "Latest version already installed" update.out
+
 ${ATOMIC} containers update --set=PORT=8082 ${NAME}
 test -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.1/${NAME}.service
 test -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.1/tmpfiles-${NAME}.conf


### PR DESCRIPTION
A couple of features I'd like to have for the OpenShift installer:

1) support `containers update --to`, let's not require to uninstall/install the container if updating to a different image/tag, it will enable to do things like:
```
atomic install --system --name origin origin:v1.3.4
atomic containers update origin --to origin:v1.3.5
```

2) make `containers update` smarter and not require an update if neither the image revision and the configuration was changed.  Before we were checking only for the image revision or if --set was used, not caring if it was used to set to the same configuration already in place.