### PR TITLE
Atomic/util.py: Check install against FQ name

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -853,6 +853,8 @@ class InstallData(object):
             return True
         if install_data.get(img_object.image, None):
             return True
+        if install_data.get("{}:{}".format(img_object.input_name, img_object.tag), None):
+            return True
         return False
 
 class Decompose(object):


### PR DESCRIPTION
## Description

In cases where a short-hand name is provided to run and the image
was installed under its fq_name, we should check againt the
fq_name as well when determining if it has been installed.

## Related Issue Numbers
- #995 
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
