### PR TITLE
Honor --gnupghome on push

### DIFF
--- a/Atomic/push.py
+++ b/Atomic/push.py
@@ -196,7 +196,8 @@ class Push(Atomic):
                                            policy_filename=self.policy_filename,
                                            sign_by=self.args.sign_by if sign else None, insecure=insecure,
                                            username=self.args.username,
-                                           password=self.args.password)
+                                           password=self.args.password,
+                                           gpghome=self.args.gnupghome)
 
             if return_code != 0:
                 raise ValueError("Pushing {} failed.".format(self.image))

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -399,7 +399,8 @@ def skopeo_manifest_digest(manifest_file, debug=False):
     cmd = cmd  + ['manifest-digest', manifest_file]
     return check_output(cmd).rstrip().decode()
 
-def skopeo_copy(source, destination, debug=False, sign_by=None, insecure=False, policy_filename=None, username=None, password=None):
+def skopeo_copy(source, destination, debug=False, sign_by=None, insecure=False, policy_filename=None,
+                username=None, password=None, gpghome=None):
 
     cmd = [SKOPEO_PATH]
     if policy_filename:
@@ -423,6 +424,8 @@ def skopeo_copy(source, destination, debug=False, sign_by=None, insecure=False, 
     cmd = cmd + [source, destination]
     if debug:
         write_out("Executing: {}".format(" ".join(cmd)))
+    if gpghome is not None:
+        os.environ['GNUPGHOME'] = gpghome
     return check_call(cmd, env=os.environ)
 
 


### PR DESCRIPTION
## Description
The command switch for --gnupghome was not being honored when an atomic
push was being done.  We now export it to an os.environ so that skopeo
can use it.

## Related Bugzillas
-
-

## Related Issue Numbers
- #1066 1066
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
