### PR TITLE
Fix docker-tagged image display

### DIFF
--- a/Atomic/objects/image.py
+++ b/Atomic/objects/image.py
@@ -207,7 +207,7 @@ class Image(object):
     def split_repotags(self):
         _repotags = []
         if not self.repotags:
-            return [('<none>', '<none')]
+            return [('<none>', '<none>')]
         for _repotag in self.repotags:
             if ':' in _repotag:
                 repo, tag = _repotag.rsplit(':', 1)

--- a/tests/integration/test_images_list.sh
+++ b/tests/integration/test_images_list.sh
@@ -1,0 +1,91 @@
+#!/bin/bash -x
+set -euo pipefail
+IFS=$'\n\t'
+
+# Test images listing and filtering functionality
+
+IMAGE="atomic-test-1"
+IMAGE_SECRET="atomic-test-secret"
+TAGGED_IMAGE="local/at1"
+
+assert_matches() {
+    if ! grep -q -e $@; then
+    sed -e s',^,| ,' < $2
+    assert_not_reached "Failed to match: " $@
+    fi
+}
+
+assert_not_matches() {
+    if grep -q -e $@; then
+    sed -e s',^,| ,' < $2
+    assert_not_reached "Matched: " $@
+    fi
+}
+
+setup () {
+    ${DOCKER} tag ${IMAGE} ${TAGGED_IMAGE}:latest
+}
+
+teardown () {
+    set +e
+    ${DOCKER} rmi ${TAGGED_IMAGE}:latest
+    set -e
+}
+
+trap teardown exit
+
+setup
+
+${ATOMIC} images list > ${WORK_DIR}/images.out
+assert_matches ${IMAGE} ${WORK_DIR}/images.out
+assert_matches ${IMAGE_SECRET} ${WORK_DIR}/images.out
+assert_matches ${TAGGED_IMAGE} ${WORK_DIR}/images.out
+
+# Testing --all
+${ATOMIC} images list > ${WORK_DIR}/images.out
+${ATOMIC} images list --all > ${WORK_DIR}/images.all.out
+test $(wc -l < ${WORK_DIR}/images.out) -lt $(wc -l < ${WORK_DIR}/images.all.out)
+assert_matches '<none>' ${WORK_DIR}/images.all.out
+assert_not_matches '<none>' ${WORK_DIR}/images.out
+
+# Testing filters
+${ATOMIC} images list -f repo=${IMAGE} > ${WORK_DIR}/images.out
+assert_matches ${IMAGE} ${WORK_DIR}/images.out
+${ATOMIC} images list -f type=docker > ${WORK_DIR}/images.out
+assert_matches ${IMAGE} ${WORK_DIR}/images.out
+${ATOMIC} images list -f repo=non-existing-repo > ${WORK_DIR}/images.out
+assert_not_matches ${IMAGE} ${WORK_DIR}/images.out
+
+OUTPUT=$(! ${ATOMIC} images list -f not-a-filter=${IMAGE} 2>&1)
+grep "not valid" <<< $OUTPUT
+
+# Testing noheading/no-trunc
+${ATOMIC} images list --noheading > ${WORK_DIR}/images.out
+assert_not_matches 'REPOSITORY' ${WORK_DIR}/images.out
+
+IMAGE_ID=$(${DOCKER} images --no-trunc | grep ${IMAGE} | awk '{print $3}' | cut -d ":" -f 2)
+${ATOMIC} images list --no-trunc > ${WORK_DIR}/images.out
+assert_matches ${IMAGE_ID} ${WORK_DIR}/images.out
+
+# Testing quiet/json
+${ATOMIC} images list -q > ${WORK_DIR}/images.out
+assert_not_matches ${IMAGE} ${WORK_DIR}/images.out
+assert_matches ${IMAGE_ID:0:12} ${WORK_DIR}/images.out
+
+${ATOMIC} images list --json > ${WORK_DIR}/images.out
+assert_matches ${IMAGE_ID} ${WORK_DIR}/images.out
+assert_matches ${IMAGE} ${WORK_DIR}/images.out
+
+# Test that filters work together
+${ATOMIC} images list -a -q --no-trunc -f repo=${IMAGE} -f type=docker > ${WORK_DIR}/images.out
+assert_matches ${IMAGE_ID} ${WORK_DIR}/images.out
+
+# Check that the tagged image is being displayed
+${ATOMIC} images list > ${WORK_DIR}/images.out
+assert_matches ${TAGGED_IMAGE} ${WORK_DIR}/images.out
+${ATOMIC} images list --json > ${WORK_DIR}/images.out
+assert_matches ${TAGGED_IMAGE} ${WORK_DIR}/images.out
+${ATOMIC} images list -f repo=${TAGGED_IMAGE} > ${WORK_DIR}/images.out
+assert_matches ${TAGGED_IMAGE} ${WORK_DIR}/images.out
+${ATOMIC} images list -f repo=${TAGGED_IMAGE} -q --no-trunc> ${WORK_DIR}/images.out
+assert_matches ${IMAGE_ID} ${WORK_DIR}/images.out

--- a/tests/integration/test_tag.sh
+++ b/tests/integration/test_tag.sh
@@ -12,7 +12,6 @@ DOCKER=${DOCKER:="/usr/bin/docker"}
 teardown () {
 	set +e
 	${DOCKER} rmi at1:latest  
-	${ATOMIC} -y images delete --storage ostree at1:latest
 	set -e
 }
 
@@ -47,8 +46,3 @@ fi
 NAME="TEST3"
 ${ATOMIC} images tag atomic-test-1:latest at1:latest
 ${DOCKER} inspect at1:latest 1>/dev/null 
-
-# Check that the tagged image is being displayed
-${ATOMIC} images list | grep "at1"
-${ATOMIC} images list --json | grep "at1"
-${ATOMIC} images list -f repo=at1 | grep "at1"

--- a/tests/integration/test_tag.sh
+++ b/tests/integration/test_tag.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 #
-# 'atomic run --display' and 'atomic install --display' integration tests
-# AUTHOR: Sally O'Malley <somalley at redhat dot com>
+# 'atomic images tag' integration tests
 #
 ATOMIC=${ATOMIC:="/usr/bin/atomic"}
 ATOMIC=$(grep -v -- --debug <<< "$ATOMIC")
@@ -34,6 +33,7 @@ if [[ ${rc} != 1 ]]; then
 fi
 
 rc=0
+
 # Try to tag a docker image to ostree should fail
 NAME="TEST2"
 ${ATOMIC} images tag --storage ostree atomic-test-1:latest at1:latest 1>/dev/null || rc=$?
@@ -48,6 +48,7 @@ NAME="TEST3"
 ${ATOMIC} images tag atomic-test-1:latest at1:latest
 ${DOCKER} inspect at1:latest 1>/dev/null 
 
-# Tag an ostree image
-${ATOMIC} pull --storage ostree docker:atomic-test-1:latest
-${ATOMIC} images tag --storage ostree atomic-test-1:latest at1:latest
+# Check that the tagged image is being displayed
+${ATOMIC} images list | grep "at1"
+${ATOMIC} images list --json | grep "at1"
+${ATOMIC} images list -f repo=at1 | grep "at1"


### PR DESCRIPTION
## Description
`atomic images list` now outputs images tagged with `atomic images tag`. Updated filtering to work with how repotags are handled.

## Check output
`# atomic pull docker.io/busybox`
`# atomic images tag docker.io/busybox:latest my.reg.local/busybox:latest`

### Old output
`# atomic images list`
`REPOSITORY                                      TAG       IMAGE ID       CREATED            VIRTUAL SIZE   TYPE`
`docker.io/busybox                               latest    c75bebcdd211   2017-05-15 22:15   1.11 MB        docker`

### New output
`# atomic images list`
`REPOSITORY                                      TAG       IMAGE ID       CREATED            VIRTUAL SIZE   TYPE`
`docker.io/busybox                               latest    c75bebcdd211   2017-05-15 22:15   1.11 MB        docker`
`my.reg.local/busybox                            latest    c75bebcdd211   2017-05-15 22:15   1.11 MB        docker`



## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [x] Integration Tests
