### PR TITLE
Atomic/systemcontainers.py: Set prefix to "/" if None

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -814,10 +814,10 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
 
         if has_container_service:
             util.write_template(unitfile, systemd_template, values, unitfileout)
-            shutil.copyfile(unitfileout, os.path.join(prefix, destination, "%s.service" % name))
+            shutil.copyfile(unitfileout, os.path.join(prefix or "/", destination, "%s.service" % name))
         if (tmpfiles_template):
             util.write_template(unitfile, tmpfiles_template, values, tmpfilesout)
-            shutil.copyfile(tmpfilesout, os.path.join(prefix, destination, "tmpfiles-%s.conf" % name))
+            shutil.copyfile(tmpfilesout, os.path.join(prefix or "/", destination, "tmpfiles-%s.conf" % name))
 
         if not prefix:
             sym = "%s/%s" % (self._get_system_checkout_path(), name)


### PR DESCRIPTION
## Description

In the case of installing a systemcontainer, if using python3 and the
prefix ends up being None, it throws a traceback as reported in
bz #1461994.  Using prefix or "/" fixes this issue.

## Related Bugzillas
- #1461994
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
