### PR TITLE
syscontainers: by default don't install rpm on AH

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -167,6 +167,7 @@ class SystemContainers(object):
         return self.install(image, name)
 
     def _install_rpm(self, rpm_file):
+        # Ensure _should_be_installed_rpm is changed as well.
         if os.path.exists("/run/ostree-booted"):
             raise ValueError("This doesn't work on Atomic Host yet")
         elif os.path.exists("/usr/bin/dnf"):
@@ -541,6 +542,8 @@ class SystemContainers(object):
         return [get_image(i) for i in matches]
 
     def _should_be_installed_rpm(self, exports):
+        if os.path.exists("/run/ostree-booted"):
+            return False
         for i in ["rpm.spec", "rpm.spec.template", "hostfs"]:
             if os.path.exists(os.path.join(exports, i)):
                 return True

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -166,15 +166,6 @@ class SystemContainers(object):
         # Same entrypoint
         return self.install(image, name)
 
-    def _install_rpm(self, rpm_file):
-        # Ensure RPMHostInstall._should_be_installed_rpm is changed as well.
-        if os.path.exists("/run/ostree-booted"):
-            raise ValueError("This doesn't work on Atomic Host yet")
-        elif os.path.exists("/usr/bin/dnf"):
-            util.check_call(["dnf", "install", "-y", rpm_file])
-        else:
-            util.check_call(["yum", "install", "-y", rpm_file])
-
     # Create a checkout and generate an RPM file
     def build_rpm(self, repo, name, image, values, destination):
         installed_files = None

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -167,7 +167,7 @@ class SystemContainers(object):
         return self.install(image, name)
 
     def _install_rpm(self, rpm_file):
-        # Ensure _should_be_installed_rpm is changed as well.
+        # Ensure RPMHostInstall._should_be_installed_rpm is changed as well.
         if os.path.exists("/run/ostree-booted"):
             raise ValueError("This doesn't work on Atomic Host yet")
         elif os.path.exists("/usr/bin/dnf"):


### PR DESCRIPTION
We still don't support it, when --system-package=auto default to no on
Atomic host.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
