### PR TITLE
Atomic/util.py: decode registries information to utf-8

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -81,7 +81,7 @@ def registries_tool_path():
 def load_registries_from_yaml():
     # Returns in JSON
     try:
-        return json.loads(check_output([registries_tool_path(), '-j']))
+        return json.loads(check_output([registries_tool_path(), '-j']).decode('utf-8'))
     except subprocess.CalledProcessError:
         return json.loads({})
 


### PR DESCRIPTION
In Python3, we need to decode the data to utf-8 to produce
a string and a note a byte type.


## Description


## Related Bugzillas
-
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
