### PR TITLE
atomic: Fix silent failure from AssertionError

### DIFF
--- a/atomic
+++ b/atomic
@@ -220,6 +220,9 @@ if __name__ == '__main__':
         else:
             write_err("%s" % str(e))
         sys.exit(1)
+    except AssertionError as e:
+        traceback.print_exc(file=sys.stderr)
+        sys.exit()
     except Exception as e: # pylint: disable=broad-except
         write_err("%s" % str(e))
         sys.exit(1)


### PR DESCRIPTION
If an AssertionError is thrown without the --debug switch, atomic
would "silently" fail not indicating a success or failure.  We now
catch the AssertionError and display a traceback.

This resolves https://github.com/projectatomic/atomic/issues/928


## Description


## Related Bugzillas
- NA
-

## Related Issue Numbers
- #928 
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [NA ] Unittests
- [ NA] Integration Tests
