### PR TITLE
Atomic/install.py: Fix what c134ee5 broke

### DIFF
--- a/atomic_dbus.py
+++ b/atomic_dbus.py
@@ -373,7 +373,7 @@ class atomic_dbus(slip.dbus.service.Object):
     # The Install method will install the specified image
     @slip.dbus.polkit.require_auth("org.atomic.readwrite")
     @dbus.service.method("org.atomic", in_signature='ssbbsbas', out_signature='i')
-    def Install(self, image, name='', system=False, remote=False, storage='', user=False, setvalues=''):
+    def Install(self, image, name, system, remote, storage, user, setvalues):
         if not setvalues:
             setvalues = []
         assert(isinstance(setvalues, list))
@@ -417,11 +417,11 @@ class atomic_dbus(slip.dbus.service.Object):
     @slip.dbus.polkit.require_auth("org.atomic.readwrite")
     # Return a 0 or 1 for success.  Errors result in exceptions.
     @dbus.service.method("org.atomic", in_signature='ssbbbas', out_signature='i')
-    def Run(self, image, name='', spc=False, detach=False, ignore=False, command=''):
+    def Run(self, image, name, spc, detach, ignore, command):
         r = Run()
         args = self.Args()
         args.image = image
-        args.name = name if name is not '' else None
+        args.name = name
         args.spc = spc
         args.detach = detach
         args.command = command if command is not '' else []

--- a/tests/integration/test_dbus.py
+++ b/tests/integration/test_dbus.py
@@ -105,11 +105,10 @@ class TestDBus():
 
     @integration_test
     def test_run(self):
-        self.dbus_object.Run('atomic-test-3', 'atomic-dbus-3', False, False, True)
+        self.dbus_object.Run('atomic-test-3', 'atomic-dbus-3', False, False, True, '')
         self.cid = TestDBus.run_cmd('docker ps -aq -l').decode('utf-8').rstrip()
         TestDBus.add_cleanup_cmd('docker rm {}'.format(self.cid))
         container_inspect = json.loads(TestDBus.run_cmd('docker inspect {}'.format(self.cid)).decode('utf-8'))[0]
-        print(container_inspect)
         assert(container_inspect['Name'] == '/atomic-dbus-3')
 
     @integration_test
@@ -132,8 +131,7 @@ class TestDBus():
         t_cid = TestDBus.run_cmd('docker ps -aq -l').decode('utf-8').rstrip()
         TestDBus.run_cmd('docker commit {} dbus-test-3'.format(t_cid))
         TestDBus.run_cmd('docker rm {}'.format(t_cid))
-
-        results = self.dbus_object.Install('dbus-test-3', name='atomic-dbus-3')
+        results = self.dbus_object.Install('dbus-test-3', 'dbus-test-3', False, False, 'docker', False, '')
         self.cid = TestDBus.run_cmd('docker ps -aq -l').decode('utf-8').rstrip()
         TestDBus.add_cleanup_cmd('docker rm {}'.format(self.cid))
         TestDBus.add_cleanup_cmd('docker rmi atomic-dbus-3')


### PR DESCRIPTION
The commit c134ee5 broke the ability for atomic install to pull an image
if it isnt present.