### PR TITLE
Atomic integration with kpod images and kpod ps

### DIFF
--- a/Atomic/containers.py
+++ b/Atomic/containers.py
@@ -192,7 +192,7 @@ class Containers(Atomic):
                                           con_obj.id[0:max_container_id],
                                           con_obj.image_name[0:max_image_name],
                                           con_obj.name[0:max_container_name],
-                                          con_obj.command[0:max_command],
+                                          str(con_obj.command)[0:max_command],
                                           con_obj.created[0:16],
                                           con_obj.state[0:10],
                                           con_obj.backend.backend[0:10],

--- a/Atomic/objects/image.py
+++ b/Atomic/objects/image.py
@@ -317,11 +317,17 @@ class Image(object): # pylint: disable=eq-without-hash
         return False
 
 def convert_size(size):
+    size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
     if size > 0:
-        size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
-        i = int(math.floor(math.log(size, 1000)))
-        p = math.pow(1000, i)
-        s = round(size/p, 2) # pylint: disable=round-builtin,old-division
-        if s > 0:
-            return '%s %s' % (s, size_name[i])
+        try:
+            i = int(math.floor(math.log(size, 1000)))
+            p = math.pow(1000, i)
+            s = round(size/p, 2) # pylint: disable=round-builtin,old-division
+            if s > 0:
+                return '%s %s' % (s, size_name[i])
+        except TypeError:
+            # kpod returns sizes in units already
+            for i in size_name:
+                if i.upper() in size:
+                    return size
     return '0B'

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -39,6 +39,7 @@ GOMTREE_PATH = os.environ.get("GOMTREE_PATH", "/usr/bin/gomtree")
 BWRAP_OCI_PATH = os.environ.get("BWRAP_OCI", "/usr/bin/bwrap-oci")
 RUNC_PATH = os.environ.get("RUNC", "/bin/runc")
 SKOPEO_PATH = os.environ.get("SKOPEO_PATH", "/usr/bin/skopeo")
+KPOD_PATH = os.environ.get("KPOD_PATH", "/usr/bin/kpod")
 
 try:
     from subprocess import DEVNULL  # pylint: disable=no-name-in-module
@@ -1080,3 +1081,15 @@ def set_proxy():
 class ImageAlreadyExists(Exception):
     def __init__(self, img):
         super(ImageAlreadyExists, self).__init__("The latest version of image {} already exists.".format(img))
+
+
+def kpod(cmd, storage=None, debug=None):
+    if not isinstance(cmd, list):
+        cmd = cmd.split()
+    _kpod = KPOD_PATH
+    if storage is not None:
+        _kpod += ["-s", storage]
+    _kpod =+ cmd
+    if debug:
+        write_out(" ".join(cmd))
+    return check_output(_kpod, env=os.environ)


### PR DESCRIPTION
## Description

This allows you to see your images and containers across the
containers-storage backend and runc front-end. For example:
```
   CONTAINER ID IMAGE                NAME       COMMAND    CREATED          STATE      BACKEND    RUNTIME
   d6e7089cd9bc 15bc1f81701b0f19cacf adoring_bh /bin/true  2017-08-01 08:44 created    docker     docker
   3e8d4ab73739 15bc1f81701b0f19cacf awesome_wi /bin/true  2017-08-01 08:44 created    docker     docker
   061a9ca5d75d microsoft/azure-cli  reverent_e bash       2017-07-13 13:11 exited     docker     docker
   7ec00efa0138 babe9f398328af8bb1f6 dazzling_s /container 2017-07-06 09:07 exited     docker     docker
   2f6139e272fb babe9f398328af8bb1f6 kind_allen /container 2017-07-06 09:07 exited     docker     docker
   foobar       foobar:latest        foobar     /usr/bin/r 2017-08-08 15:04 running    ostree     runc
   foo          foo:latest           foo        /usr/bin/r 2017-08-08 15:16 failed     ostree     runc
   4261d79d6056 docker.io/library/re k8s_podsan ['/bin/sh' 2017-08-28 18:02 running    containers runc
```



## Related Bugzillas
-
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
