### PR TITLE
Create a mountpoint directory with overlay storage driver

### DIFF
--- a/Atomic/mount.py
+++ b/Atomic/mount.py
@@ -587,6 +587,19 @@ class DockerMount(Mount):
                              'writeable mounts.')
 
         cid = self._identifier_as_cid(identifier)
+
+        if self.mnt_mkdir:
+            # If the given mount_path is just a parent dir for where
+            # to mount things by cid, then the new mountpoint is the
+            # mount_path plus the first 20 chars of the cid
+            self.mountpoint = os.path.join(self.mountpoint, cid[:20])
+
+            try:
+                if not os.path.exists(self.mountpoint):
+                    os.mkdir(self.mountpoint)
+            except (TypeError, OSError) as e:
+                raise MountError(e)
+
         cinfo = self.d.inspect_container(cid)
 
         ld, ud, wd = '', '', ''


### PR DESCRIPTION
## Description
Method _mount_overlay didn't support mnt_mkdir attribute. The behavior of _mount_overlay method should be consistent with _mount_devicemapper method. 

This commit copies code from _mount_devicemapper.

It will fix OpenSCAP scans on overlay.

## Related Bugzillas
-
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
