### PR TITLE
Atomic/trust.py: Fix str/byte encoding for Python3

### DIFF
--- a/Atomic/trust.py
+++ b/Atomic/trust.py
@@ -249,7 +249,7 @@ class Trust(Atomic):
                 keydata = r.content
             else:
                 raise ValueError("Could not download public key from %s. Status code %s." % (key_reference, r.status_code))
-        return b64encode(keydata)
+        return b64encode(keydata.encode())
 
     def check_policy(self, policy, sstype):
         """


### PR DESCRIPTION
## Description

A TypeError was being thrown in pure Python3 environments due to a
lack of encoding the string keydata.

## Related Bugzillas
-
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
