### PR TITLE
syscontainers: fix copy to host of symlinks

### DIFF
--- a/Atomic/rpm_host_install.py
+++ b/Atomic/rpm_host_install.py
@@ -10,6 +10,14 @@ RPM_NAME_PREFIX = "atomic-container"
 class RPMHostInstall(object):
 
     @staticmethod
+    def copyfile(src, dest):
+        if os.path.islink(src):
+            linkto = os.readlink(src)
+            os.symlink(linkto, dest)
+        else:
+            shutil.copy2(src, dest)
+
+    @staticmethod
     def _do_rename_path(path, rename_files):
         path_split = path.split('/')
         path = ""
@@ -63,7 +71,7 @@ class RPMHostInstall(object):
                         util.write_template(src_file, data, values or {}, dest_path)
                         shutil.copystat(src_file, dest_path)
                     else:
-                        shutil.copy2(src_file, dest_path)
+                        RPMHostInstall.copyfile(src_file, dest_path)
 
                     new_installed_files.append(rel_dest_path)
             new_installed_files.sort()  # just for an aesthetic reason in the info file output

--- a/tests/test-images/Dockerfile.system-hostfs
+++ b/tests/test-images/Dockerfile.system-hostfs
@@ -6,6 +6,7 @@ LABEL "atomic.has_install_files"="yes"
 
 # Add a file that can be handled by the rpm generator
 RUN mkdir -p /exports/hostfs/usr/local/lib
+RUN ln -s /does/not/exist /exports/hostfs/broken-symlink
 ADD message /exports/hostfs/usr/local/lib/secret-message
 ADD message-template /exports/hostfs/usr/local/lib/secret-message-template
 


### PR DESCRIPTION
copy2 fails when the source file is a broken symlink.  If we are trying
to copy a symlink, read where it points to and create a new symlink.

More information here:
https://github.com/openshift/openshift-ansible/pull/4898#issuecomment-318734884

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>


## Description


## Related Bugzillas
-
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [x] Unittests
- [x] Integration Tests
