### PR TITLE
syscontainers: use Skopeo copy to pull images

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1822,7 +1822,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         if not upgrade and current_rev[1]:
             return False
 
-        can_use_skopeo_copy = str(util.check_output([util.SKOPEO_PATH, "copy", "--help"])).find("ostree") >= 0
+        can_use_skopeo_copy = util.check_output([util.SKOPEO_PATH, "copy", "--help"]).decode().find("ostree") >= 0
 
         if can_use_skopeo_copy:
             return self._check_system_oci_image_skopeo_copy(repo, img)

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1821,6 +1821,28 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         current_rev = repo.resolve_rev(imagebranch, True)
         if not upgrade and current_rev[1]:
             return False
+
+        can_use_skopeo_copy = str(util.check_output([util.SKOPEO_PATH, "copy", "--help"])).find("ostree") >= 0
+
+        if can_use_skopeo_copy:
+            return self._check_system_oci_image_skopeo_copy(repo, img)
+        return self._check_system_oci_image_no_skopeo_copy(repo, img, imagebranch)
+
+    def _check_system_oci_image_skopeo_copy(self, repo, img):
+        repo = self.get_ostree_repo_location()
+
+        checkout = self._get_system_checkout_path()
+        destdir = checkout if os.path.exists(checkout) else None
+        temp_dir = tempfile.mkdtemp(prefix=".", dir=destdir)
+
+        destination = "ostree:{}@{}".format(img, repo)
+        try:
+            util.skopeo_copy("docker://" + img, destination, dest_ostree_tmp_dir=temp_dir)
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+        return True
+
+    def _check_system_oci_image_no_skopeo_copy(self, repo, img, imagebranch):
         try:
             manifest = self._skopeo_get_manifest(img)
         except ValueError:

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -400,7 +400,7 @@ def skopeo_manifest_digest(manifest_file, debug=False):
     return check_output(cmd).rstrip().decode()
 
 def skopeo_copy(source, destination, debug=False, sign_by=None, insecure=False, policy_filename=None,
-                username=None, password=None, gpghome=None):
+                username=None, password=None, gpghome=None, dest_ostree_tmp_dir=None):
 
     cmd = [SKOPEO_PATH]
     if policy_filename:
@@ -421,6 +421,9 @@ def skopeo_copy(source, destination, debug=False, sign_by=None, insecure=False, 
 
     if sign_by:
         cmd = cmd + ['--sign-by', sign_by]
+
+    if dest_ostree_tmp_dir:
+        cmd = cmd + ['--dest-ostree-tmp-dir', dest_ostree_tmp_dir]
     cmd = cmd + [source, destination]
     if debug:
         write_out("Executing: {}".format(" ".join(cmd)))


### PR DESCRIPTION
New versions of Skopeo support "ostree:" as a destination for copy.
Use directly Skopeo to copy an image to the OSTree repository.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

