### PR TITLE
Fix Stop Regression: BZ #1422448

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -157,6 +157,12 @@ class Atomic(object):
             if self.system or self.user:
                 self.name = self.syscontainers.get_default_system_name(self.image)
 
+        try:
+            if not self.name and args.container:
+                self.name = args.container
+        except (NameError, AttributeError):
+            pass
+
         self.syscontainers.set_args(self.args)
 
     def _getconfig(self, key, default=None):

--- a/Atomic/backends/_ostree.py
+++ b/Atomic/backends/_ostree.py
@@ -100,7 +100,7 @@ class OSTreeBackend(Backend):
     def start_container(self, name):
         return self.syscontainers.start_service(name)
 
-    def stop_container(self, con_obj):
+    def stop_container(self, con_obj, **kwargs):
         return self.syscontainers.stop_service(con_obj.id)
 
     def get_images(self, get_all=False):

--- a/Atomic/backends/backend.py
+++ b/Atomic/backends/backend.py
@@ -110,7 +110,7 @@ class Backend(object): #pylint: disable=metaclass-assignment
         pass
 
     @abstractmethod
-    def stop_container(self, con_obj):
+    def stop_container(self, con_obj, **kwargs):
         pass
 
     @abstractmethod

--- a/Atomic/trust.py
+++ b/Atomic/trust.py
@@ -80,6 +80,13 @@ def cli(subparser):
     resetp = subparsers.add_parser("reset", help="Reset trust policy")
     resetp.set_defaults(_class=Trust, func="reset")
 
+class Args():
+    def __init__(self):
+        self.debug = None
+        self.assumeyes = None
+        self.pubkeysfile = None
+
+
 class Trust(Atomic):
     def __init__(self, policy_filename="/etc/containers/policy.json"):
         """
@@ -88,11 +95,6 @@ class Trust(Atomic):
         super(Trust, self).__init__()
         self.policy_filename = os.environ.get('TRUST_POLICY', policy_filename)
         self.atomic_config = util.get_atomic_config()
-        class Args():
-            def __init__(self):
-                self.debug = None
-                self.assumeyes = None
-                self.pubkeysfile = None
         self.set_args(Args())
 
     def add(self, registry=None, pubkeys=None, pubkeysfile=None, sigstore=None, sigstoretype=None, keytype=None, trust_type=None):

--- a/bash/atomic
+++ b/bash/atomic
@@ -1138,9 +1138,15 @@ _atomic_unmount() {
 }
 
 _atomic_stop() {
+    local options_with_args="
+		--name -n
+		"
+    local all_options="$options_with_args
+        --display
+        "
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--name -n" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "$all_options" -- "$cur" ) )
 			;;
 		*)
 			__atomic_containers_running

--- a/docs/atomic-stop.1.md
+++ b/docs/atomic-stop.1.md
@@ -6,6 +6,7 @@ atomic-stop - Execute container image stop method
 
 # SYNOPSIS
 **atomic stop**
+[**--display**]
 [**-h**|**--help**]
 container [ARG...]
 
@@ -27,6 +28,10 @@ the container is running.
 Any additional arguments will be appended to the command.
 
 # OPTIONS:
+**--display**
+  Display the container's stop options and environment variables populated into the stop command.
+The stop command will not execute if --display is specified.
+If --display is not specified the stop command will execute.
 **-h** **--help**
   Print usage statement
 

--- a/tests/integration/test_display.sh
+++ b/tests/integration/test_display.sh
@@ -69,3 +69,14 @@ if [[ ${OUTPUT} != ${OUTPUT2} ]]; then
     echo "Failed ${TNAME} 7"
     exit 1
 fi
+
+# Test for regression on atomic stop
+CID=`docker run -d atomic-test-6 sleep 100`
+OUTPUT=`${ATOMIC} stop --display ${CID}`
+OUTPUT2="docker stop ${CID}"
+docker stop ${CID}
+
+if [[ ${OUTPUT} != ${OUTPUT2} ]]; then
+    echo "Failed ${TNAME} 8"
+    exit 1
+fi

--- a/tests/test-images/Dockerfile.6
+++ b/tests/test-images/Dockerfile.6
@@ -5,3 +5,4 @@ LABEL INSTALL 'docker run --rm=true --net=host -v /:/host -e NAME=${NAME} -e IMA
 LABEL "Name"="atomic-test-6"
 LABEL RUN_OPTS_FILE '$PWD/docker-run-opts-${NAME}'
 LABEL RUN 'docker run --rm=true ${RUN_OPTS} ${IMAGE} /bin/show-hostname.sh'
+LABEL STOP 'docker stop $NAME'


### PR DESCRIPTION
BZ #1422448 actually points out one regression and one
bug related to atomic stop. The BZ itself points out
a TypeError exception in the code when trying to glue
together a python list and str.

Then the atomic stop command was failling in the case where a
STOP label was defined and it uses the variable $NAME resulting
in a subprocess exception.

The self.name variable was not being set by set_args after
refactoring occured.  Ideally, this should all be moved
into the image|container object handling but for now we
just handle it in set_args.

Also added a test in test_display to catch any future
regressions.