### PR TITLE
Add verification options to dbus

### DIFF
--- a/atomic_dbus.py
+++ b/atomic_dbus.py
@@ -83,6 +83,7 @@ class atomic_dbus(slip.dbus.service.Object):
             self.name = None
             self.names_only = False
             self.no_files = False
+            self.no_validate = False
             self.optional = None
             self.options = None
             self.os = None
@@ -694,13 +695,16 @@ class atomic_dbus(slip.dbus.service.Object):
     # The Verify method takes in an image name and returns whether or not the
     # image should be updated
     @slip.dbus.polkit.require_auth("org.atomic.read")
-    @dbus.service.method("org.atomic", in_signature='s', out_signature='s')
-    def Verify(self, image):
+    @dbus.service.method("org.atomic", in_signature='sbbs', out_signature='s')
+    def Verify(self, image, no_validate, verbose, storage):
         verifications = []
         verify = Verify()
         verify.useTTY = False
         args = self.Args()
         args.image = image
+        args.verbose = verbose
+        args.no_validate = no_validate
+        args.storage = storage
         verify.set_args(args)
         verifications.append({"Image": image,
                               "Verification": verify.verify_dbus()}) #pylint: disable=no-member

--- a/atomic_dbus_client.py
+++ b/atomic_dbus_client.py
@@ -198,8 +198,8 @@ class AtomicDBus (object):
         return ret
 
     @polkit.enable_proxy
-    def Verify(self, image):
-        ret = self.dbus_object.Verify(image, dbus_interface="org.atomic")
+    def Verify(self, image, no_validate, verbose, storage):
+        ret = self.dbus_object.Verify(image, no_validate, verbose, storage, dbus_interface="org.atomic")
         return ret
 
     @polkit.enable_proxy


### PR DESCRIPTION



## Description
There were three unused verification options normally available to the
atomic CLI but absent in the dbus API: no_validate, verbose, and
storage.  These were added to the dbus client and server.

Signed-off-by: baude <bbaude@redhat.com>

## Related Bugzillas
-
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
