### PR TITLE
dbus: Anonymous pushes should not fail on auth

### DIFF
--- a/atomic_dbus.py
+++ b/atomic_dbus.py
@@ -315,14 +315,14 @@ class atomic_dbus(slip.dbus.service.Object):
         args.satellite = satellite
         args.verify_ssl = verify_ssl
         args.insecure = insecure
-        args.anonymous = anonymous
+        args.anonymous = bool(anonymous)
         args.url = None if not url else url
         args.username = None if not username else username
         args.password = None if not password else password
         args.activation_key = activation_key
         args.repo_id = repo_id
         registry = Decompose(image).registry
-        if registry not in self.atomic.load_local_tokens() and not args.username or not args.password:
+        if (registry not in self.atomic.load_local_tokens() and not args.username or not args.password) and not args.anonymous:
             raise dbus.DBusException("There is no local token and no username/password were provided.  Please try "
                                      "again with a username and password")
         if args.satellite or args.pulp:

--- a/atomic_dbus_client.py
+++ b/atomic_dbus_client.py
@@ -95,6 +95,13 @@ class AtomicDBus (object):
     def ImagesPrune(self):
         return self.dbus_object.ImagesPrune(dbus_interface="org.atomic")
 
+    @polkit.enable_proxy
+    def ImagePush(self, image, pulp, satellite, verify_ssl, url, username, password, activation_key, repo_id,
+                  registry_type, sign_by, gnupghome, insecure, anonymous):
+        return self.dbus_object.ImagePush(image, pulp, satellite, verify_ssl, url, username, password,
+                                          activation_key, repo_id, registry_type, sign_by, gnupghome,
+                                          insecure, anonymous)
+
     # The ImagesPull method will pull the specified image
     @polkit.enable_proxy
     def ImagePull(self, image, storage="docker", reg_type=""):


### PR DESCRIPTION
## Description

When pushing an image to registry anonymously, the check for user and
password should not fail. This was reported in BZ #1453135.

Added ImagePush() to dbus_client which was lacking.

## Related Bugzillas
- #1453135
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
