### PR TITLE
Atomic/tag.py: Fix tag to work with dockerd, invalid images BZ #1454656

### DIFF
--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -686,5 +686,13 @@ class DockerBackend(Backend):
                     [atomic.docker_binary(), "start", con_obj.name],
                     stderr=DEVNULL)
 
-    def tag_image(self, src, dest):
-        return self.d.tag(src, dest)
+    def tag_image(self, _src, _dest):
+        registry, repo, image, tag, _ = util.Decompose(_dest).all
+        result = registry
+        if repo:
+            result += "/{}".format(repo)
+        result += "/{}".format(image)
+        if result.startswith("/"):
+            result = result[1:]
+        return self.d.tag(_src, result, tag=tag)
+

--- a/Atomic/tag.py
+++ b/Atomic/tag.py
@@ -23,10 +23,12 @@ class Tag(Atomic):
         backend = None
         if self.args.storage:
             backend = beu.get_backend_from_string(self.args.storage)
-        else:            
-            backend, _ = beu.get_backend_and_image_obj(self.args.src, required=False)
+            image  = backend.has_image(self.args.src)
 
-        if not backend:
+        else:            
+            backend, image = beu.get_backend_and_image_obj(self.args.src, required=False)
+
+        if not backend or not image:
             raise ValueError("Cannot find image {}.".format(self.args.src))
 
         backend.tag_image(self.args.src, self.args.target)

--- a/tests/integration/test_tag.sh
+++ b/tests/integration/test_tag.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -x
+set -euo pipefail
+IFS=$'\n\t'
+
+#
+# 'atomic run --display' and 'atomic install --display' integration tests
+# AUTHOR: Sally O'Malley <somalley at redhat dot com>
+#
+ATOMIC=${ATOMIC:="/usr/bin/atomic"}
+ATOMIC=$(grep -v -- --debug <<< "$ATOMIC")
+DOCKER=${DOCKER:="/usr/bin/docker"}
+
+teardown () {
+	set +e
+	${DOCKER} rmi at1:latest  
+	${ATOMIC} -y images delete --storage ostree at1:latest
+	set -e
+}
+
+failed () {
+	echo "${1} should have failed and did not"
+}
+
+trap teardown EXIT
+
+rc=0
+NAME="TEST1"
+# Try to tag a non-existant image
+${ATOMIC} images tag foobar123:latest f:latest 1>/dev/null || rc=$?
+if [[ ${rc} != 1 ]]; then
+    # Test failed
+    failed "${NAME}"
+    exit 1
+fi
+
+rc=0
+# Try to tag a docker image to ostree should fail
+NAME="TEST2"
+${ATOMIC} images tag --storage ostree atomic-test-1:latest at1:latest 1>/dev/null || rc=$?
+if [[ ${rc} != 1 ]]; then
+    # Test failed
+    failed "${NAME}"
+    exit 1
+fi
+
+# Tag a docker image
+NAME="TEST3"
+${ATOMIC} images tag atomic-test-1:latest at1:latest
+${DOCKER} inspect at1:latest 1>/dev/null 
+
+# Tag an ostree image
+${ATOMIC} pull --storage ostree docker:atomic-test-1:latest
+${ATOMIC} images tag --storage ostree atomic-test-1:latest at1:latest


### PR DESCRIPTION
## Description

The atomic tag function was not working correctly for docker images
in the dockerd.  Also, when attempting to tag an image from one
backend into another, we didn't handle the error correctly.  This should
not work.

Add integration tests for tagging invalid images, dockerd, and ostree.

This should fix BZ #1454656.

## Related Bugzillas
- #1454656
-

## Related Issue Numbers
- #1002 
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [x] Integration Tests
