### PR TITLE
Fix the _mark_used function to identify image as being used

### DIFF
--- a/Atomic/images.py
+++ b/Atomic/images.py
@@ -305,7 +305,7 @@ class Images(Atomic):
 
     def _mark_used(self, images):
         assert isinstance(images, list)
-        all_containers = [x.id for x in self.be_utils.get_containers()]
+        all_containers = [x.image for x in self.be_utils.get_containers()]
         for image in images:
             if image.id in all_containers:
                 image.used = True

--- a/tests/integration/test_images_list.sh
+++ b/tests/integration/test_images_list.sh
@@ -7,6 +7,13 @@ IFS=$'\n\t'
 IMAGE="atomic-test-1"
 IMAGE_SECRET="atomic-test-secret"
 TAGGED_IMAGE="local/at1"
+RUNNING_CONTAINER="testContainerOut"
+
+assert_not_reached() {
+    echo $@ 1>&2
+    exit 1
+
+}
 
 assert_matches() {
     if ! grep -q -e $@; then
@@ -28,6 +35,7 @@ setup () {
 
 teardown () {
     set +e
+    ${DOCKER} rm ${RUNNING_CONTAINER}
     ${DOCKER} rmi ${TAGGED_IMAGE}:latest
     set -e
 }
@@ -48,9 +56,14 @@ test $(wc -l < ${WORK_DIR}/images.out) -lt $(wc -l < ${WORK_DIR}/images.all.out)
 assert_matches '<none>' ${WORK_DIR}/images.all.out
 assert_not_matches '<none>' ${WORK_DIR}/images.out
 
-# Testing filters
+# Testing filters and used tag >
 ${ATOMIC} images list -f repo=${IMAGE} > ${WORK_DIR}/images.out
 assert_matches ${IMAGE} ${WORK_DIR}/images.out
+assert_not_matches ">  "${IMAGE} ${WORK_DIR}/images.out
+${DOCKER} run --name=${RUNNING_CONTAINER} ${IMAGE}
+${ATOMIC} images list -f repo=${IMAGE} > ${WORK_DIR}/images.out
+assert_matches ">  "${IMAGE} ${WORK_DIR}/images.out
+
 ${ATOMIC} images list -f type=docker > ${WORK_DIR}/images.out
 assert_matches ${IMAGE} ${WORK_DIR}/images.out
 ${ATOMIC} images list -f repo=non-existing-repo > ${WORK_DIR}/images.out

--- a/tests/integration/test_system_containers_images.sh
+++ b/tests/integration/test_system_containers_images.sh
@@ -20,7 +20,7 @@ setup () {
 
 teardown () {
     set +o pipefail
-
+    ${ATOMIC} -y containers delete busybox  &> /dev/null || true
     # Delete all images from ostree
     ostree --repo=${ATOMIC_OSTREE_REPO} refs --delete ociimage &> /dev/null || true
 }
@@ -52,8 +52,15 @@ assert_matches "ociimage/docker.io_2Fbusybox_3Alatest" ${WORK_DIR}/ostree_refs.o
 # 2. listing local images
 ${ATOMIC} images list > ${WORK_DIR}/images.out
 assert_matches "busybox" ${WORK_DIR}/images.out
+assert_not_matches ">  busybox" ${WORK_DIR}/images.out
 ${ATOMIC} images list -q > ${WORK_DIR}/images.out
 assert_not_matches "busybox" ${WORK_DIR}/images.out
+
+# Testing after installtion the '>' will show up
+${ATOMIC} install --system busybox
+${ATOMIC} images list > ${WORK_DIR}/images.out
+assert_matches ">  busybox" ${WORK_DIR}/images.out
+${ATOMIC} -y containers delete busybox
 
 # Testing filters
 ${ATOMIC} images list -f repo=busybox > ${WORK_DIR}/images.out


### PR DESCRIPTION
When image is being referenced by a container,
_mark_used function should mark image as being
used if the image id is found inside the information of
containers.

In this case, the image id for containers should be
referenced as container.image instead of container.id

Some tests are added for future regression.


## Description


## Related Bugzillas
-
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
