### PR TITLE
Atomic/util.py Fix Try/Catch exceptions for dockerd

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -20,6 +20,7 @@ import re
 import requests
 import ipaddress
 import socket
+from Atomic.backends._docker_errors import NoDockerDaemon
 # Atomic Utility Module
 
 ReturnTuple = collections.namedtuple('ReturnTuple',
@@ -55,7 +56,7 @@ def get_docker_conf():
     with AtomicDocker() as c:
         try:
             dconf = c.info()
-        except requests.exceptions.ConnectionError:
+        except (NoDockerDaemon, requests.exceptions.ConnectionError):
             raise ValueError("This Atomic function requires an active docker daemon.")
     return dconf
 


### PR DESCRIPTION
Fix a cirucular dependancy in atomic storage reset where certain
functions require a dockerd but storage reset requires dockerd to
be stopped.