### PR TITLE
syscontainers: drop support for runC 0.x

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -319,10 +319,11 @@ class SystemContainers(object):
             version = str(util.check_output([util.RUNC_PATH, "--version"], stderr=DEVNULL))
         except util.FileNotFound:
             version = ""
+
         if "version 0" in version:
-            runc_commands = ["start", "kill"]
-        else:
-            runc_commands = ["run", "kill"]
+            raise ValueError("The version of runC is too old.")
+
+        runc_commands = ["run", "kill"]
         return ["%s --systemd-cgroup %s '%s'" % (util.RUNC_PATH, command, name) for command in runc_commands]
 
     def _get_systemd_destination_files(self, name, prefix=None):

--- a/tests/integration/test_system_containers.sh
+++ b/tests/integration/test_system_containers.sh
@@ -46,6 +46,10 @@ PYTHON=${PYTHON:-/usr/bin/python}
 ostree --version &>/dev/null || exit 77
 runc --version &>/dev/null || exit 77
 
+if runc --version | grep -q "version 0"; then
+    exit 77
+fi
+
 ${ATOMIC}  install --help 2>&1 > help.out
 grep -q -- --system help.out || exit 77
 

--- a/tests/integration/test_system_containers_rpm.sh
+++ b/tests/integration/test_system_containers_rpm.sh
@@ -35,6 +35,10 @@ ostree --version &>/dev/null || exit 77
 runc --version &>/dev/null || exit 77
 rpmbuild --version &>/dev/null || exit 77
 
+if runc --version | grep -q "version 0"; then
+    exit 77
+fi
+
 touch /usr/lib/.writeable || exit 77
 rm /usr/lib/.writeable
 


### PR DESCRIPTION
it is too old, and the containers most likely won't work as there are
several differences in the configuration schema.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>