### PR TITLE
Atomic/backends/_docker.py: Error prevention with atomic run

### DIFF
--- a/Atomic/run.py
+++ b/Atomic/run.py
@@ -45,6 +45,9 @@ def cli(subparser):
     runp.set_defaults(_class=Run, func='run')
     run_group = runp.add_mutually_exclusive_group()
     util.add_opt(runp)
+    runp.add_argument("--replace", "-r", dest="replace", default=False,
+                      action="store_true", help=_("Replaces an existing container by the same name"
+                                                  "if it exists."))
     runp.add_argument("--storage", dest="storage", default=None,
                           help=_("Specify the storage. Default is currently '%s'.  You can"
                                  " change the default by editing /etc/atomic.conf and changing"

--- a/bash/atomic
+++ b/bash/atomic
@@ -675,6 +675,7 @@ _atomic_run() {
 		--spc
 	       --display
 	--quiet
+	       --replace
 	    --storage
 	"
 

--- a/docs/atomic-run.1.md
+++ b/docs/atomic-run.1.md
@@ -9,6 +9,7 @@ atomic-run - Execute container image run method
 [**-h**|**--help**]
 [**--display**]
 [**-n**][**--name**[=*NAME*]]
+[**-r**, **--replace**]
 [**--spc**]
 [**--storage**]
 [**--quiet**]
@@ -66,6 +67,9 @@ If --display is not specified the run command will execute.
    Use this name for creating run content for the container.
 NAME will default to the IMAGENAME if it is not specified.
 
+**-r** **--replace**
+   Replaces an existing container by the same name if it exists prior to running.
+   
 **--spc**
   Run container in super privileged container mode.  The image will run with the following command:
 

--- a/tests/integration/test_run.sh
+++ b/tests/integration/test_run.sh
@@ -1,0 +1,69 @@
+#!/bin/bash -x
+set -euo pipefail
+IFS=$'\n\t'
+
+ATOMIC=${ATOMIC:="/usr/bin/atomic"}
+ATOMIC=$(grep -v -- --debug <<< "$ATOMIC")
+DOCKER=${DOCKER:="/usr/bin/docker"}
+
+teardown () {
+	set +e
+	${DOCKER} rm -f RUN_TEST > /dev/null
+	set -e
+}
+
+fail () {
+	echo "Fail: TEST ${1} should have failed and did not"
+	exit 1
+}
+
+passed () {
+	echo "Passed: TEST ${1}"
+}
+
+
+failed () {
+	echo "Fail: TEST ${1}"
+	exit 1
+}
+
+
+trap teardown EXIT
+
+# Check that atomic run's naming
+TEST_NUM=1
+${ATOMIC} run -n RUN_TEST atomic-test-1 date
+CID=$("$DOCKER" ps -alq)
+NAME=$("$DOCKER" inspect --format='{{.Name}}' "$CID")
+
+
+if [[ "${NAME}" != /RUN_TEST ]]; then
+    failed "${TEST_NUM}"
+fi
+passed "${TEST_NUM}"
+
+TEST_NUM=2
+rc=0
+${ATOMIC} run -n RUN_TEST atomic-test-1 date 1>/dev/null || rc=$?
+if [[ ${rc} != 1 ]]; then
+    # Test failed
+    fail "${TEST_NUM}"
+fi
+
+passed "${TEST_NUM}"
+
+
+TEST_NUM=3
+${ATOMIC} run --replace -n RUN_TEST atomic-test-1 date
+NEW_CID=$("$DOCKER" ps -alq)
+NAME=$("$DOCKER" inspect --format='{{.Name}}' "$NEW_CID")
+
+if [[ "${NAME}" != /RUN_TEST ]]; then
+    failed "${TEST_NUM}"
+fi
+
+if [[ "${NEW_CID}" == "${CID}" ]]; then
+    failed "${TEST_NUM}"
+fi
+
+passed "${TEST_NUM}"


### PR DESCRIPTION
## Description

There were two primary cases where a secondary atomic run with a command
would trigger an exception.  The first was reported in
https://github.com/projectatomic/atomic/issues/1006. Basically it can
be summarized as:

```
atomic run registry.fedoraproject.org/fedora:25 date  # works fine
atomic run registry.fedoraproject.org/fedora:26 date  # tries to run in the existing f25 container
```

The second case is as simple as:

```
atomic run registry.fedoraproject.org/fedora:25 date  # works fine
atomic run registry.fedoraproject.org/fedora:25 date  # fails
```

This fails because atomic starts the stopped f25 container and then attempts a docker exec.  The
exec fails because the 'date' command is short-lived and the container exits prior to the exec
being run.

We now catch those exceptions and notify the user.  We added a `--replace` option to run where
atomic will now delete the container in question and re-run it from the correct image.

## Related Bugzillas
-
-

## Related Issue Numbers
- #1006 
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [x] Integration Tests
