### PR TITLE
syscontainers: create empty directories in the .rpm case

### DIFF
--- a/Atomic/rpm_host_install.py
+++ b/Atomic/rpm_host_install.py
@@ -11,7 +11,10 @@ class RPMHostInstall(object):
 
     @staticmethod
     def copyfile(src, dest):
-        if os.path.islink(src):
+        if os.path.isdir(src):
+            if len(os.listdir(src)) == 0:
+                os.mkdir(dest)
+        elif os.path.islink(src):
             linkto = os.readlink(src)
             os.symlink(linkto, dest)
         else:
@@ -45,11 +48,11 @@ class RPMHostInstall(object):
         hostfs = os.path.join(exports, "hostfs")
         new_installed_files = []
         if os.path.exists(hostfs):
-            for root, _, files in os.walk(hostfs):
+            for root, dirs, files in os.walk(hostfs):
                 rel_root_path = os.path.relpath(root, hostfs)
                 if not os.path.exists(os.path.join(prefix, rel_root_path)):
                     os.makedirs(os.path.join(prefix, rel_root_path))
-                for f in files:
+                for f in dirs + files:
                     src_file = os.path.join(root, f)
                     dest_path = os.path.join(prefix, rel_root_path, f)
                     rel_dest_path = os.path.join("/", rel_root_path, f)
@@ -111,9 +114,9 @@ class RPMHostInstall(object):
         files_to_install = installed_files or []
         if include_containers_file:
             files_to_install.append("/usr/lib/systemd/system/%s.service" % name)
-            for root, _, files in os.walk(os.path.join(rpm_content, "usr/lib/containers/atomic", name)):
+            for root, dirs, files in os.walk(os.path.join(rpm_content, "usr/lib/containers/atomic", name)):
                 rel_path = os.path.relpath(root, rpm_content)
-                for f in files:
+                for f in dirs + files:
                     p = os.path.join("/", rel_path, f)
                     files_to_install.append(p)
 

--- a/Atomic/rpm_host_install.py
+++ b/Atomic/rpm_host_install.py
@@ -12,6 +12,9 @@ class RPMHostInstall(object):
     @staticmethod
     def copyfile(src, dest):
         if os.path.isdir(src):
+            # add the directory only if it is empty, so we don't create directories that
+            # weren't added by us.  Anyway a non empty directory would be created by
+            # its children.
             if len(os.listdir(src)) == 0:
                 os.mkdir(dest)
         elif os.path.islink(src):

--- a/Atomic/rpmwriter.py
+++ b/Atomic/rpmwriter.py
@@ -272,8 +272,8 @@ class RpmWriter(object):
 
     def generate(self):
         self.all_files = []
-        for root, _, files in os.walk(self.root):
-            for f in files:
+        for root, dirs, files in os.walk(self.root):
+            for f in dirs + files:
                 path = os.path.join(root, f)
                 relpath = os.path.relpath(path, self.root)
                 if self.whitelist is None or "/%s" % relpath in self.whitelist:

--- a/tests/integration/test_system_containers_rpm.sh
+++ b/tests/integration/test_system_containers_rpm.sh
@@ -74,6 +74,8 @@ assert_matches "/usr/lib/containers/atomic/atomic-test-system" rpm_file_list
 # now install the package to the system
 ATOMIC_OSTREE_TEST_FORCE_IMAGE_ID=563246d74eda8a9337a5ad1f019d1c7aaa221c5288f16b975d230644017953b1 ${ATOMIC} install --system --system-package=yes atomic-test-system-hostfs
 
+test -e /usr/local/placeholder-lib
+
 teardown () {
     set +o pipefail
     ${ATOMIC} uninstall --storage ostree atomic-test-system-hostfs || true
@@ -116,10 +118,14 @@ if ${ATOMIC} install --system --system-package=yes --set RECEIVER=Mars --name at
 	assert_not_reached "Conflicting container installation succedeed"
 fi
 
+test -e /usr/local/placeholder-lib
+
 test \! -e /etc/systemd/system/atomic-test-system-broken.service
 test \! -e /etc/tmpfiles.d/atomic-test-system-broken.conf
 
 ${ATOMIC} uninstall --storage ostree atomic-test-system-hostfs
+
+test \! -e /usr/local/placeholder-lib
 
 # check that auto behaves in the same way as yes with this container.
 ${ATOMIC} install --system --system-package=auto --set RECEIVER=Jupiter atomic-test-system-hostfs
@@ -130,6 +136,8 @@ assert_matches "Jupiter" /usr/local/lib/secret-message-template
 rpm -ql $RPM_NAME > rpm_file_list_2
 cmp rpm_file_list rpm_file_list_2
 ${ATOMIC} uninstall --storage ostree atomic-test-system-hostfs
+
+test \! -e /usr/local/placeholder-lib
 
 for i in /usr/local/lib/renamed-atomic-test-system-hostfs /usr/local/lib/secret-message /usr/local/lib/secret-message-template;
 do

--- a/tests/test-images/Dockerfile.system-hostfs
+++ b/tests/test-images/Dockerfile.system-hostfs
@@ -5,7 +5,7 @@ LABEL "Name"="atomic-test-system-hostfs"
 LABEL "atomic.has_install_files"="yes"
 
 # Add a file that can be handled by the rpm generator
-RUN mkdir -p /exports/hostfs/usr/local/lib
+RUN mkdir -p /exports/hostfs/usr/local/lib /exports/hostfs/usr/local/placeholder-lib
 RUN ln -s /does/not/exist /exports/hostfs/broken-symlink
 ADD message /exports/hostfs/usr/local/lib/secret-message
 ADD message-template /exports/hostfs/usr/local/lib/secret-message-template


### PR DESCRIPTION
We already do this when copying directly to the host.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
