### PR TITLE
System containers storage

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -864,11 +864,14 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             return ATOMIC_VAR
 
     def get_ostree_repo_location(self):
+        location = os.environ.get("ATOMIC_OSTREE_REPO")
+        if location is not None:
+            return location
+
         if self.user:
-            return "%s/.containers/repo" % HOME
+            return  "%s/.containers/repo" % HOME
         else:
-            return os.environ.get("ATOMIC_OSTREE_REPO") or \
-                self.get_atomic_config_item(["ostree_repository"]) or \
+            return self.get_atomic_config_item(["ostree_repository"]) or \
                 "/ostree/repo"
 
     def _get_ostree_repo(self):

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -94,32 +94,13 @@ class SystemContainers(object):
         return OSTREE_PRESENT
 
     def _checkout_layer(self, repo, rootfs_fd, rootfs, rev):
-        # ostree 2016.8 has a glib introspection safe API for checkout, use it
-        # when available.
-        if hasattr(repo, "checkout_at"):
-            options = OSTree.RepoCheckoutAtOptions() # pylint: disable=no-member
-            options.overwrite_mode = OSTree.RepoCheckoutOverwriteMode.UNION_FILES
-            options.process_whiteouts = True
-            options.disable_fsync = True
-            if self.user:
-                options.mode = OSTree.RepoCheckoutMode.USER
-            repo.checkout_at(options, rootfs_fd, rootfs, rev)
-        else:
-            if self.user:
-                user = ["--user-mode"]
-            else:
-                user = []
-            util.check_call(["ostree", "--repo=%s" % self.get_ostree_repo_location(),
-                             "checkout",
-                             "--union"] +
-                            user +
-                             ["--whiteouts",
-                              "--fsync=no",
-                              rev,
-                              rootfs],
-                            stdin=DEVNULL,
-                            stdout=DEVNULL,
-                            stderr=DEVNULL)
+        options = OSTree.RepoCheckoutAtOptions() # pylint: disable=no-member
+        options.overwrite_mode = OSTree.RepoCheckoutOverwriteMode.UNION_FILES
+        options.process_whiteouts = True
+        options.disable_fsync = True
+        if self.user:
+            options.mode = OSTree.RepoCheckoutMode.USER
+        repo.checkout_at(options, rootfs_fd, rootfs, rev)
 
     def set_args(self, args):
         self.args = args

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1832,3 +1832,12 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             rev_layer = repo.resolve_rev(branch, True)[1]
             if not rev_layer:
                 shutil.rmtree(os.path.join(storage, i))
+
+
+    def mount_from_storage(self, img, destination):
+        repo = self._get_ostree_repo()
+        if not repo:
+            raise ValueError("OSTree not supported")
+        layers_dir = self._ensure_storage_for_image(repo, img)
+        cmd = "mount -t overlay overlay -olowerdir={} {}".format(":".join(layers_dir), destination)
+        return util.call(cmd)

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1377,6 +1377,8 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
                 util.write_out("Deleting %s" % k)
                 repo.set_ref_immediate(ref[1], ref[2], None)
         repo.prune(OSTree.RepoPruneFlags.NONE, -1)
+        self._prune_storage(repo)
+
 
     @staticmethod
     def get_default_system_name(image):
@@ -1819,3 +1821,14 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
                     os.close(rootfs_fd)
 
         return layers_dir
+
+
+    def _prune_storage(self, repo):
+        storage = self.get_storage_path()
+        if not os.path.exists(storage):
+            return
+        for i in os.listdir(storage):
+            branch = "{}{}".format(OSTREE_OCIIMAGE_PREFIX, i)
+            rev_layer = repo.resolve_rev(branch, True)[1]
+            if not rev_layer:
+                shutil.rmtree(os.path.join(storage, i))

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -286,7 +286,7 @@ class SystemContainers(object):
             image_manifest = self._image_manifest(repo, rev)
             image_id = rev
             if image_manifest:
-                image_id = SystemContainers._get_image_id_from_manifest(manifest) or image_id
+                image_id = SystemContainers._get_image_id_from_manifest(image_manifest) or image_id
 
             self._amend_values(values, manifest, name, image, image_id, base_dir)
 


### PR DESCRIPTION
## Description

Introduce system containers storage.  It is used to checkout each layer separately under $CHECKOUT/.storage/$LAYER_ID.

This is going to be used for 'atomic mount' and 'one shot' containers that are controlled from `atomic` and that can mount the image using overlay2
