### PR TITLE
Atomic/storage.py: Prevent circular dep on dockerd

### DIFF
--- a/Atomic/storage.py
+++ b/Atomic/storage.py
@@ -149,9 +149,8 @@ class Storage(Atomic):
         try:
             self.d.info()
             raise ValueError("Docker daemon must be stopped before resetting storage")
-        except requests.exceptions.ConnectionError:
+        except (NoDockerDaemon, requests.exceptions.ConnectionError):
             pass
-
         util.check_call(["docker-storage-setup", "--reset"], stdout=DEVNULL)
         util.call(["umount", root + "/devicemapper"], stderr=DEVNULL)
         util.call(["umount", root + "/overlay"], stderr=DEVNULL)


### PR DESCRIPTION
atomic storage reset requires that the dockerd be inactive.  However,
calling the d.info() requires that docker be active.  Adding the
NoDockerDaemon exception allows it to progress without the daemon.

This fixes https://github.com/projectatomic/atomic/issues/910