### PR TITLE
Dockertar sha256 helper enhancements

### DIFF
--- a/dockertar-sha256-helper.go
+++ b/dockertar-sha256-helper.go
@@ -1,14 +1,18 @@
 package main
 
 import (
-	"fmt"
 	"compress/gzip"
-	"os"
-	"io"
 	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
 )
 
 func main() {
+	// Require one positional argument
+	if len(os.Args) != 2 {
+		panic("One positional argument is required")
+	}
 	reader, err := os.Open(os.Args[1])
 	if err != nil {
 		os.Exit(1)

--- a/dockertar-sha256-helper.go
+++ b/dockertar-sha256-helper.go
@@ -14,12 +14,16 @@ func main() {
 		panic("One positional argument is required")
 	}
 	reader, err := os.Open(os.Args[1])
+	// Close the input file at the end of the function
+	defer reader.Close()
 	if err != nil {
 		os.Exit(1)
 	}
 	buf := make([]byte, 4096)
 	sha_256 := sha256.New()
 	w := gzip.NewWriter(sha_256)
+	// Close output file at the end of the function
+	defer w.Close()
 
 	for {
 		n, err := reader.Read(buf)
@@ -33,7 +37,5 @@ func main() {
 			panic(err)
 		}
 	}
-	w.Close()
-
 	fmt.Printf("%x\n", sha_256.Sum(nil))
 }

--- a/dockertar-sha256-helper.go
+++ b/dockertar-sha256-helper.go
@@ -22,8 +22,6 @@ func main() {
 	buf := make([]byte, 4096)
 	sha_256 := sha256.New()
 	w := gzip.NewWriter(sha_256)
-	// Close output file at the end of the function
-	defer w.Close()
 
 	for {
 		n, err := reader.Read(buf)
@@ -37,5 +35,8 @@ func main() {
 			panic(err)
 		}
 	}
+	// We must explicitly close before executing the sum
+	// as defer will cause an incorrect result
+	w.Close()
 	fmt.Printf("%x\n", sha_256.Sum(nil))
 }


### PR DESCRIPTION
## Description

- Error when the wrong number of arguments are provided
- Ensure closing of all open items using ``defer``.