### PR TITLE
Atomic/discovery.py: Fix exception with FQDN in atomic sign

### DIFF
--- a/Atomic/discovery.py
+++ b/Atomic/discovery.py
@@ -29,7 +29,7 @@ class RegistryInspect():
     @property
     def fqdn(self):
         if not self._fqdn:
-            self.fqdn = self.assemble_fqdn(include_tag=True) if self.registry else self.find_image_on_registry()
+            self._fqdn = self.assemble_fqdn(include_tag=True) if self.registry else self.find_image_on_registry()
         return self._fqdn
 
     @fqdn.setter
@@ -37,8 +37,6 @@ class RegistryInspect():
         self._fqdn = value
 
     def inspect(self):
-        if not self.fqdn:
-            _ = self.fqdn
         if self.registry:
             inspect_data = util.skopeo_inspect("docker://{}".format(self.fqdn), return_json=True)
         else:

--- a/Atomic/discovery.py
+++ b/Atomic/discovery.py
@@ -21,17 +21,27 @@ class RegistryInspect():
         self.digest = digest
         self.orig_input = orig_input
         self._remote_inspect = None
-        self.fqdn = None
+        self._fqdn = None
 
         if self.debug:
             util.output_json(self.registries)
 
+    @property
+    def fqdn(self):
+        if not self._fqdn:
+            self.fqdn = self.assemble_fqdn(include_tag=True) if self.registry else self.find_image_on_registry()
+        return self._fqdn
+
+    @fqdn.setter
+    def fqdn(self, value):
+        self._fqdn = value
+
     def inspect(self):
+        if not self.fqdn:
+            _ = self.fqdn
         if self.registry:
-            self.fqdn = self.assemble_fqdn(include_tag=True)
             inspect_data = util.skopeo_inspect("docker://{}".format(self.fqdn), return_json=True)
         else:
-            self.fqdn = self.find_image_on_registry()
             inspect_data = self._remote_inspect
         inspect_data['Tag'] = self.tag
         inspect_data['Name'] = self.assemble_fqdn(include_tag=False)

--- a/Atomic/sign.py
+++ b/Atomic/sign.py
@@ -137,8 +137,9 @@ class Sign(Atomic):
         cmd = ['gpg2', '--no-permission-warning', '--with-colons', '--fingerprint', signer]
         stdout = util.check_output(cmd)
         for line in stdout.splitlines():
-            if line.startswith('fpr:'):
-                return line.split(":")[9]
+            _line = line.decode('utf-8')
+            if _line.startswith('fpr:'):
+                return _line.split(":")[9]
 
     @staticmethod
     def make_sig_dirs(sig_path):


### PR DESCRIPTION
When running atomic sign, we were throwing an exception because
the fqdn has not been determined yet.  Made fqdn a property instead
of a variable.  The property will define itself.