### PR TITLE
Account for API Changes in docker-py-2

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -9,7 +9,7 @@ import requests
 
 from . import util
 import re
-from .util import NoDockerDaemon, DockerObjectNotFound
+from Atomic.backends._docker_errors import NoDockerDaemon, DockerObjectNotFound
 from docker.errors import NotFound
 from .discovery import RegistryInspect, RegistryInspectError
 

--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -12,6 +12,7 @@ from dateutil.parser import parse as dateparse
 from Atomic import Atomic
 import os
 from requests.exceptions import HTTPError
+from Atomic.backends._docker_errors import NoDockerDaemon
 
 try:
     from subprocess import DEVNULL  # pylint: disable=no-name-in-module
@@ -28,7 +29,7 @@ class DockerBackend(Backend):
         try:
             _ = self.d
             return True
-        except util.NoDockerDaemon:
+        except NoDockerDaemon:
             return False
 
     @property
@@ -289,7 +290,7 @@ class DockerBackend(Backend):
         try:
             self.d.ping()
         except exceptions.ConnectionError:
-            raise util.NoDockerDaemon()
+            raise NoDockerDaemon()
 
     def delete_image(self, image, force=False):
         assert(image is not None)

--- a/Atomic/backends/_docker_errors.py
+++ b/Atomic/backends/_docker_errors.py
@@ -1,0 +1,7 @@
+class DockerObjectNotFound(ValueError):
+    def __init__(self, msg):
+        super(DockerObjectNotFound, self).__init__("Unable to associate '{}' with an image or container".format(msg))
+        
+class NoDockerDaemon(Exception):
+    def __init__(self):
+        super(NoDockerDaemon, self).__init__("The docker daemon does not appear to be running.")

--- a/Atomic/backendutils.py
+++ b/Atomic/backendutils.py
@@ -1,4 +1,5 @@
 from Atomic.backends._docker import DockerBackend
+from Atomic.backends._docker_errors import NoDockerDaemon
 from Atomic.backends._ostree import OSTreeBackend
 from Atomic.util import write_out, get_atomic_config
 
@@ -19,9 +20,12 @@ class BackendUtils(object):
     def _set_available_backends(self):
         bes = []
         for x in self.BACKENDS:
-            be = x()
-            if be.available:
-                bes.append(x)
+            try:
+                be = x()
+                if be.available:
+                    bes.append(x)
+            except NoDockerDaemon:
+                pass
         if len(bes) < 1:
             raise ValueError("No backends are enabled for Atomic.")
         return bes

--- a/Atomic/mount.py
+++ b/Atomic/mount.py
@@ -29,7 +29,7 @@ import time
 import docker
 from . import util
 import requests
-from .util import NoDockerDaemon
+from Atomic.backends._docker_errors import NoDockerDaemon
 import shutil
 from .syscontainers import OSTREE_PRESENT as OSTREE_PRESENT
 from gi.repository import GLib  # pylint: disable=no-name-in-module

--- a/Atomic/storage.py
+++ b/Atomic/storage.py
@@ -6,7 +6,8 @@ import os
 from . import util
 from .Export import export_docker
 from .Import import import_docker
-from .util import NoDockerDaemon, default_docker_lib
+from .util import default_docker_lib
+from Atomic.backends._docker_errors import NoDockerDaemon
 import subprocess
 
 try:

--- a/Atomic/top.py
+++ b/Atomic/top.py
@@ -9,7 +9,7 @@ import select
 from os import isatty
 from operator import itemgetter
 import requests
-from .util import NoDockerDaemon
+from Atomic.backends._docker_errors import NoDockerDaemon
 
 def check_negative(value):
     ivalue = int(value)

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -364,14 +364,6 @@ def skopeo_copy(source, destination, debug=False, sign_by=None, insecure=False, 
     return check_call(cmd)
 
 
-class NoDockerDaemon(Exception):
-    def __init__(self):
-        super(NoDockerDaemon, self).__init__("The docker daemon does not appear to be running.")
-
-
-class DockerObjectNotFound(ValueError):
-    def __init__(self, msg):
-        super(DockerObjectNotFound, self).__init__("Unable to associate '{}' with an image or container".format(msg))
 
 def get_atomic_config(atomic_config=None):
     """

--- a/atomic
+++ b/atomic
@@ -52,7 +52,8 @@ from Atomic import update
 from Atomic import verify
 from Atomic.mount import MountError
 from Atomic import images
-from Atomic.util import write_err, NoDockerDaemon
+from Atomic.util import write_err
+from Atomic.backends._docker_errors import NoDockerDaemon
 
 PROGNAME = "atomic"
 gettext.bindtextdomain(PROGNAME, "/usr/share/locale")


### PR DESCRIPTION
The new 2.x version of the docker python API has non-backward
compatible changes.  These changes are described here:

https://docker-py.readthedocs.io/en/stable/change-log.html#breaking-changes

We need to account for docker.Client and docker.APIClient as well
as changes in the way kwargs are handled.  Also, it appears the
AutoVersion method is deprecated.