### PR TITLE
system containers: prevent files to be left installed if the checkout could not be deleted

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1441,11 +1441,13 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         if not self.display:
             util.check_call(cmd)
 
-    def _systemctl_command(self, command, name=None, quiet=False):
+    def _systemctl_command(self, command, name=None, now=False, quiet=False):
         cmd = ["systemctl"]
         if self.user:
             cmd.append("--user")
         cmd.append(command)
+        if now:
+            cmd.append("--now")
         if name:
             cmd.append(name)
         if not quiet:
@@ -1505,11 +1507,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         unitfileout, tmpfilesout = self._get_systemd_destination_files(name)
         if has_container_service:
             try:
-                self._systemctl_command("stop", name)
-            except subprocess.CalledProcessError:
-                pass
-            try:
-                self._systemctl_command("disable", name)
+                self._systemctl_command("disable", name, now=True)
             except subprocess.CalledProcessError:
                 pass
 

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1516,6 +1516,11 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         if os.path.exists(unitfileout):
             os.unlink(unitfileout)
 
+        try:
+            self._systemctl_command("daemon-reload")
+        except subprocess.CalledProcessError:
+            pass
+
         if os.path.exists(tmpfilesout):
             try:
                 self._systemd_tmpfiles("--remove", tmpfilesout)

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1580,7 +1580,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
                 ref = OSTree.parse_refspec(k)
                 util.write_out("Deleting %s" % k)
                 repo.set_ref_immediate(ref[1], ref[2], None)
-        repo.prune(OSTree.RepoPruneFlags.NONE, -1)
+        repo.prune(OSTree.RepoPruneFlags.REFS_ONLY, -1)
         self._prune_storage(repo)
 
 

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1550,6 +1550,32 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         refs = {}
         app_refs = []
 
+        # Check for dangling checkouts that couldn't be deleted on uninstall.
+        checkouts = self._get_system_checkout_path()
+        for i in os.listdir(checkouts):
+            if i[0] == '.':
+                continue
+            if i[-2:] not in [".0", ".1"]:
+                continue
+
+            container = i[:-2]
+
+            # Check if the container is still installed.
+            if os.path.lexists(os.path.join(checkouts, container)):
+                continue
+
+            fullpath = os.path.join(checkouts, i)
+
+            if not os.path.isdir(fullpath):
+                continue
+
+            # If we got here, the deployment is not related to an installed
+            # container, so delete it.
+            try:
+                shutil.rmtree(fullpath)
+            except OSError:
+                pass
+
         for i in repo.list_refs()[1]:
             if i.startswith(OSTREE_OCIIMAGE_PREFIX):
                 if len(i) == len(OSTREE_OCIIMAGE_PREFIX) + 64:

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -521,7 +521,7 @@ class SystemContainers(object):
         return real_path
 
     def _checkout(self, repo, name, img, deployment, upgrade, values=None, destination=None, extract_only=False, remote=None, prefix=None, installed_files=None, system_package='no'):
-        destination = destination or "%s/%s.%d" % (self._get_system_checkout_path(), name, deployment)
+        destination = destination or os.path.join(self._get_system_checkout_path(), "{}.{}".format(name, deployment))
         unitfileout, tmpfilesout = self._get_systemd_destination_files(name, prefix)
 
         if not upgrade:
@@ -628,13 +628,13 @@ class SystemContainers(object):
 
         if "CONF_DIRECTORY" not in values:
             if self.user:
-                values["CONF_DIRECTORY"] = "%s/.config" % HOME
+                values["CONF_DIRECTORY"] = os.path.join(HOME, ".config")
             else:
                 values["CONF_DIRECTORY"] = "/etc"
 
         if "STATE_DIRECTORY" not in values:
             if self.user:
-                values["STATE_DIRECTORY"] = "%s/.data" % HOME
+                values["STATE_DIRECTORY"] = os.path.join(HOME, ".data")
             else:
                 values["STATE_DIRECTORY"] = "/var/lib"
 
@@ -888,7 +888,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             shutil.copyfile(tmpfilesout, os.path.join(prefix or "/", destination, "tmpfiles-%s.conf" % name))
 
         if not prefix:
-            sym = "%s/%s" % (self._get_system_checkout_path(), name)
+            sym = os.path.join(self._get_system_checkout_path(), name)
             if os.path.exists(sym):
                 os.unlink(sym)
             os.symlink(destination, sym)
@@ -903,7 +903,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         if prefix:
             return values
 
-        sym = "%s/%s" % (self._get_system_checkout_path(), name)
+        sym = os.path.join(self._get_system_checkout_path(), name)
         if os.path.exists(sym):
             os.unlink(sym)
         os.symlink(destination, sym)
@@ -958,7 +958,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             return location
 
         if self.user:
-            return "%s/.containers/repo" % HOME
+            return os.path.join(HOME, ".containers/repo")
 
         return self.get_atomic_config_item(["ostree_repository"]) or "/ostree/repo"
 
@@ -1467,22 +1467,22 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         """
         if len(name) == 0:
             raise ValueError("Invalid container name")
-        path = "%s/%s" % (self._get_system_checkout_path(), name)
+        path = os.path.join(self._get_system_checkout_path(), name)
         if os.path.exists(path):
             return path
 
-        path = "%s/%s" % (self._get_preinstalled_containers_path(), name)
+        path = os.path.join(self._get_preinstalled_containers_path(), name)
         if os.path.exists(path):
             return path
 
         return None
 
     def _is_preinstalled_container(self, name):
-        path = "%s/%s" % (self._get_system_checkout_path(), name)
+        path = os.path.join(self._get_system_checkout_path(), name)
         if os.path.exists(path):
             return False
 
-        path = "%s/%s" % (self._get_preinstalled_containers_path(), name)
+        path = os.path.join(self._get_preinstalled_containers_path(), name)
         return os.path.exists(path)
 
     def uninstall(self, name):

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1577,7 +1577,6 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
                 continue
 
             fullpath = os.path.join(checkouts, i)
-
             if not os.path.isdir(fullpath):
                 continue
 
@@ -1586,7 +1585,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             try:
                 shutil.rmtree(fullpath)
             except OSError:
-                pass
+                util.write_err("Could not remove directory {}".format(fullpath))
 
         for i in repo.list_refs()[1]:
             if i.startswith(OSTREE_OCIIMAGE_PREFIX):


### PR DESCRIPTION
It solves some issues I've seen on repeatedly installing/uninstalling the OpenShift system containers.  In some cases the containers are restarted immediately during the `uninstall` phase and it caused some files (such as the systemd service file) to be left on the file system.  The half installed container prevented it to be reinstalled without manual intervention.

Also, now "atomic images prune" is a bit more aggressive and it frees immediately not referenced objects from the the ostree storage (the extra `ostree prune --refs-only` seemed to be confusing).
