### PR TITLE
Diff dup

### DIFF
--- a/Atomic/mount.py
+++ b/Atomic/mount.py
@@ -418,6 +418,13 @@ class DockerMount(Mount):
         elif len(images) == 1:
             return self._create_temp_container(images[0])
 
+        # Check if identifier is fully qualified
+        # local import only
+        from Atomic.objects.image import Image
+        _image = Image(identifier)
+        if _image.fully_qualified:
+            return self._create_temp_container(identifier)
+
         # Match image tag.
         images = util.image_by_name(identifier)
         if len(images) > 1:


### PR DESCRIPTION
## Description
Atomic/mount.py: Fix duplication with fq image name (BZ #1480325)
    
When performing a diff and the user has provided fq names for both images, the code was performing a lookup by the image name and sometimes finding duplicates.  This should never happen when the user provides a fully-qualified image name.
    
This was reported in BZ# 1480325


## Related Bugzillas
- 1480325
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
