### PR TITLE
syscontainers: fix systemd directive tag for Restart=

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -54,7 +54,7 @@ ExecStartPre=$EXEC_STARTPRE
 ExecStart=$EXEC_START
 ExecStop=$EXEC_STOP
 ExecStopPost=$EXEC_STOPPOST
-Restart=on-crash
+Restart=on-failure
 WorkingDirectory=$DESTDIR
 PIDFile=$PIDFILE
 


### PR DESCRIPTION
Probably nobody noticed as it is used only for containers
that do not have a default config.json.template file.  I've seen
the error while installing busybox for a test.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
