### PR TITLE
syscontainers: Fall back to destination

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -991,7 +991,8 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         checkouts = self._get_system_checkout_path()
         if not os.path.exists(checkouts):
             os.makedirs(checkouts)
-        if not SystemContainers._are_on_the_same_filesystem("/ostree/repo", checkouts):
+        rootdir = "/ostree/repo" if os.path.exists("/ostree/repo") else "/"
+        if not SystemContainers._are_on_the_same_filesystem(rootdir, checkouts):
             return os.path.join(self.get_storage_path(skip_canonicalize=True), "ostree")
 
         return "/ostree/repo"

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -981,7 +981,19 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         if self.user:
             return os.path.join(HOME, ".containers/repo")
 
-        return self.get_atomic_config_item(["ostree_repository"]) or "/ostree/repo"
+        if self.get_atomic_config_item(["ostree_repository"]) is not None:
+            return self.get_atomic_config_item(["ostree_repository"])
+
+        # If the checkout directory and the OSTree storage are not on the same
+        # file system, then we cannot use the system repository, as it would not
+        # support hard links checkouts.
+        checkouts = self._get_system_checkout_path()
+        if not os.path.exists(checkouts):
+            os.makedirs(checkouts)
+        if not SystemContainers._are_on_the_same_filesystem("/ostree/repo", checkouts):
+            return os.path.join(self.get_storage_path(skip_canonicalize=True), "ostree")
+
+        return "/ostree/repo"
 
     def _get_ostree_repo(self):
         if not OSTREE_PRESENT:
@@ -2137,7 +2149,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         repo.transaction_set_ref(None, get_image_branch(dest), rev)
         repo.commit_transaction(None)
 
-    def get_storage_path(self):
+    def get_storage_path(self, skip_canonicalize=False):
         """
         Returns the path to storage.
 
@@ -2145,6 +2157,8 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         :rtype: str
         """
         storage = os.path.sep.join([self._get_system_checkout_path(), ".storage"])
+        if skip_canonicalize:
+            return storage
         return self._canonicalize_location(storage)
 
     def _ensure_storage_for_image(self, repo, img):
@@ -2187,6 +2201,8 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         if not os.path.exists(storage):
             return
         for i in os.listdir(storage):
+            if i == "ostree":
+                continue
             branch = "{}{}".format(OSTREE_OCIIMAGE_PREFIX, i)
             rev_layer = repo.resolve_rev(branch, True)[1]
             if not rev_layer:

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -260,6 +260,7 @@ class SystemContainers(object):
         return_value = None
         # If we don't have a dockertar file or a reference to a docker engine image
         if not image.startswith('dockertar:/') and not (image.startswith("docker:") and image.count(':') > 1):
+            image = util.remove_skopeo_prefixes(image)
             labels = self.inspect_system_image(image).get('Labels', {})
             # And we have a run-once label
             if labels and labels.get('atomic.run') == 'once':

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -668,7 +668,18 @@ class SystemContainers(object):
             sysroot = OSTree.Sysroot()
             sysroot.load()
             osname = sysroot.get_booted_deployment().get_osname()
-            destination = os.path.realpath(os.path.join("/ostree/deploy/", osname, os.path.relpath(destination, "/")))
+            ostree_destination = os.path.realpath(
+                os.path.join("/ostree/deploy/", osname, os.path.relpath(
+                    destination, "/")))
+
+            # Verify that content under the ostree destination shows up on destination.
+            # If it does, we use the ostree destination.
+            os.makedirs(os.path.dirname(destination))
+            dest_stat = os.stat(os.path.dirname(destination))
+            ostree_stat = os.stat(os.path.dirname(ostree_destination))
+            if dest_stat.st_dev == ostree_stat.st_dev and dest_stat.st_ino == ostree_stat.st_ino:
+                destination = ostree_destination
+
         except: #pylint: disable=bare-except
             pass
         return destination

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1703,7 +1703,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         :rtype: tuple(bool, str)
         """
         # Remove prefixes which we use to map to skopeo args
-        real_image = utils.remove_skopeo_prefixes(image)
+        real_image = util.remove_skopeo_prefixes(image)
 
         if full_resolution:
             try:

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1692,18 +1692,27 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             return reg, image, "latest"
 
     def _get_skopeo_args(self, image, full_resolution=False):
-        insecure = "http:" in image
+        """
+        Finds the real image name and if the registry is secure or not.
 
-        for i in ["oci:", "http:", "https:"]:
-            image = image.replace(i, "")
+        :param image: The image as given by the user.
+        :type image: str
+        :param full_resolution: If the image should be remotely resolved
+        :type full_resolution: bool
+        :returns: If the registry is secure and the real image name
+        :rtype: tuple(bool, str)
+        """
+        # Remove prefixes which we use to map to skopeo args
+        real_image = utils.remove_skopeo_prefixes(image)
 
         if full_resolution:
             try:
                 with AtomicDocker() as client:
-                    image = util.find_remote_image(client, image) or image
+                    real_image = util.find_remote_image(client, real_image) or real_image
             except NoDockerDaemon:
                 pass
-        return insecure, image
+
+        return "http:" in image, real_image
 
     def _convert_to_skopeo(self, image):
         insecure, image = self._get_skopeo_args(image, full_resolution=True)

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -957,6 +957,9 @@ class Decompose(object):
                 return False
             return True
 
+        # Skopeo requires http: if the image is insecure. However,
+        # parsing fails when http: remains in the input_name
+        input_name = remove_skopeo_prefixes(input_name)
         reg, repo, image, tag = '', input_name, '', ''
         digest = None
         if '/' in repo:
@@ -1096,3 +1099,18 @@ def kpod(cmd, storage=None, debug=None):
     if debug:
         write_out(" ".join(cmd))
     return check_output(_kpod, env=os.environ)
+
+
+def remove_skopeo_prefixes(image):
+    """
+    Remove prefixes used by skopeo but not expected in other image uses.
+
+    :param image: The full image string
+    :type image: str
+    :returns: The image string without skopeo prefixes
+    :rtype: str
+    """
+    for remove in ('http:', 'https:'):
+        if image.startswith(remove):
+            image = image.replace(remove, '')
+    return image

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -1103,14 +1103,15 @@ def kpod(cmd, storage=None, debug=None):
 
 def remove_skopeo_prefixes(image):
     """
-    Remove prefixes used by skopeo but not expected in other image uses.
+    Remove prefixes that map to skopeo args but not expected
+    in other image uses.
 
     :param image: The full image string
     :type image: str
-    :returns: The image string without skopeo prefixes
+    :returns: The image string without prefixes
     :rtype: str
     """
-    for remove in ('http:', 'https:'):
+    for remove in ('oci:', 'http:', 'https:'):
         if image.startswith(remove):
             image = image.replace(remove, '')
     return image


### PR DESCRIPTION
## Description

If /sysroot/ostree/deploy/rhel-atomic-host/var does not show the same
content destination then fall back destination.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1500961

## Related Bugzillas
- https://bugzilla.redhat.com/show_bug.cgi?id=1500961