### PR TITLE
Support "runc run --detach" for system containers

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -50,10 +50,13 @@ SYSTEMD_UNIT_FILE_DEFAULT_TEMPLATE = """
 Description=$NAME
 
 [Service]
+ExecStartPre=$EXEC_STARTPRE
 ExecStart=$EXEC_START
 ExecStop=$EXEC_STOP
+ExecStop=$EXEC_STOPPOST
 Restart=on-crash
 WorkingDirectory=$DESTDIR
+PIDFile=$PIDFILE
 
 [Install]
 WantedBy=multi-user.target

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -61,7 +61,7 @@ WantedBy=multi-user.target
 TEMPLATE_FORCED_VARIABLES = ["DESTDIR", "NAME", "EXEC_START", "EXEC_STOP",
                              "EXEC_STARTPRE", "EXEC_STOPPOST", "HOST_UID",
                              "HOST_GID", "IMAGE_ID", "IMAGE_NAME"]
-TEMPLATE_OVERRIDABLE_VARIABLES = ["RUN_DIRECTORY", "STATE_DIRECTORY", "UUID"]
+TEMPLATE_OVERRIDABLE_VARIABLES = ["RUN_DIRECTORY", "STATE_DIRECTORY", "UUID", "PIDFILE"]
 
 class SystemContainers(object):
 
@@ -545,6 +545,9 @@ class SystemContainers(object):
                 values["RUN_DIRECTORY"] = os.environ.get("XDG_RUNTIME_DIR", "/run/user/%s" % (os.getuid()))
             else:
                 values["RUN_DIRECTORY"] = "/run"
+
+        if "PIDFILE" not in values:
+            values["PIDFILE"] = os.path.sep.join([values["RUN_DIRECTORY"], "container-{}.pid".format(name)])
 
         if "STATE_DIRECTORY" not in values:
             if self.user:

--- a/tests/test-images/system-container-files/service.template
+++ b/tests/test-images/system-container-files/service.template
@@ -2,10 +2,13 @@
 Description=Hello World System Container
 
 [Service]
+ExecStartPre=$EXEC_STARTPRE
 ExecStart=$EXEC_START
 ExecStop=$EXEC_STOP
-Restart=on-failure
+ExecStopPost=$EXEC_STOPPOST
+Restart=on-crash
 WorkingDirectory=$DESTDIR
+PIDFile=$PIDFILE
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Description

Currently system containers require runc to always run, even after the container is initialized.  This PR adds support for `runc run -d` to detach the container process once it is started.

To support "runc run -d" some changes in the unit file of the images are required (`EXEC_STARTPRE`, `EXEC_STOPPOST` and `PIDFILE` were added).

```
    [Service]
    ExecStartPre=$EXEC_STARTPRE
    ExecStart=$EXEC_START
    ExecStop=$EXEC_STOP
    ExecStopPost=$EXEC_STOPPOST
    Restart=on-failure
    WorkingDirectory=$DESTDIR
    RuntimeDirectory=${NAME}
    PIDFile=$PIDFILE
```
For example, I've locally modified the etcd container to use "runc run -d"
```bash
# systemctl start etcd
# pgrep -fa etcd
24999 /usr/bin/etcd
# pgrep -fa runc
# runc list
ID          PID         STATUS      BUNDLE                              CREATED
etcd        24999       running     /var/lib/containers/atomic/etcd.0   2017-05-24T09:09:51.675332022Z
# systemctl stop etcd
# runc list
ID          PID         STATUS      BUNDLE      CREATED
```
