### PR TITLE
Always use fq names for dest image

### DIFF
--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -280,7 +280,7 @@ class DockerBackend(Backend):
             if self.already_has_image(local_image, remote_image_obj):
                 raise ValueError("Latest version of {} already present.".format(image))
         registry, _, _, tag, _ = util.Decompose(fq_name).all
-        image = "docker-daemon:{}".format(image)
+        image = "docker-daemon:{}".format(fq_name)
         if not image.endswith(tag):
             image += ":{}".format(tag)
         if '@sha256:' in image:


### PR DESCRIPTION
Bugzilla 1437447 has brought up an issue where if a user runs:

atomic pull rhel7

The resulting image in dockerd is docker.io/rhel7. The Atomic CLI
does tell skopeo the right information"

/usr/bin/skopeo --debug --policy=/etc/containers/policy.json --debug copy --remove-signatures docker://registry.access.redhat.com/rhel7:latest docker-daemon:rhel7:latest

But somewhere along the line, we think in skopeo, docker.io is prepending to the destination
image name.  One way to resolve this is to always use the fq name for the destination and not
what the user wanted.

This is a change in the default behaviour of atomic and I am not sure I am confortable with this.  But
given that we have several folks on PTO or travelling, I'm putting this PR together so that
if we decide this is the proper route for fixing, it will be done.