### PR TITLE
syscontainers: when using --rootfs create a symlink to rootfs

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -505,6 +505,9 @@ class SystemContainers(object):
                 config['root']['path'] = remote_rootfs
             with open(destination_path, 'w') as config_file:
                 config_file.write(json.dumps(config, indent=4))
+            # create a symlink to the real rootfs, so that it is possible
+            # to access the rootfs in the same way as in the not --remote case.
+            os.symlink(remote_rootfs, os.path.join(destination, "rootfs"))
 
         # When upgrading, stop the service and remove previously installed
         # tmpfiles, before restarting the service.

--- a/tests/integration/test_system_containers.sh
+++ b/tests/integration/test_system_containers.sh
@@ -205,11 +205,10 @@ systemctl start ${NAME}-remote
 
 ${ATOMIC} --debug containers list --no-trunc > ps.out
 assert_matches "remote" ps.out
-test -h /var/lib/containers/atomic/${NAME}/rootfs
 test -e /etc/systemd/system/${NAME}-remote.service
 
-# The rootfs should not exist
-test \! -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}-remote.0/rootfs
+# The rootfs should be a symlink
+test -h ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}-remote/rootfs
 
 # Values should still be able to be updated for remote containers
 ${ATOMIC} containers update --set=PORT=8083 ${NAME}-remote

--- a/tests/integration/test_system_containers.sh
+++ b/tests/integration/test_system_containers.sh
@@ -205,6 +205,7 @@ systemctl start ${NAME}-remote
 
 ${ATOMIC} --debug containers list --no-trunc > ps.out
 assert_matches "remote" ps.out
+test -h /var/lib/containers/atomic/${NAME}/rootfs
 test -e /etc/systemd/system/${NAME}-remote.service
 
 # The rootfs should not exist


### PR DESCRIPTION
In this way it is still possible to access $DESTDIR/rootfs as in the
case --rootfs is not specified.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>