### PR TITLE
Atomic/backends/_containers_storage.py: Enable tagging

### DIFF
--- a/Atomic/backends/_containers_storage.py
+++ b/Atomic/backends/_containers_storage.py
@@ -270,5 +270,6 @@ class ContainersStorageBackend(object): #pylint: disable=metaclass-assignment
             return True
         return False
 
-    def tag_image(self, src, dest):
-        raise UnderDevelopment()
+    def tag_image(self, _src, _dest):
+        cmd = ['tag', _src, _dest]
+        return util.kpod(cmd)


### PR DESCRIPTION
## Description
Enable tagging as a function on the backend.  This gives c-s parity
with the other backends where needed.

Signed-off-by: baude <bbaude@redhat.com>


## Related Bugzillas
-
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
