### PR TITLE
Fix FQ Name for SystemContainers

### DIFF
--- a/Atomic/backends/_ostree.py
+++ b/Atomic/backends/_ostree.py
@@ -5,6 +5,7 @@ from Atomic.objects.container import Container
 from Atomic.syscontainers import SystemContainers
 from Atomic.objects.layer import Layer
 from json import loads as json_loads
+from Atomic.util import Decompose
 
 class OSTreeBackend(Backend):
 
@@ -56,16 +57,13 @@ class OSTreeBackend(Backend):
         img_obj.config = info
         img_obj.backend = self
         img_obj.id = name
-        img_obj.registry = None
-        img_obj.repo = None
-        img_obj.image = image
-        img_obj.tag = 'latest'
+        img_obj.registry, img_obj.repo, img_obj.image, img_obj.tag, _ = Decompose(image).all
         img_obj.repotags = info['RepoTags']
         img_obj.created = info['Created']
         img_obj.size = None
         img_obj.original_structure = info
         img_obj.deep = True
-        img_obj.labels = info['Labels']
+        img_obj.labels = info.get('Labels', None)
         img_obj.version = img_obj.get_label("Version")
         img_obj.release = img_obj.get_label("Release")
         ostree_manifest = self.syscontainers.get_manifest(image)

--- a/Atomic/objects/image.py
+++ b/Atomic/objects/image.py
@@ -245,8 +245,8 @@ class Image(object):
         return 'image'
 
     def _get_template_info(self):
-        self._template_variables_set, self._template_variables_unset = self.backend.syscontainers.\
-            get_template_variables(self.image)
+        self._template_variables_set, self._template_variables_unset = \
+            self.backend.syscontainers.get_template_variables(self.image)
 
     @property
     def template_variables_set(self):

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -734,7 +734,7 @@ class SystemContainers(object):
         repo = self._get_ostree_repo()
         imgs = self._resolve_image(repo, image)
         if not imgs:
-            return
+            return None, None
         _, commit_rev = imgs[0]
         manifest = self._image_manifest(repo, commit_rev)
         layers = SystemContainers.get_layers_from_manifest(json.loads(manifest))


### PR DESCRIPTION
When calling atomic images info --storage ostree <some_image>, the
FQ Name of the image being returned was incorrect.  We now call
Decompose to set the name correctly in the image object.

This was reported as a side issue in https://github.com/projectatomic/atomic/issues/870