### PR TITLE
  Handle image deletion for used images and unnamed layer images 

### DIFF
--- a/Atomic/backends/_ostree.py
+++ b/Atomic/backends/_ostree.py
@@ -172,7 +172,8 @@ class OSTreeBackend(Backend):
 
     @staticmethod
     def get_dangling_images():
-        return []
+        syscontainers = SystemContainers()
+        return syscontainers.get_dangling_system_images()
 
     def make_remote_image(self, image):
         img_obj = self._make_remote_image(image)

--- a/Atomic/backends/_ostree.py
+++ b/Atomic/backends/_ostree.py
@@ -112,7 +112,29 @@ class OSTreeBackend(Backend):
     def pull_image(self, image, remote_image_obj=None, **kwargs):
         return self.syscontainers.pull_image(image)
 
+    # get containers that is using this image
+    def get_container_from_image(self,image):
+
+        # We get the system containers for its id and image
+        all_container_images = [(container.image,container.id) for container in self.get_containers()]
+
+        matching_container_ids = [container_id for (image_id, container_id) in all_container_images if image_id == image]
+
+        return matching_container_ids
+
     def delete_image(self, image, force=False):
+
+        # when force option is true, delete the containers associated with it
+        if force:
+            # to handle the case where partial id or image name was typed
+            img_obj = self.has_image(image)
+
+            if img_obj:
+                used_containers = self.get_container_from_image(img_obj.id)
+
+                for container in used_containers:
+                    self.delete_container(container)
+
         return self.syscontainers.delete_image(image)
 
     def version(self, image):

--- a/Atomic/backends/_ostree.py
+++ b/Atomic/backends/_ostree.py
@@ -112,25 +112,18 @@ class OSTreeBackend(Backend):
     def pull_image(self, image, remote_image_obj=None, **kwargs):
         return self.syscontainers.pull_image(image)
 
-    # get containers that is using this image
-    def get_container_from_image(self,image):
 
-        # We get the system containers for its id and image
-        all_container_images = [(container.image,container.id) for container in self.get_containers()]
-
-        matching_container_ids = [container_id for (image_id, container_id) in all_container_images if image_id == image]
-
+    def get_corresponding_containers_from_image_id (self,image_id):
+        all_container_and_image_ids = [(container.image,container.id) for container in self.get_containers()]
+        matching_container_ids = [container_id for (container_image_id, container_id) in all_container_and_image_ids if container_image_id == image_id]
         return matching_container_ids
 
     def delete_image(self, image, force=False):
-
-        # when force option is true, delete the containers associated with it
         if force:
             # to handle the case where partial id or image name was typed
             img_obj = self.has_image(image)
-
             if img_obj:
-                used_containers = self.get_container_from_image(img_obj.id)
+                used_containers = self.get_corresponding_containers_from_image_id(img_obj.id)
 
                 for container in used_containers:
                     self.delete_container(container)
@@ -170,10 +163,8 @@ class OSTreeBackend(Backend):
             layers.append(layer)
         return layers
 
-    @staticmethod
-    def get_dangling_images():
-        syscontainers = SystemContainers()
-        return syscontainers.get_dangling_system_images()
+    def get_dangling_images(self):
+        return self.syscontainers.get_dangling_system_images()
 
     def make_remote_image(self, image):
         img_obj = self._make_remote_image(image)

--- a/Atomic/backendutils.py
+++ b/Atomic/backendutils.py
@@ -156,11 +156,9 @@ class BackendUtils(object):
             con_objs += be.get_containers()
         return con_objs
 
-    def get_container_ids_from_image(self,image):
-        # We get the system containers for its id and image
+    def get_container_ids_from_image_id(self,image_id):
         all_container_images = [(container.image,container.id) for container in self.get_containers()]
-
-        matching_container_ids = [container_id for (image_id, container_id) in all_container_images if image_id == image]
+        matching_container_ids = [container_id for (container_image_id, container_id) in all_container_images if container_image_id == image_id]
         return matching_container_ids
 
     def get_container_obj_by_image_name(self, image_name, str_preferred_backend):

--- a/Atomic/backendutils.py
+++ b/Atomic/backendutils.py
@@ -156,6 +156,13 @@ class BackendUtils(object):
             con_objs += be.get_containers()
         return con_objs
 
+    def get_container_ids_from_image(self,image):
+        # We get the system containers for its id and image
+        all_container_images = [(container.image,container.id) for container in self.get_containers()]
+
+        matching_container_ids = [container_id for (image_id, container_id) in all_container_images if image_id == image]
+        return matching_container_ids
+
     def get_container_obj_by_image_name(self, image_name, str_preferred_backend):
         pass
 

--- a/Atomic/delete.py
+++ b/Atomic/delete.py
@@ -49,10 +49,12 @@ class Delete(Atomic):
         _image_names = []
         for del_obj in delete_objects:
             if del_obj.repotags:
-                _image_names.append(len(del_obj.repotags[0]))
+                length = 12 if "<none>" in del_obj.repotags[0] else len(del_obj.repotags[0])
+                _image_names.append(length)
             else:
                 _image_names.append(len(del_obj.id))
         max_img_name = max(_image_names) + 2
+
 
         # When found used imags, we stop action of trying to delete it
         # we then add it to a new list which will be processed
@@ -83,7 +85,7 @@ class Delete(Atomic):
                 used_images.append(del_obj)
             util.write_out(three_col.format(image, del_obj.backend.backend, image_status))
 
-        # always elminate out the unnamed not dangling layer
+        # always disable the intention that tries to delete unnamed layers which are not dangling
         delete_objects = [deletable for deletable in delete_objects if deletable not in unnamed_not_dangling_imgs]
 
         if not self.args.force:
@@ -105,7 +107,7 @@ class Delete(Atomic):
             # for the used images, output the error messages
             for used_img in used_images:
                 util.write_out("Error: conflict: unable to remove repository reference \"{}\"(must-force) - container(s) {} is using its referenced image {}".format(used_img.input_name,
-                                beu.get_container_ids_from_image(used_img.id),used_img.id[0:12]))
+                                beu.get_container_ids_from_image_id(used_img.id),used_img.id[0:12]))
 
         for undangling_layer in unnamed_not_dangling_imgs:
             util.write_out("Image {} is an unnamed layer of an image".format(undangling_layer.id[0:12]))

--- a/Atomic/delete.py
+++ b/Atomic/delete.py
@@ -54,18 +54,35 @@ class Delete(Atomic):
                 _image_names.append(len(del_obj.id))
         max_img_name = max(_image_names) + 2
 
+        # When found used imags, we stop action of trying to delete it
+        # we then add it to a new list which will be processed
+        used_images = []
+        all_containers = [x.image for x in beu.get_containers()]
+        for image in delete_objects:
+            if image.id in all_containers:
+                image.used = True
+
         if not self.args.assumeyes:
             util.write_out("Do you wish to delete the following images?\n")
         else:
             util.write_out("The following images will be deleted.\n")
 
-        two_col = "   {0:" + str(max_img_name) + "} {1}"
-        util.write_out(two_col.format("IMAGE", "STORAGE"))
+        three_col = "   {0:" + str(max_img_name) + "} {1:12}  {2}"
+        util.write_out(three_col.format("IMAGE", "STORAGE", "USED"))
         for del_obj in delete_objects:
             image = None if not del_obj.repotags else del_obj.repotags[0]
+            image_status  = 'YES' if del_obj.used else 'NO'
             if image is None or "<none>" in image:
                 image = del_obj.id[0:12]
-            util.write_out(two_col.format(image, del_obj.backend.backend))
+
+            if del_obj.used and not self.args.force:
+                used_images.append(del_obj)
+            util.write_out(three_col.format(image, del_obj.backend.backend, image_status))
+
+        if not self.args.force:
+            # redefine the objects that needed to be deleted
+            delete_objects = [del_obj for del_obj in delete_objects if del_obj not in used_images]
+
         if not self.args.assumeyes:
             confirm = util.input("\nConfirm (y/N) ")
             confirm = confirm.strip().lower()
@@ -77,6 +94,11 @@ class Delete(Atomic):
         for del_obj in delete_objects:
             del_obj.backend.delete_image(del_obj.input_name, force=self.args.force)
 
+        if not self.args.force:
+            # for the used images, output the error messages
+            for used_img in used_images:
+                util.write_out("Error: conflict: unable to remove repository reference \"{}\"(must-force) - container(s) {} is using its referenced image {}".format(used_img.input_name,
+                                beu.get_container_ids_from_image(used_img.id),used_img.id[0:12]))
         # We need to return something here for dbus
         return 0
 

--- a/tests/integration/test_system_containers_images.sh
+++ b/tests/integration/test_system_containers_images.sh
@@ -14,6 +14,8 @@ IFS=$'\n\t'
 # 7. info of local images (environment vars)
 # 8. version and verify
 
+CONTAINER_NAME="busybox-test"
+
 setup () {
     docker save atomic-test-system > ${WORK_DIR}/atomic-test-system.tar
 }
@@ -21,6 +23,7 @@ setup () {
 teardown () {
     set +o pipefail
     ${ATOMIC} -y containers delete busybox  &> /dev/null || true
+    ${ATOMIC} -y containers delete ${CONTAINER_NAME} &> /dev/null || true
     # Delete all images from ostree
     ostree --repo=${ATOMIC_OSTREE_REPO} refs --delete ociimage &> /dev/null || true
 }
@@ -78,7 +81,9 @@ assert_not_matches '<none>' ${WORK_DIR}/images.out
 
 
 # 3. deleting/pruning local images
-${ATOMIC} --assumeyes images delete -f --storage ostree busybox
+${ATOMIC} --assumeyes images delete -f --storage ostree busybox > ${WORK_DIR}/image.delete.out
+assert_matches "NO" ${WORK_DIR}/image.delete.out
+assert_matches "USED" ${WORK_DIR}/image.delete.out
 ostree --repo=${ATOMIC_OSTREE_REPO} refs > ${WORK_DIR}/ostree_refs.out
 assert_not_matches "ociimage/busybox_3Alatest" ${WORK_DIR}/ostree_refs.out
 
@@ -88,9 +93,21 @@ ${ATOMIC} images prune
 ${ATOMIC} images list -f type=ostree --all > ${WORK_DIR}/images.all.out
 assert_matches "<none>" ${WORK_DIR}/images.all.out
 
-# Test that the image can be deleted by ID
+#Test that when image is being used, it can not be deleted without force option
+${ATOMIC} install --system -n ${CONTAINER_NAME} docker.io/busybox
+${ATOMIC} --assumeyes images delete --storage ostree docker.io/busybox > ${WORK_DIR}/image.delete.out
+assert_matches "YES" ${WORK_DIR}/image.delete.out
+assert_matches "unable to remove repository reference" ${WORK_DIR}/image.delete.out
+assert_matches ${CONTAINER_NAME} ${WORK_DIR}/image.delete.out
+assert_matches "docker.io/busybox" ${WORK_DIR}/image.delete.out
+${ATOMIC} --assumeyes containers delete ${CONTAINER_NAME}
+
+# Test that the image can be deleted by ID and will uninstall containers through -f
 BUSYBOX_IMAGE_ID=$(${ATOMIC} images list -f type=ostree | grep busybox | awk '{print $3}')
+${ATOMIC} install --system -n ${CONTAINER_NAME} docker.io/busybox
 ${ATOMIC} --assumeyes images delete -f --storage=ostree ${BUSYBOX_IMAGE_ID}
+${ATOMIC} containers list -a > ${WORK_DIR}/image.delete.out
+assert_not_matches ${CONTAINER_NAME} ${WORK_DIR}/image.delete.out
 ${ATOMIC} images list -f type=ostree > ${WORK_DIR}/images.out
 assert_not_matches "busybox" ${WORK_DIR}/images.out
 

--- a/tests/integration/test_system_containers_images.sh
+++ b/tests/integration/test_system_containers_images.sh
@@ -102,14 +102,28 @@ assert_matches ${CONTAINER_NAME} ${WORK_DIR}/image.delete.out
 assert_matches "docker.io/busybox" ${WORK_DIR}/image.delete.out
 ${ATOMIC} --assumeyes containers delete ${CONTAINER_NAME}
 
-# Test that the image can be deleted by ID and will uninstall containers through -f
+# Test that when the named layer is still present, we are unable to delete the unnamedlayer
+UNNAMED_LAYER_ID=$(${ATOMIC} images list -a -f type=ostree| grep '<none>' | awk '{print $3}')
+${ATOMIC} --assumeyes images delete -f ${UNNAMED_LAYER_ID} > ${WORK_DIR}/images.out
+assert_matches "Image ${UNNAMED_LAYER_ID} is an unnamed layer of an image"  ${WORK_DIR}/images.out
+
+# Test that the image can be deleted by ID and see if unnamedly layer becoming dangling
+# and delete -f will remove the image with the container
 BUSYBOX_IMAGE_ID=$(${ATOMIC} images list -f type=ostree | grep busybox | awk '{print $3}')
 ${ATOMIC} install --system -n ${CONTAINER_NAME} docker.io/busybox
 ${ATOMIC} --assumeyes images delete -f --storage=ostree ${BUSYBOX_IMAGE_ID}
 ${ATOMIC} containers list -a > ${WORK_DIR}/image.delete.out
 assert_not_matches ${CONTAINER_NAME} ${WORK_DIR}/image.delete.out
-${ATOMIC} images list -f type=ostree > ${WORK_DIR}/images.out
+${ATOMIC} images list -a -f type=ostree > ${WORK_DIR}/images.out
 assert_not_matches "busybox" ${WORK_DIR}/images.out
+assert_matches "*  <none>" ${WORK_DIR}/images.out
+
+# Now test if we can remove the dangling images
+${ATOMIC} --assumeyes images delete -f ${UNNAMED_LAYER_ID}  > ${WORK_DIR}/images.out
+assert_not_matches "Image ${UNNAMED_LAYER_ID} is an unnamed layer of an image"  ${WORK_DIR}/images.out
+#check that unnamed image layer is gone
+${ATOMIC} images list -a -f type=ostree > ${WORK_DIR}/images.all.out
+assert_not_matches "<none>" ${WORK_DIR}/images.all.out
 
 # Test that pruning now removes all images
 ${ATOMIC} images prune

--- a/tests/unit/test_delete.py
+++ b/tests/unit/test_delete.py
@@ -89,19 +89,14 @@ class TestInfo(unittest.TestCase):
     def test_delete_all_docker(self):
         with patch('Atomic.backends._docker.DockerBackend.delete_image') as deleteobj:
             with patch('Atomic.backends._docker.DockerBackend._get_images') as imageobj:
-                with patch('Atomic.objects.image.Image.is_dangling') as danglingobj:
-                    args = self.Args()
-                    args.all = True
-                    args.storage = 'docker'
-                    del_ = Delete()
-                    del_.set_args(args)
-                    deleteobj.return_value = None
-                    imageobj.return_value = docker_images
-
-                    # as the data was not real, there is no way to get the metadata
-                    danglingobj.return_value =None
-
-                    self.assertEqual(del_.delete_image(), 0)
+                args = self.Args()
+                args.all = True
+                args.storage = 'docker'
+                del_ = Delete()
+                del_.set_args(args)
+                deleteobj.return_value = None
+                imageobj.return_value = docker_images
+                self.assertEqual(del_.delete_image(), 0)
 
     def test_delete_all_ostree(self):
         with patch('Atomic.backends._ostree.OSTreeBackend.delete_image') as deleteobj:
@@ -113,7 +108,9 @@ class TestInfo(unittest.TestCase):
                     del_ = Delete()
                     del_.set_args(args)
                     deleteobj.return_value = None
-                    # Similar reason as docker above
+                    # Set the dangling object to be none because checking layer information
+                    # requires data from metadata, which we currenlty do not have for
+                    # the unit test object
                     danglingobj.return_value = None
                     imageobj.return_value = ostree_images
                     self.assertEqual(del_.delete_image(), 0)

--- a/tests/unit/test_delete.py
+++ b/tests/unit/test_delete.py
@@ -89,23 +89,31 @@ class TestInfo(unittest.TestCase):
     def test_delete_all_docker(self):
         with patch('Atomic.backends._docker.DockerBackend.delete_image') as deleteobj:
             with patch('Atomic.backends._docker.DockerBackend._get_images') as imageobj:
-                args = self.Args()
-                args.all = True
-                args.storage = 'docker'
-                del_ = Delete()
-                del_.set_args(args)
-                deleteobj.return_value = None
-                imageobj.return_value = docker_images
-                self.assertEqual(del_.delete_image(), 0)
+                with patch('Atomic.objects.image.Image.is_dangling') as danglingobj:
+                    args = self.Args()
+                    args.all = True
+                    args.storage = 'docker'
+                    del_ = Delete()
+                    del_.set_args(args)
+                    deleteobj.return_value = None
+                    imageobj.return_value = docker_images
+
+                    # as the data was not real, there is no way to get the metadata
+                    danglingobj.return_value =None
+
+                    self.assertEqual(del_.delete_image(), 0)
 
     def test_delete_all_ostree(self):
         with patch('Atomic.backends._ostree.OSTreeBackend.delete_image') as deleteobj:
             with patch('Atomic.syscontainers.SystemContainers.get_system_images') as imageobj:
-                args = self.Args()
-                args.all = True
-                args.storage = 'ostree'
-                del_ = Delete()
-                del_.set_args(args)
-                deleteobj.return_value = None
-                imageobj.return_value = ostree_images
-                self.assertEqual(del_.delete_image(), 0)
+                with patch('Atomic.objects.image.Image.is_dangling') as danglingobj:
+                    args = self.Args()
+                    args.all = True
+                    args.storage = 'ostree'
+                    del_ = Delete()
+                    del_.set_args(args)
+                    deleteobj.return_value = None
+                    # Similar reason as docker above
+                    danglingobj.return_value = None
+                    imageobj.return_value = ostree_images
+                    self.assertEqual(del_.delete_image(), 0)


### PR DESCRIPTION
Before, when an image is referenced by a container, user is still
able to delete the image even without force command

To avoid that thing to happen, another column is added
in the delete message(shown below):

 IMAGE                     STORAGE       USED
 xxxxx                         xxxxxxx           xxxx

When user is trying to delete an image,
the USED column will have a YES or NO answer
to indicate the stauts of the image

The user will no longer be able to delete
"used" images(without force)
and an error message will be
shown to further indicate that.

Some tests are added for future regression.


## Description


## Related Bugzillas
-
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [x] Integration Tests
