### PR TITLE
Introduce building hardened images

### DIFF
--- a/Atomic/scan.py
+++ b/Atomic/scan.py
@@ -548,7 +548,7 @@ class Scan(Atomic):
                     raise RuntimeError("Docker exception: {}\n".format(e))
                 build_output = []
                 for item in build_output_generator:
-                    item_dict = eval(item.decode("utf-8"))
+                    item_dict = json.loads(item.decode("utf-8"))
                     if "error" in item_dict:
                         raise RuntimeError("Error during Docker build {}\n".format(item_dict["error"]))
                     if self.args.debug:

--- a/Atomic/scan.py
+++ b/Atomic/scan.py
@@ -529,7 +529,8 @@ class Scan(Atomic):
 
     def harden(self):
         for target in self.scan_list:
-            util.write_out("Hardening target {}.\n".format(target.id))
+            name = self._get_input_name_for_id(target.id)
+            util.write_out("Hardening target {}.\n".format(name))
             temp_dir = tempfile.mkdtemp()
             fix_script = os.path.join(self.results_dir, target.id, "fix.sh")
             try:
@@ -557,10 +558,10 @@ class Scan(Atomic):
                         util.write_out(item_dict["stream"], lf="")
                     build_output.append(item_dict["stream"])
                 image_id = build_output[-1].split()[-1]
-                util.write_out("Sucessfully built hardened image {} from {}.\n".format(image_id, target.id))
+                util.write_out("Sucessfully built hardened image {} from {}.\n".format(image_id, name))
             except RuntimeError as e:
                 util.write_err("Cannot build hardened image from {}: {}\n"
-                           .format(target.id, e))
+                           .format(name, e))
             finally:
                 shutil.rmtree(temp_dir)
         return 0

--- a/atomic.d/openscap
+++ b/atomic.d/openscap
@@ -12,7 +12,7 @@ scans: [
         description: "!DEPRECATED! Performs scan with Standard Profile, as present in SCAP Security Guide shipped in Red Hat Enterprise Linux"
       },
       { name: configuration_compliance,
-        args: ['oscapd-evaluate', 'scan', '--targets', 'chroots-in-dir:///scanin',  '--output', '/scanout', '--no-cve-scan', '-j1'],
+        args: ['oscapd-evaluate', 'scan', '--targets', 'chroots-in-dir:///scanin',  '--output', '/scanout', '--no-cve-scan', '--fix_type', 'bash', '-j1'],
         description: "Performs a configuration compliance scan according to selected profile from SCAP Security Guide shipped in Red Hat Enterprise Linux."
       }
 ]


### PR DESCRIPTION
## Description

I would like to propose an extension of Atomic scan command. It enables to create images that are compliant with a security policy (STIG, OSPP, PCI-DSS or others available in SCAP Security Guide) from existing images. 

The pull request adds a new option `--harden`  to `atomic scan`. It works like this: First, it performs a scan. Based on scan results, it creates a remediation script, and then simply builds a new image from the scanned image. During the build the fix script is be invoked. We can think of it as adding new layer on the original image. This layer contains all the changes needed to comply with a SCAP profile.

Most of the work is done by openscap-daemon. This pull request requires openscap-daemon-0.1.7 (released last week) in the underlying "openscap" container, it doesn't work with older versions of openscap-daemon.
EDIT: openscap-daemon-0.1.7 is now available in Fedora repositories

Example:
```
atomic scan --harden --scan_type configuration_compliance --scanner_args profile=xccdf_org.ssgproject.content_profile_stig-rhel7-disa registry.access.redhat.com/rhel7
``` 
I have opened this as a work in progress pull request. I assume there needs to be done much more. I have already a couple of thoughts:
* Should it use Docker API instead of a process call?
* I guess it should show the build progress
* maybe extend the JSON results
* it works for images now, what about containers? I think we need make an image from them first

Feedback and suggestions are welcome.

## Related Bugzillas
- https://bugzilla.redhat.com/show_bug.cgi?id=1472379

## Related Issue Numbers
- none

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
