### PR TITLE
Atomic/backends/_docker.py: Correct NoneType error (BZ #1481967)

### DIFF
--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -683,7 +683,7 @@ class DockerBackend(Backend):
 
     def _running(self, con_obj, args, atomic):
         requested_image = self.has_image(args.image)
-        if con_obj.image != requested_image.id:
+        if requested_image is not None and con_obj.image != requested_image.id:
             requested_image_fq_name = requested_image.fq_name
             raise AtomicError("Warning: container '{}' already points to {}\nRun 'atomic run {}' to run "
                                           "the existing container.\nRun 'atomic run --replace '{}' to replace "


### PR DESCRIPTION
## Description
When wanting to run a command in a already running container,
a NoneType error was being thrown when the image lookup
failed.

This was reported in BZ #1481967

## Related Bugzillas
- 1481967
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
