### PR TITLE
storage: On reset, umount docker root dir before removing

### DIFF
--- a/Atomic/storage.py
+++ b/Atomic/storage.py
@@ -160,6 +160,7 @@ class Storage(Atomic):
         util.call(["umount", root + "/devicemapper"], stderr=DEVNULL)
         util.call(["umount", root + "/overlay"], stderr=DEVNULL)
         util.call(["umount", root + "/overlay2"], stderr=DEVNULL)
+        util.call(["umount", root], stderr=DEVNULL)
         shutil.rmtree(root)
         os.mkdir(root)
         try:


### PR DESCRIPTION
If the storage configuration used
```
  CONTAINER_ROOT_LV_MOUNT_PATH=/var/lib/docker
```
then the volume must be unmounted before attempting to remove the directory.

Fixes https://github.com/projectatomic/container-storage-setup/issues/254