### PR TITLE
Re-pulling image error should exit 0

### DIFF
--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -328,7 +328,7 @@ class DockerBackend(Backend):
         local_image = self.has_image(image)
         if local_image is not None:
             if self.already_has_image(local_image, remote_image_obj):
-                raise ValueError("Latest version of {} already present.".format(image))
+                raise util.ImageAlreadyExists(image)
         registry, _, _, tag, _ = util.Decompose(fq_name).all
         image = "docker-daemon:{}".format(fq_name)
         if not image.endswith(tag):

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -1010,3 +1010,7 @@ def set_proxy():
     if proxies['https'] and 'HTTPS_PROXY' not in os.environ:
         os.environ['HTTPS_PROXY'] = proxies['https']
     return proxies
+
+class ImageAlreadyExists(Exception):
+    def __init__(self, img):
+        super(ImageAlreadyExists, self).__init__("The latest version of image {} already exists.".format(img))

--- a/atomic
+++ b/atomic
@@ -52,7 +52,7 @@ from Atomic import update
 from Atomic import verify
 from Atomic.mount import MountError
 from Atomic import images
-from Atomic.util import write_err
+from Atomic.util import write_err, ImageAlreadyExists
 from Atomic.backends._docker_errors import NoDockerDaemon
 
 try:
@@ -205,6 +205,9 @@ if __name__ == '__main__':
                 aparser.print_usage()
                 sys.exit(1)
     except KeyboardInterrupt:
+        sys.exit(0)
+    except ImageAlreadyExists as e:
+        write_err("%s" % str(e))
         sys.exit(0)
     except (ValueError, IOError, docker.errors.DockerException, NoDockerDaemon) as e:
         write_err("%s" % str(e))


### PR DESCRIPTION
## Description
Bugzilla #1430708 recommends that if an atomic user attempts to pull
an image that is already present, we should not exit with a '1' which
indicates a failure; rather a 0.

## Related Bugzillas
- Bugzilla #1430708
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
