### PR TITLE
Atomic/backends/_docker.py: Fix uninstall

### DIFF
--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -456,9 +456,9 @@ class DockerBackend(Backend):
         cmd = []
         if uninstall_command:
             try:
-                cmd += uninstall_command
+                cmd = cmd + uninstall_command
             except TypeError:
-                cmd += uninstall_command.split()
+                cmd = cmd + uninstall_command.split()
         if command_line_args:
             cmd += command_line_args
 


### PR DESCRIPTION
## Description
For some reason when shorthand is used to add a list and str/unicode,
a type Error is not thrown where shorthand is cmd += foo versus
cmd = cmd + foo.  Reverting to the long hand appears to resolve issue
https://github.com/projectatomic/atomic/issues/986

## Related Issue Numbers
- #986 
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
