### PR TITLE
Add configuration compliance scan to "atomic scan"

### DIFF
--- a/atomic.d/openscap
+++ b/atomic.d/openscap
@@ -9,7 +9,11 @@ scans: [
         description: "Performs a CVE scan based on Red Hat relesead CVE OVAL. !WARNING! This CVE is built into container image and it might be out-of-date. Change config.ini to configure the scanner to fetch latest CVE data"},
       { name: standards_compliance,
         args: ['oscapd-evaluate', 'scan', '--targets', 'chroots-in-dir:///scanin',  '--output', '/scanout', '--no-cve-scan', '-j1'],
-        description: "Performs scan with Standard Profile, as present in Scap Security Guide shipped in Red Hat Enterprise Linux"
+        description: "!DEPRECATED! Performs scan with Standard Profile, as present in SCAP Security Guide shipped in Red Hat Enterprise Linux"
+      },
+      { name: configuration_compliance,
+        args: ['oscapd-evaluate', 'scan', '--targets', 'chroots-in-dir:///scanin',  '--output', '/scanout', '--no-cve-scan', '-j1'],
+        description: "Performs a configuration compliance scan according to selected profile from SCAP Security Guide shipped in Red Hat Enterprise Linux."
       }
 ]
     

--- a/bash/atomic
+++ b/bash/atomic
@@ -253,6 +253,7 @@ _atomic_scan() {
 		--scanner
 		--scan_type
 		--verbose
+		--scanner_args
 	"
 	[ "$command" = "scan" ] && all_options="$all_options"
 

--- a/docs/atomic-scan.1.md
+++ b/docs/atomic-scan.1.md
@@ -38,6 +38,9 @@ Select as scanner other than the default.
 **--scan_type**
 Select a scan_type other than the default.
 
+**--scanner_args**
+  Provide additional arguments for the scanner, for example specify a compliance profile.
+
 **--all**
   Instead of providing image or container names, scan all images (excluding intermediate image layers) and containers
 


### PR DESCRIPTION
## Description
This PR enables scanning images and containers for configuration compliance with security profiles provided by SCAP Security Guide.

Note: This feature requires latest OpenSCAP Daemon from upstream installed in the underlying "rhel7/openscap" container.

## Related Bugzillas
- none

## Related Issue Numbers
- none

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
