### PR TITLE
[WIP] syscontainers: support external /var on Atomic Host

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -668,7 +668,16 @@ class SystemContainers(object):
             sysroot = OSTree.Sysroot()
             sysroot.load()
             osname = sysroot.get_booted_deployment().get_osname()
-            destination = os.path.realpath(os.path.join("/ostree/deploy/", osname, os.path.relpath(destination, "/")))
+            deploy_destination = os.path.realpath(os.path.join("/ostree/deploy/", osname, os.path.relpath(destination, "/")))
+            test_file = "test-file-atomic-%i" % os.getpid()
+            test_path = os.path.join(os.path.dirname(deploy_destination), test_file)
+            try:
+                with open(test_path, 'w') as t:
+                    t.write("atomic")
+                if os.path.exists(os.path.join(os.path.dirname(destination), test_file)):
+                    destination = deploy_destination
+            finally:
+                os.unlink(test_file)
         except: #pylint: disable=bare-except
             pass
         return destination


### PR DESCRIPTION
Check if what we write under /sysroot/ostree/deploy/rhel-atomic-host/var
is visible under /var as well before using the former directory.  This
is done on AH to ensure we are using hard links instead of copying files
for the containers.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1500961

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>


## Description


## Related Bugzillas
-
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
