### PR TITLE
Atomic/util.py: Use tls-verify on skopeo subcommands

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -320,7 +320,7 @@ def skopeo_inspect(image, args=None, return_json=True, newline=False):
     # docker configuration. If so, then use false in the future.  This
     # is complicated by the fact that CIDR notation can be used in the
     # docker conf
-    cmd = [SKOPEO_PATH, '--tls-verify=false', 'inspect'] + args + [image]
+    cmd = [SKOPEO_PATH,  'inspect', '--tls-verify=false']+ args + [image]
     try:
         results = subp(cmd, newline=newline)
     except OSError:
@@ -345,7 +345,7 @@ def skopeo_delete(image, args=None):
     if not args:
         args=[]
 
-    cmd = [SKOPEO_PATH, 'tls-verify=false', 'delete'] + args + [image]
+    cmd = [SKOPEO_PATH, 'delete', '--tls-verify=false'], + args + [image]
     try:
         results = subp(cmd)
     except OSError:
@@ -407,9 +407,9 @@ def skopeo_copy(source, destination, debug=False, sign_by=None, insecure=False, 
 
     if debug:
         cmd = cmd + ['--debug']
-    if insecure:
-        cmd = cmd + ['--tls-verify=false']
     cmd = cmd + ['copy']
+    if insecure:
+        cmd = cmd + ['--src-tls-verify=false', '--dest-tls-verify=false']
     if username:
         # it's ok to send an empty password (think of krb for instance)
         cmd = cmd + [ "--dest-creds=%s%s" % (username, ":%s" % password if password else "") ]


### PR DESCRIPTION
## Description

In order to avoid warnings from skopeo, we should be using
tls-verify on the skopeo subcommand (like copy) rather than
skopeo itself.

This was reported in issue #1067.

## Related Issue Numbers
- #1067 
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
