### PR TITLE
atomic.conf: fix syntax error of the YAML format

### DIFF
--- a/atomic.conf
+++ b/atomic.conf
@@ -21,6 +21,6 @@ sigstore_metadata_image: sigstore
 # To always use a proxy with atomic, you can uncomment and fill out
 # below.
 #
-#http_proxy=
-#https_proxy=
-#no_proxy=
+#http_proxy:
+#https_proxy:
+#no_proxy:


### PR DESCRIPTION
We use YAML format in atomic.conf file, so it should be KEY: VALUE
not KEY=VALUE.

Signed-off-by: Alex Jia <ajia@redhat.com>


## Description


## Related Bugzillas
-
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
