### PR TITLE
Implement run for system containers

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -52,3 +52,4 @@ packages:
   - python3-coverage
   - rpm-build
   - make
+  - python3-PyYAML

--- a/.papr.yml
+++ b/.papr.yml
@@ -51,3 +51,4 @@ packages:
   - atomic
   - python3-coverage
   - rpm-build
+  - make

--- a/Atomic/backends/_ostree.py
+++ b/Atomic/backends/_ostree.py
@@ -164,8 +164,12 @@ class OSTreeBackend(Backend):
         return self.syscontainers.uninstall(container)
 
     def run(self, iobject, **kwargs):
-        name = iobject.name
         args = kwargs.get('args')
+        try:
+            name = iobject.name
+        except AttributeError:  # iobject isn't populated
+            raise ValueError('Unable to find an image named {} in {}'.format(
+                args.image, args.storage))
         if len(args.command) == 0:
             return self.syscontainers.start_service(name)
         return self.syscontainers.container_exec(name, args.detach, args.command)

--- a/Atomic/backends/_ostree.py
+++ b/Atomic/backends/_ostree.py
@@ -164,7 +164,11 @@ class OSTreeBackend(Backend):
         return self.syscontainers.uninstall(container)
 
     def run(self, iobject, **kwargs):
-        return self.syscontainers.start_service(iobject.name)
+        name = iobject.name
+        args = kwargs.get('args')
+        if len(args.command) == 0:
+            return self.syscontainers.start_service(name)
+        return self.syscontainers.container_exec(name, args.detach, args.command)
 
     def tag_image(self, src, dest):
         return self.syscontainers.tag_image(src, dest)

--- a/Atomic/run.py
+++ b/Atomic/run.py
@@ -112,14 +112,6 @@ class Run(Atomic):
                 img_object = db.has_image(self.image)
             except RegistryInspectError:
                 raise ValueError("Unable to find image {}".format(self.image))
-        if storage == 'ostree':
-            if img_object is None:
-                be.pull_image(self.args.image, None)
-            # For system containers, the run method really needs a container obj
-            con_obj = be.has_container(self.name)
-            if con_obj is None:
-                be.install(self.image, self.name)
-            img_object = be.has_container(self.name)
         return be.run(img_object, atomic=self, args=self.args)
 
     @staticmethod

--- a/tests/integration/test_system_containers_runtime.sh
+++ b/tests/integration/test_system_containers_runtime.sh
@@ -52,7 +52,14 @@ setup
 
 # 1. Install a system container and start/stop the container with systemctl
 ${ATOMIC} install --name=${NAME} --set=RECEIVER=${SECRET} --system atomic-test-system
+${ATOMIC} run --storage ostree ${NAME} echo hello world < /dev/null > ${WORK_DIR}/status.out
+assert_matches "hello world" ${WORK_DIR}/status.out
+
 systemctl start ${NAME}.service
+
+${ATOMIC} run --storage ostree ${NAME} echo hello world again < /dev/null > ${WORK_DIR}/status.out
+assert_matches "hello world again" ${WORK_DIR}/status.out
+
 # Check the service is running
 systemctl status ${NAME}.service > ${WORK_DIR}/status.out
 assert_matches "Active: active (running)" ${WORK_DIR}/status.out

--- a/tests/unit/test_syscontainers.py
+++ b/tests/unit/test_syscontainers.py
@@ -1,0 +1,130 @@
+#pylint: skip-file
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from Atomic import util
+from Atomic.syscontainers import SystemContainers
+
+
+no_mock = True
+try:
+    from unittest.mock import ANY, patch, call
+    no_mock = False
+except ImportError:
+    try:
+        from mock import ANY, patch, call
+        no_mock = False
+    except ImportError:
+        # Mock is already set to False
+        pass
+
+
+@unittest.skipIf(no_mock, "Mock not found")
+class TestSystemContainers_container_exec(unittest.TestCase):
+    """
+    Unit tests for the SystemContainres.container_exec method.
+    """
+
+    class Args():
+        """
+        Fake argument object for use in tests.
+        """
+        def __init__(self, atomic_config=None, backend=None, user=False, args=None, setvalues=None, display=False):
+            self.atomic_config = atomic_config or util.get_atomic_config()
+            self.backend = backend
+            self.user = user
+            self.args = args or []
+            self.setvalues = setvalues
+            self.display = display
+
+    def test_container_exec_in_usermode(self):
+        """
+        A ValueError should be raised as usermode is not supported.
+        """
+        args = self.Args(backend='ostree')
+        sc = SystemContainers()
+        sc.set_args(args)
+        self.assertRaises(ValueError, sc.container_exec, 'test', False, {})
+
+    @patch('Atomic.syscontainers.SystemContainers._is_service_active')
+    @patch('Atomic.util.is_user_mode')
+    @patch('Atomic.backendutils.BackendUtils.get_backend_and_container_obj')
+    def test_container_exec_not_running_no_checkout(self, _gb, _um, _sa):
+        """
+        A ValueError should be raised when the container is not running and there is no checkout.
+        """
+        _sa.return_value = False  # The service is not active
+        _um.return_value = False  # user mode is False
+        _gb.return_value = None  # The checkout is None
+
+        args = self.Args(backend='ostree')
+        sc = SystemContainers()
+        sc.set_args(args)
+        self.assertRaises(ValueError, sc.container_exec, 'test', False, {})
+
+    @patch('Atomic.syscontainers.SystemContainers._is_service_active')
+    @patch('Atomic.util.is_user_mode')
+    @patch('Atomic.syscontainers.SystemContainers._canonicalize_location')
+    def test_container_exec_not_running_with_detach(self, _cl, _um, _sa):
+        """
+        A ValueError should be raised when the container is not running and detach is requested.
+        """
+        _sa.return_value = False  # The service is not active
+        _um.return_value = False  # user mode is False
+        _cl.return_value = True  # Fake a checkout
+
+        args = self.Args(backend='ostree')
+        sc = SystemContainers()
+        sc.set_args(args)
+        self.assertRaises(ValueError, sc.container_exec, 'test', True, {})  # Run with detach as True
+
+    @patch('Atomic.syscontainers.SystemContainers._is_service_active')
+    @patch('Atomic.util.check_call')
+    @patch('Atomic.util.is_user_mode')
+    def test_container_exec_with_container_running(self, _um, _cc, _sa):
+        """
+        Expect the container exec command to be used when container is running.
+        """
+        cmd_call = [util.RUNC_PATH, 'exec', 'test']
+        if os.isatty(0):  # If we are a tty then we need to pop --tty in there
+            cmd_call.insert(2, '--tty')
+        expected_call = call(cmd_call, stderr=ANY, stdin=ANY, stdout=ANY)
+
+        _sa.return_value = True  # The service is active
+        _um.return_value = False  # user mode is False
+        args = self.Args(backend='ostree', user=False)
+        sc = SystemContainers()
+        sc.set_args(args)
+        sc.container_exec('test', False, {})
+
+        self.assertEquals(_cc.call_args, expected_call)
+
+    @patch('Atomic.syscontainers.SystemContainers._is_service_active')
+    @patch('Atomic.util.check_call')
+    @patch('Atomic.util.is_user_mode')
+    @patch('Atomic.syscontainers.SystemContainers._canonicalize_location')
+    def test_container_exec_without_container_running(self, _ce, _um, _cc, _sa):
+        """
+        Expect the container to be started if it's not already running.
+        """
+        expected_call = call([util.RUNC_PATH, 'run', 'test'], stdin=ANY, stderr=ANY, stdout=ANY)
+
+        _sa.return_value = False  # The service is not active
+        _um.return_value = False  # user mode is False
+        tmpd = tempfile.mkdtemp()
+        _ce.return_value = tmpd  # Use a temporary directory for testing
+        args = self.Args(backend='ostree', user=False)
+        sc = SystemContainers()
+        sc.set_args(args)
+
+        shutil.copy('./tests/test-images/system-container-files-hostfs/config.json.template', os.path.join(tmpd, 'config.json'))
+
+        sc.container_exec('test', False, {})
+        self.assertEquals(_cc.call_args, expected_call)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

Allows to run commands in a container.  This is more useful for system containers as it allows to run a command before the container is running.  To do so, a new `config.json` file is created with a modified `args` block.

## Related Issue Numbers

https://github.com/projectatomic/atomic-system-containers/pull/89

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [x] Unittests
- [x] Integration Tests
