### PR TITLE
syscontainers: cleanup on GLib.Error

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -532,7 +532,7 @@ class SystemContainers(object):
         try:
             return self._do_checkout(repo, name, img, upgrade, deployment, values, destination, unitfileout, tmpfilesout, extract_only, remote, prefix, installed_files=installed_files,
                                      system_package=system_package)
-        except (ValueError, OSError, subprocess.CalledProcessError, KeyboardInterrupt) as e:
+        except (GLib.Error, ValueError, OSError, subprocess.CalledProcessError, KeyboardInterrupt) as e:
             try:
                 if not extract_only and not upgrade:
                     shutil.rmtree(destination)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ all: python-build docs pylint-check dockertar-sha256-helper gotar
 
 .PHONY: test-python3-pylint
 test-python3-pylint:
-	$(PYTHON3_PYLINT) --disable=all --enable=E --enable=W --additional-builtins=_ *.py atomic Atomic tests/unit/*.py -d=no-absolute-import,print-statement,no-absolute-import,bad-builtin
+	$(PYTHON3_PYLINT) --disable=all --enable=E --enable=W --additional-builtins=_ *.py atomic Atomic tests/unit/*.py -d=no-absolute-import,print-statement,no-absolute-import,bad-builtin,catching-non-exception,raising-non-exception
 
 .PHONY: test check test-suite
 
@@ -38,7 +38,7 @@ python-build:
 
 .PHONY: pylint-check
 pylint-check:
-	$(PYLINT) --disable=all --enable=E --enable=W --additional-builtins=_ *.py atomic Atomic tests/unit/*.py -d=no-absolute-import,print-statement,no-absolute-import,bad-builtin
+	$(PYLINT) --disable=all --enable=E --enable=W --additional-builtins=_ *.py atomic Atomic tests/unit/*.py -d=no-absolute-import,print-statement,no-absolute-import,bad-builtin,catching-non-exception,raising-non-exception
 
 MANPAGES_MD = $(wildcard docs/*.md)
 


### PR DESCRIPTION
This is the exception type raised by OSTree if the checkout fails.  I've
observed while running out of space on /var and the installation left
the incomplete checkout for the container.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>