### PR TITLE
Atomic/scan.py: Add rootfs to self.mount_paths BZ:1461788

### DIFF
--- a/Atomic/scan.py
+++ b/Atomic/scan.py
@@ -469,6 +469,7 @@ class Scan(Atomic):
             chroot_scan_dir = os.path.join(self.chroot_dir, bind_dir)
             os.mkdir(chroot_scan_dir)
             mcmd = ['mount', '-o', 'ro,bind', _dir, chroot_scan_dir]
+            self.mount_paths[chroot_scan_dir] = chroot_scan_dir
             util.check_call(mcmd)
             self.rootfs_mappings[_dir] = bind_dir
 


### PR DESCRIPTION
## Description
When a rootfs is scanned, it needs its dir added to self.mount_paths
so that it can be unmounted properly.  Failure to do so was resulting
in a read-only filesystem error during scan clean ups because atomic
deletes the temporary directory with shutil.rmtree.

## Related Bugzillas
- #1461788
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
