### PR TITLE
Incorporate registries parsing tool

### DIFF
--- a/Atomic/pull.py
+++ b/Atomic/pull.py
@@ -2,7 +2,7 @@ try:
     from . import Atomic
 except ImportError:
     from atomic import Atomic  # pylint: disable=relative-import
-from .util import get_atomic_config, write_out
+from .util import get_atomic_config, write_out, check_storage_is_available
 from Atomic.backendutils import BackendUtils
 
 ATOMIC_CONFIG = get_atomic_config()
@@ -36,6 +36,7 @@ class Pull(Atomic):
     def pull_image(self):
         storage_set = False if self.args.storage is None else True
         storage = _storage if not storage_set else self.args.storage
+        check_storage_is_available(storage)
         if self.args.debug:
             write_out(str(self.args))
 

--- a/tests/unit/test_registries.py
+++ b/tests/unit/test_registries.py
@@ -1,0 +1,86 @@
+#pylint: skip-file
+
+import unittest
+from Atomic.util import is_backend_available, load_registries_from_yaml, get_registries
+import json
+import subprocess
+
+no_mock = True
+try:
+    from unittest.mock import MagicMock, patch
+    no_mock = False
+except ImportError:
+    try:
+        from mock import MagicMock, patch
+        no_mock = False
+    except ImportError:
+        # Mock is already set to False
+        pass
+
+
+@unittest.skipIf(no_mock, "Mock not found")
+class TestRegistriesFromYAML(unittest.TestCase):
+
+    def compare_list_of_dicts(self, results, answer):
+        if not isinstance(results, list) or not isinstance(answer, list):
+            raise AssertionError("Results must always be of type list")
+        if len(results) != len(answer):
+            raise AssertionError("Length of the lists differ.")
+        for registry in results:
+            self.assertDictEqual(registry, next(item for item in answer if item["hostname"] == registry['hostname']))
+
+    def test_no_registries(self):
+        with patch('Atomic.util.registries_tool_path') as reg_path:
+            reg_path.return_value = "/usr/libexec/registries"
+            with patch('Atomic.util.load_registries_from_yaml') as mockobj:
+                mockobj.return_value = json.loads("{}")
+                results = get_registries()
+        answer = [{'name': 'docker.io', 'hostname': 'registry-1.docker.io', 'search': True, 'secure': True}]
+        self.compare_list_of_dicts(results, answer)
+
+    def test_block_dockerio(self):
+        with patch('Atomic.util.registries_tool_path') as reg_path:
+            reg_path.return_value = "/usr/libexec/registries"
+            with patch('Atomic.util.load_registries_from_yaml') as mockobj:
+                mockobj.return_value = json.loads('{"block_registries": ["docker.io"]}')
+                results = get_registries()
+        answer = []
+        self.compare_list_of_dicts(results, answer)
+
+
+    def test_duplicate_dockerio(self):
+        with patch('Atomic.util.registries_tool_path') as reg_path:
+            reg_path.return_value = "/usr/libexec/registries"
+            with patch('Atomic.util.load_registries_from_yaml') as mockobj:
+                mockobj.return_value = json.loads('{"registries": ["docker.io"]}')
+                results = get_registries()
+        answer = [{'secure': True, 'hostname': 'docker.io', 'name': 'docker.io', 'search': True}]
+        self.compare_list_of_dicts(results, answer)
+
+    def test_all(self):
+        with patch('Atomic.util.registries_tool_path') as reg_path:
+            reg_path.return_value = "/usr/libexec/registries"
+            with patch('Atomic.util.load_registries_from_yaml') as mockobj:
+                mockobj.return_value = json.loads('{"registries": ["one.com", "two.com"], "insecure_registries": ["three.com"], "block_registries": []}')
+                results = get_registries()
+        answer = [{'secure': True, 'search': True, 'name': 'one.com', 'hostname': 'one.com'}, {'secure': True, 'search': True, 'name': 'two.com', 'hostname': 'two.com'}, {'secure': True, 'search': True, 'name': 'three.com', 'hostname': 'three.com'}, {'secure': True, 'search': True, 'name': 'docker.io', 'hostname': 'registry-1.docker.io'}]
+        self.compare_list_of_dicts(results, answer)
+
+    def test_duplicate_in_secure_and_insecure(self):
+        with patch('Atomic.util.registries_tool_path') as reg_path:
+            reg_path.return_value = "/usr/libexec/registries"
+            with patch('Atomic.util.load_registries_from_yaml') as mockobj:
+                mockobj.return_value = json.loads('{"registries": ["one.com", "two.com"], "insecure_registries": ["two.com"], "block_registries": []}')
+                self.assertRaises(ValueError, get_registries)
+
+    def test_duplicate_in_registries(self):
+        with patch('Atomic.util.registries_tool_path') as reg_path:
+            reg_path.return_value = "/usr/libexec/registries"
+            with patch('Atomic.util.load_registries_from_yaml') as mockobj:
+                mockobj.return_value = json.loads('{"registries": ["one.com", "two.com", "one.com"], "insecure_registries": ["three.com"], "block_registries": []}')
+                results = get_registries()
+        answer = [{'secure': True, 'search': True, 'name': 'one.com', 'hostname': 'one.com'}, {'secure': True, 'search': True, 'name': 'two.com', 'hostname': 'two.com'}, {'secure': True, 'search': True, 'name': 'three.com', 'hostname': 'three.com'}, {'secure': True, 'search': True, 'name': 'docker.io', 'hostname': 'registry-1.docker.io'}]
+        self.compare_list_of_dicts(results, answer)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description
Ideally atomic will be able to run multiple container
runtimes.  In and effort to do so, we must have a concept
of a global registries configuration file which will allow
us to pull images with atomic and skopeo. The tooling
that parses the global configuration file is:

https://github.com/projectatomic/registries

This is step one in the implementation of this tooling
and direction.



## Related Issue Numbers
- #870 
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [x] Unittests
- [ ] Integration Tests
