### PR TITLE
Allow systemcontainers to install, run, and uninstall in one go

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -110,6 +110,11 @@ make_docker_images () {
             cp ./tests/test-images/system-container-files-hostfs/* ${WORK_DIR}
         fi
 
+        # Copy runonce files into into atomic-test-runonce-system
+        if [[ ${iname} = "atomic-test-runonce" ]]; then
+            cp ./tests/test-images/system-container-runonce-files/* ${WORK_DIR}
+        fi
+
         # Remove the old image... Though there may not be one.
         set +e
         ${DOCKER} rmi ${iname} &>> ${LOG}

--- a/tests/integration/test_system_containers.sh
+++ b/tests/integration/test_system_containers.sh
@@ -349,6 +349,6 @@ teardown
 echo "Test runonce..."
 export NAME="atomic-test-runonce"
 ${ATOMIC} pull --storage ostree docker:${NAME}:latest
-${ATOMIC} install --system ${NAME}:latest > ps.out
-assert_matches "HI" ps.out
+${ATOMIC} install --system --name=Saturn --set RECEIVER=Pluto ${NAME}:latest > ps.out
+assert_matches "HI Pluto from Saturn" ps.out
 ${ATOMIC} --assumeyes images delete -f --storage ostree ${NAME}

--- a/tests/integration/test_system_containers.sh
+++ b/tests/integration/test_system_containers.sh
@@ -57,7 +57,6 @@ export ATOMIC_OSTREE_REPO=${WORK_DIR}/repo
 export ATOMIC_OSTREE_CHECKOUT_PATH=${WORK_DIR}/checkout
 
 docker save atomic-test-system > ${WORK_DIR}/atomic-test-system.tar
-
 ${ATOMIC} pull --storage ostree dockertar:/${WORK_DIR}/atomic-test-system.tar
 
 # Check that the branch is created in the OSTree repository
@@ -343,3 +342,13 @@ test -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.0/${NAME}.service
 test -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.0/tmpfiles-${NAME}.conf
 
 systemctl start ${NAME}
+
+teardown
+
+# "Install" a run once system container
+echo "Test runonce..."
+export NAME="atomic-test-runonce"
+${ATOMIC} pull --storage ostree docker:${NAME}:latest
+${ATOMIC} install --system ${NAME}:latest > ps.out
+assert_matches "HI" ps.out
+${ATOMIC} --assumeyes images delete -f --storage ostree ${NAME}

--- a/tests/test-images/Dockerfile.runonce
+++ b/tests/test-images/Dockerfile.runonce
@@ -1,0 +1,10 @@
+FROM centos
+
+LABEL "Name"="atomic-test-runonce"\
+      "atomic.run"="once"\
+      "atomic.type"="system"
+
+ADD hi.sh /usr/bin/run.sh
+
+# Export the files used for the system container
+ADD manifest.json config.json.template /exports/

--- a/tests/test-images/system-container-runonce-files/config.json.template
+++ b/tests/test-images/system-container-runonce-files/config.json.template
@@ -16,7 +16,9 @@
 		],
 		"env": [
 			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-			"TERM=xterm"
+			"TERM=xterm",
+			"NAME=$NAME",
+			"RECEIVER=$RECEIVER"
 		],
 		"cwd": "/"
 	},

--- a/tests/test-images/system-container-runonce-files/config.json.template
+++ b/tests/test-images/system-container-runonce-files/config.json.template
@@ -1,0 +1,132 @@
+{
+	"ociVersion": "0.6.0-dev",
+	"platform": {
+		"os": "linux",
+		"arch": "amd64"
+	},
+
+	"process": {
+		"terminal": false,
+		"user": {
+			"uid": 0,
+			"gid": 0
+		},
+		"args": [
+			"/usr/bin/run.sh"
+		],
+		"env": [
+			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"TERM=xterm"
+		],
+		"cwd": "/"
+	},
+	"root": {
+		"path": "rootfs",
+		"readonly": false
+	},
+	"hostname": "acme",
+	"mounts": [
+		{
+			"destination": "/proc",
+			"type": "proc",
+			"source": "proc"
+		},
+		{
+			"destination": "/dev",
+			"type": "tmpfs",
+			"source": "tmpfs",
+			"options": [
+				"nosuid",
+				"strictatime",
+				"mode=755",
+				"size=65536k"
+			]
+		},
+		{
+			"destination": "/dev/pts",
+			"type": "devpts",
+			"source": "devpts",
+			"options": [
+				"nosuid",
+				"noexec",
+				"newinstance",
+				"ptmxmode=0666",
+				"mode=0620",
+				"gid=5"
+			]
+		},
+		{
+			"destination": "/dev/shm",
+			"type": "tmpfs",
+			"source": "shm",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev",
+				"mode=1777",
+				"size=65536k"
+			]
+		},
+		{
+			"destination": "/dev/mqueue",
+			"type": "mqueue",
+			"source": "mqueue",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev"
+			]
+		},
+		{
+			"destination": "/sys",
+			"type": "sysfs",
+			"source": "sysfs",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev",
+				"ro"
+			]
+		},
+		{
+			"destination": "/sys/fs/cgroup",
+			"type": "cgroup",
+			"source": "cgroup",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev",
+				"relatime",
+				"ro"
+			]
+		}
+	],
+	"hooks": {},
+	"linux": {
+		"resources": {
+			"devices": [
+				{
+					"allow": false,
+					"access": "rwm"
+				}
+			]
+		},
+		"namespaces": [
+			{
+				"type": "network"
+			},
+			{
+				"type": "pid"
+			},
+			{
+				"type": "mount"
+			},
+			{
+				"type": "ipc"
+			},
+			{
+				"type": "uts"
+			}
+		]
+	}
+}

--- a/tests/test-images/system-container-runonce-files/hi.sh
+++ b/tests/test-images/system-container-runonce-files/hi.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "HI"

--- a/tests/test-images/system-container-runonce-files/hi.sh
+++ b/tests/test-images/system-container-runonce-files/hi.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-echo "HI"
+
+echo "HI $RECEIVER from $NAME"

--- a/tests/test-images/system-container-runonce-files/manifest.json
+++ b/tests/test-images/system-container-runonce-files/manifest.json
@@ -1,0 +1,4 @@
+{
+	"version": "1.0",
+	"defaultValues": {}
+}


### PR DESCRIPTION
This change adds a new optional label called ``atomic.run``. When set to ``once`` the image will be extracted, run, and cleaned up. This currently requires the use of ``--system``.

The idea behind this new option is that there are cases where a system container would not be a full fledged service on a host. For example, the openshift-ansible installer isn't a service, but a containerized installer.

Example:

```
$ sudo atomic pull --storage ostree docker:testcontainer:latest
$ sudo atomic install --system testcontainer:latest
Extracting to /ostree/repo/tmp/atomic-container/15926/rootfs
HI
$ ls /ostree/repo/tmp/atomic-container/15926/rootfs
ls: cannot access '/ostree/repo/tmp/atomic-container/15926/rootfs': No such file or directory
$
```

/cc @sdodson @tbielawa