### PR TITLE
Atomic/scan.py: Add ability to remediate

### DIFF
--- a/bash/atomic
+++ b/bash/atomic
@@ -250,6 +250,7 @@ _atomic_scan() {
 		--containers
 		--rootfs
 		--list
+		--remediate
 		--scanner
 		--scan_type
 		--verbose

--- a/docs/atomic-scan.1.md
+++ b/docs/atomic-scan.1.md
@@ -54,6 +54,12 @@ Select a scan_type other than the default.
   Rootfs path to scan.  Can provide _--rootfs_ multiple times.
   Note: SELinux separation will be disabled for --rootfs scans, but all other container
   separation will still be in place.
+  
+**--remediate**
+  Allows the scanner to run a remediation script when scanning is complete.  The remediation script is provided
+  by the scanner itself.  
+  
+  **Note:** not all scanners provide remediation scripts.
 
 # EXAMPLES
 List all the scanners atomic knows about and display their default scan types.
@@ -63,6 +69,11 @@ List all the scanners atomic knows about and display their default scan types.
 Scan an image named 'foo1'.
 
     atomic scan foo1
+    
+    
+Scan and remediate an image named 'foo1'.
+
+    atomic scan --remediate foo1
 
 Scan images named 'foo1' and 'foo2' and produce a detailed report.
 


### PR DESCRIPTION
## Description

In the case of some scanners, they generate a script to remediate the
images|containers they have scanned.  We needed to provide a hook
for this ability. We now read the scanner's configuration file looking
for a "remediation_script" key, whose value should be a fq path to the
remediation script.  The remediation script should be delivered via
the scanning image via atomic install.

As of now, we pass the id of the scanned object and its results directory
as named arguments to the remediation script.

Signed-off-by: baude <bbaude@redhat.com>

## Related Bugzillas
-
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
