### PR TITLE
atomic containers list json fix

### DIFF
--- a/Atomic/containers.py
+++ b/Atomic/containers.py
@@ -134,11 +134,14 @@ class Containers(Atomic):
 
 
         container_objects = self._ps()
-        if len(container_objects) == 0:
-            return 0
+        # If we were not asked for json output, return out with no output
+        # when there are no applicable container objects
+        if not self.args.json:
+            if len(container_objects) == 0:
+                return 0
 
-        if not any([x.running for x in container_objects]) and not self.args.all:
-            return 0
+            if not any([x.running for x in container_objects]) and not self.args.all:
+                return 0
 
         max_container_id = 12 if self.args.truncate else max([len(x.id) for x in container_objects])
         if self.args.quiet:

--- a/Atomic/containers.py
+++ b/Atomic/containers.py
@@ -143,7 +143,14 @@ class Containers(Atomic):
             if not any([x.running for x in container_objects]) and not self.args.all:
                 return 0
 
-        max_container_id = 12 if self.args.truncate else max([len(x.id) for x in container_objects])
+        # Set to 12 when truncate
+        if self.args.truncate:
+            max_container_id = 12
+        # Otherwise set to the max, falling back to 0
+        else:
+            max_container_id = max([len(x.id) for x in container_objects] or [0])
+
+        # Quiet supersedes json output
         if self.args.quiet:
             for con_obj in container_objects:
                 util.write_out(con_obj.id[0:max_container_id])

--- a/tests/integration/test_containers_list.sh
+++ b/tests/integration/test_containers_list.sh
@@ -24,3 +24,7 @@ diff docker.ps.out atomic.ps.out
 ${ATOMIC} containers list -q -f runtime=Docker | sort > atomic.ps.out
 docker ps -q | sort > docker.ps.out
 diff docker.ps.out atomic.ps.out
+
+# Ensure that when json is requested and no containers are returned we still
+# get valid json ([])
+${ATOMIC} containers list --json -f container=idonotexist | grep "\[\]"


### PR DESCRIPTION
## Description
The ``atomic containers list --json`` returns nothing when no containers will be returned. This causes some parsers, such as Python's ``json`` module, to fail reading the output. This change does the following:

When ``atomic containers list --json`` is used...
- empty results are returned as an empty json list: ``[]``
- and ``-q`` is also used, the quiet is honored over the ``--json`` request

## Related Bugzillas
- https://bugzilla.redhat.com/show_bug.cgi?id=1450307

## Related Issue Numbers
- https://github.com/openshift/openshift-ansible/pull/4272#issuecomment-304075181

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [x] Integration Tests
