### PR TITLE
Fix outdated container image message (BZ 1434430)

### DIFF
--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -189,7 +189,7 @@ class DockerBackend(Backend):
 
         else:
             con_obj.status = con_struct['Status']
-            con_obj.image_id = con_struct['ImageID']
+            con_obj.image = con_struct['ImageID']
             con_obj.image_name = con_struct['Image']
 
         return con_obj
@@ -305,7 +305,7 @@ class DockerBackend(Backend):
     def get_containers_by_image(self, img_obj):
         containers = []
         for container in self.get_containers():
-            if img_obj.id == container.image_id:
+            if img_obj.id == container.image:
                 containers.append(container)
         return containers
 
@@ -367,7 +367,6 @@ class DockerBackend(Backend):
         assert(isinstance(atomic, Atomic))
         args = atomic.args
         con_obj = None if not name else self.has_container(name)
-
         # We have a container by that name, need to stop and delete it
         if con_obj:
             if con_obj.running:
@@ -438,7 +437,7 @@ class DockerBackend(Backend):
             iobject.user_command = args.command
         if isinstance(iobject, Container):
             latest_image = self.inspect_image(iobject.image_name)
-            if latest_image.id != iobject.image_id:
+            if latest_image.id != iobject.image:
                 util.write_out("The '{}' container is using an older version of the installed\n'{}' container image. If "
                                "you wish to use the newer image,\nyou must either create a new container with a "
                                "new name or\nuninstall the '{}' container. \n\n# atomic uninstall --name "

--- a/Atomic/objects/container.py
+++ b/Atomic/objects/container.py
@@ -14,7 +14,7 @@ class Container(object):
         self.deep = False
         self._backend = backend
         self.runtime = backend.backend
-        self.image_id = None
+        self.image = None
         self.image_name = None
         self._command = None
         self.state = None
@@ -104,3 +104,4 @@ class Container(object):
     @user_command.setter
     def user_command(self, value):
         self._user_command = value
+


### PR DESCRIPTION
When running an image with atomic run, if the container already exists,
we were accidently displaying a message stating that the container's
image was old.  This was due to an invalid comparison between the container's
image id and the image's id.  The comparison was failing because we were
comparing two different variables and not the ids.

This was reported in bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1434430