### PR TITLE
syscontainers: do not resolve the image name if Docker is down

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -446,6 +446,10 @@ class SystemContainers(object):
             values["RUN_DIRECTORY"] = "/run"
             values["STATE_DIRECTORY"] = "/var/lib"
 
+        if not os.path.exists(exports):
+            util.write_out("""Warning: /exports directory not found.  Default config files will be generated.
+Warning: You may want to modify `%s` before starting the service""" % os.path.join(destination, "config.json"))
+
         # When installing a new system container, set values in this order:
         #
         # 1) What comes from manifest.json, if present, as default value.


### PR DESCRIPTION
there are 2 small improvements here:

1) if the image cannot be resolved, use the provided image name.  It won't cause an error when Docker is down.
2) Print a warning if the image is not ready to be used as a system container, suggest the user to manually modify the generated config.json file before trying to run the service.