### PR TITLE
Do not print docker command for atomic scan without verbose

### DIFF
--- a/Atomic/diff.py
+++ b/Atomic/diff.py
@@ -22,8 +22,6 @@ def cli(subparser):
                        help=_("Container images to compare"))
     diffp.add_argument("-m", "--metadata", default=False, action='store_true', dest='metadata',
                        help=_("Compare images' metadata"))
-    diffp.add_argument("--json", default=False, action='store_true',
-                       help=_("output json"))
     diffp.add_argument("-k", "--keywords", nargs='?',
                        action='append',
                        choices=['all'] + CHOICES,
@@ -34,8 +32,12 @@ def cli(subparser):
                        action='store_true', help=_("Only compare RPM names and not versions"))
     diffp.add_argument("-r", "--rpms", default=False, action='store_true',
                        help=_("List different rpms between the container images."))
-    diffp.add_argument("-v", "--verbose", default=False, action='store_true',
-                       help=_("Show verbose output, listing all RPMs"))
+    disp_group = diffp.add_mutually_exclusive_group()
+    disp_group.add_argument("--json", default=False, action='store_true',
+                            help=_("output json"))
+    disp_group.add_argument("-v", "--verbose", default=False, action='store_true',
+                            help=_("Show verbose output, listing all RPMs"))
+
 
 
 class Diff(Atomic):

--- a/Atomic/scan.py
+++ b/Atomic/scan.py
@@ -19,8 +19,9 @@ def cli(subparser):
     scanp.add_argument("--scanner", choices=[x['scanner_name'] for x in scanners], default=None, help=_("define the intended scanner"))
     scanp.add_argument("--scan_type", default=None, help=_("define the intended scan type"))
     scanp.add_argument("--list", action='store_true', default=False, help=_("List available scanners"))
-    scanp.add_argument("--verbose", action='store_true', default=False, help=_("Show more output from scanning container"))
-    scanp.add_argument("--json", action='store_true', default=False, help=_("Output results in JSON format"))
+    disp_group = scanp.add_mutually_exclusive_group()
+    disp_group.add_argument("--verbose", action='store_true', default=False, help=_("Show more output from scanning container"))
+    disp_group.add_argument("--json", action='store_true', default=False, help=_("Output results in JSON format"))
     scan_group.add_argument("--rootfs", nargs='?', default=[], action='append', help=_("Rootfs path to scan"))
     scan_group.add_argument("--all", default=False, action='store_true', help=_("scan all images (excluding intermediate layers) and containers"))
     scan_group.add_argument("--images", default=False, action='store_true', help=_("scan all images (excluding intermediate layers)"))
@@ -144,7 +145,7 @@ class Scan(Atomic):
         scan_cmd = self.sub_env_strings(" ".join(scan_cmd))
 
         # Show the command being run
-        if self.useTTY and (self.args.verbose or self.args.debug):
+        if self.useTTY and not self.args.json:
             util.write_out(scan_cmd)
 
         # Show stdout from container if --debug or --verbose

--- a/Atomic/scan.py
+++ b/Atomic/scan.py
@@ -144,7 +144,7 @@ class Scan(Atomic):
         scan_cmd = self.sub_env_strings(" ".join(scan_cmd))
 
         # Show the command being run
-        if self.useTTY:
+        if self.useTTY and (self.args.verbose or self.args.debug):
             util.write_out(scan_cmd)
 
         # Show stdout from container if --debug or --verbose


### PR DESCRIPTION
When running atomic scan <img> --json, docker command is printed on stdout,
which makes the JSON output invalid:

```
#> atomic scan <img> --json >/tmp/out.json
#> cat /tmp/out.json
docker run -t --rm -v /etc/localtime:/etc/localtime -v /run/atomic/2017-02-24-13-29-15-255245:/scanin -v /var/lib/atomic/openscap/2017-02-24-13-29-15-255245:/scanout:rw,Z -v /etc/oscapd:/etc/oscapd:ro rhel7/openscap oscapd-evaluate scan --no-standard-compliance --targets chroots-in-dir:///scanin --output /scanout
{
    "Vulnerabilities": [],
    "Time": "2017-02-24T13:29:18",
    "Scanner": "openscap",
    "CVE Feed Last Updated": "2017-02-24T06:10:03",
    "UUID": "/scanin/95064c8c85af597c35a18b2581555c1e1a8640c72dd96551c43699ade9b398ea",
    "Successful": "true",
    "Finished Time": "2017-02-24T13:29:23",
    "Scan Type": "CVE"
}
```

This change only prints the docker command when --verbose or --debug options
are used.