### PR TITLE
Atomic/util.py: Add logic to install lookup for shortnames

### DIFF
--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -467,10 +467,15 @@ class DockerBackend(Backend):
         atomic.display(cmd)
         if args.display:
             return 0
-        if cmd:
-            return util.check_call(cmd, env=atomic.cmd_env())
 
         install_data = util.InstallData.get_install_data_by_id(iobject.id)
+
+        if cmd:
+            result = util.check_call(cmd, env=atomic.cmd_env())
+            if result == 0:
+                util.InstallData.delete_by_id(iobject.id, ignore=ignore)
+            return result
+
         system_package_nvra = install_data.get("system_package_nvra", None)
         if system_package_nvra:
             RPMHostInstall.uninstall_rpm(system_package_nvra)

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -857,8 +857,11 @@ class InstallData(object):
     def write_install_data(cls, new_data):
         install_data = cls.read_install_data()
         with file_lock(ATOMIC_INSTALL_JSON):
-            for x in new_data:
-                install_data[x] = new_data[x]
+            if len(new_data) < 1:
+                install_data = {}
+            else:
+                for x in new_data:
+                    install_data[x] = new_data[x]
             temp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
             json.dump(install_data, temp_file)
             temp_file.close()
@@ -908,6 +911,12 @@ class InstallData(object):
             return True
         if install_data.get("{}:{}".format(img_object.input_name, img_object.tag), None):
             return True
+        try:
+            from Atomic.discovery import RegistryInspectError
+            if install_data.get(img_object.fq_name, None):
+                return True
+        except RegistryInspectError:
+            pass
         return False
 
 class Decompose(object):


### PR DESCRIPTION
If a shortname is used to run an image, we need to transform the short
name into the fq-name when doing the lookup in the installed images
data.

Reported in BZ #1454292


## Description


## Related Bugzillas
- 1454292
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
