### PR TITLE
Atomic/storage.py: Reduce number of times NoDockerDaemon is called

### DIFF
--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -68,7 +68,10 @@ class Atomic(object):
         return self
 
     def __exit__(self, typ, value, traceback):
-        self.d.close()
+        try:
+            self.d.close()
+        except NoDockerDaemon:
+            pass
 
     def docker_binary(self):
         if not self.docker_cmd:

--- a/Atomic/storage.py
+++ b/Atomic/storage.py
@@ -20,6 +20,11 @@ try:
 except ImportError:
     from atomic import Atomic # pylint: disable=relative-import
 
+try:
+    _default_docker_lib = default_docker_lib()
+except NoDockerDaemon:
+    _default_docker_lib = None
+
 def cli(subparser):
     # atomic storage
     storagep = subparser.add_parser(
@@ -35,8 +40,8 @@ def cli(subparser):
                                            "containers, and volumes into a filesystem directory.")
     exportp.set_defaults(_class=Storage, func='Export')
     exportp.add_argument("--graph", dest="graph",
-                         default=default_docker_lib(),
-                         help=_("Root of the Docker runtime (Default: %s)" % default_docker_lib()))
+                         default=_default_docker_lib,
+                         help=_("Root of the Docker runtime (Default: %s)" % _default_docker_lib))
     exportp.add_argument("--dir", dest="export_location",
                          default="/var/lib/atomic/migrate",
                          help=_("Path for exporting container's content (Default: /var/lib/atomic/migrate)"))
@@ -48,8 +53,8 @@ def cli(subparser):
                                            "containers, and volumes from a filesystem directory.")
     importp.set_defaults(_class=Storage, func='Import')
     importp.add_argument("--graph", dest="graph",
-                         default=default_docker_lib(),
-                         help=_("Root of the Docker runtime (Default: %s)" % default_docker_lib()))
+                         default=_default_docker_lib,
+                         help=_("Root of the Docker runtime (Default: %s)" % _default_docker_lib))
 
     importp.add_argument("--dir", dest="import_location",
                          default="/var/lib/atomic/migrate",
@@ -70,16 +75,16 @@ def cli(subparser):
     modifyp.add_argument('--driver', dest="driver", default=None, help='The storage backend driver', choices=['devicemapper', 'overlay', 'overlay2'])
     modifyp.add_argument('--vgroup', dest="vgroup", default=None, help='The storage volume group')
     modifyp.add_argument("--graph", dest="graph",
-                        default=default_docker_lib(),
-                        help=_("Root of the Docker runtime (Default: %s)" % default_docker_lib()))
+                        default=_default_docker_lib,
+                        help=_("Root of the Docker runtime (Default: %s)" % _default_docker_lib))
     modifyp.set_defaults(_class=Storage, func='modify')
 
     # atomic storage reset
     resetp = storage_subparser.add_parser("reset",
                                           help=_("delete all containers/images from your system. Reset storage to its initial configuration."))
     resetp.add_argument("--graph", dest="graph",
-                        default=default_docker_lib(),
-                        help=_("Root of the Docker runtime (Default: %s)" % default_docker_lib()))
+                        default=_default_docker_lib,
+                        help=_("Root of the Docker runtime (Default: %s)" % _default_docker_lib))
     resetp.set_defaults(_class=Storage, func='reset')
 
 def query_pvs(pv, fields):

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -53,11 +53,9 @@ input, is_python2 = check_if_python2() # pylint: disable=redefined-builtin
 
 
 def get_docker_conf():
+    dconf = []
     with AtomicDocker() as c:
-        try:
-            dconf = c.info()
-        except (NoDockerDaemon, requests.exceptions.ConnectionError):
-            raise ValueError("This Atomic function requires an active docker daemon.")
+        dconf = c.info()
     return dconf
 
 def get_registries():
@@ -447,7 +445,7 @@ default_docker.cache = None
 def default_docker_lib():
     try:
         return get_docker_conf()["DockerRootDir"]
-    except ValueError:
+    except (NoDockerDaemon, requests.ConnectionError):
         # looks like dockerd is not running
         pass
 


### PR DESCRIPTION
Instead of calling the default_docker_lib function a bunch of times
in the arg parser, we call it one and use the result in the parser.

Also, tighten up some exit conditions where self.d.close() is being
called when dockerd is not running.