### PR TITLE
Fix regressions atomic list and system containers

### DIFF
--- a/Atomic/backends/_ostree.py
+++ b/Atomic/backends/_ostree.py
@@ -59,7 +59,7 @@ class OSTreeBackend(Backend):
         img_obj.registry, img_obj.repo, img_obj.image, img_obj.tag, _ = Decompose(image).all
         img_obj.repotags = info['RepoTags']
         img_obj.created = info['Created']
-        img_obj.size = None
+        img_obj.size = info.get('VirtualSize', None)
         img_obj.virtual_size = info.get('VirtualSize', None)
         img_obj.original_structure = info
         img_obj.deep = True


### PR DESCRIPTION
A couple of regressions I've seen while using the new "skopeo copy" code path for system containers