### PR TITLE
Do not strip port for insecure check

### DIFF
--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -336,7 +336,7 @@ class DockerBackend(Backend):
         if '@sha256:' in image:
             image = image.replace("@sha256:", ":")
 
-        insecure = True if util.is_insecure_registry(self.d.info()['RegistryConfig'], util.strip_port(registry)) else False
+        insecure = True if util.is_insecure_registry(self.d.info()['RegistryConfig'], registry) else False
         trust = Trust()
         trust.discover_sigstore(fq_name)
         util.write_out("Pulling {} ...".format(fq_name))

--- a/Atomic/push.py
+++ b/Atomic/push.py
@@ -189,7 +189,7 @@ class Push(Atomic):
             if self.args.insecure:
                 insecure = True
             else:
-                insecure = True if util.is_insecure_registry(self.d.info()['RegistryConfig'], util.strip_port(reg)) else False
+                insecure = True if util.is_insecure_registry(self.d.info()['RegistryConfig'], reg) else False
             # We must push the file to the registry first prior to performing a
             # local signature because the manifest file must be on the registry
             return_code = util.skopeo_copy(local_image, remote_image, debug=self.args.debug,


### PR DESCRIPTION
## Description
When checking if a registry is insecure, we should not be stripping
the port from the registry name.


## Related Bugzillas
- #1453100
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
