### PR TITLE
syscontainers: introduce ALL_PROCESS_CAPABILITIES

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1583,7 +1583,10 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             RPMHostInstall.rm_add_files_to_host(installed_files, None)
 
         if rpm_installed:
-            RPMHostInstall.uninstall_rpm(rpm_installed.replace(".rpm", ""))
+            try:
+                RPMHostInstall.uninstall_rpm(rpm_installed.replace(".rpm", ""))
+            except subprocess.CalledProcessError:
+                pass
 
         # Until the symlink and the deployment are in place, we can attempt the uninstall again.
         # So treat as fatal each failure that happens before we rm the symlink.

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1217,9 +1217,12 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
                 created = info["created"] if "created" in info else 0
                 image = info["image"] if "image" in info else ""
 
-            with open(os.path.join(fullpath, "config.json"), "r") as config_file:
-                config = json.load(config_file)
-                command = u' '.join(config["process"]["args"])
+            command = ""
+            config_json = os.path.join(fullpath, "config.json")
+            if os.path.exists(config_json):
+                with open(config_json, "r") as config_file:
+                    config = json.load(config_file)
+                    command = u' '.join(config["process"]["args"])
 
             runtime = "bwrap-oci" if self.user else "runc"
             container = {'Image' : image, 'ImageID' : revision, 'Id' : x, 'Created' : created, 'Names' : [x],

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -64,7 +64,8 @@ WantedBy=multi-user.target
 TEMPLATE_FORCED_VARIABLES = ["DESTDIR", "NAME", "EXEC_START", "EXEC_STOP",
                              "EXEC_STARTPRE", "EXEC_STOPPOST", "HOST_UID",
                              "HOST_GID", "IMAGE_ID", "IMAGE_NAME"]
-TEMPLATE_OVERRIDABLE_VARIABLES = ["RUN_DIRECTORY", "STATE_DIRECTORY", "CONF_DIRECTORY", "UUID", "PIDFILE"]
+TEMPLATE_OVERRIDABLE_VARIABLES = ["RUN_DIRECTORY", "STATE_DIRECTORY", "CONF_DIRECTORY", "UUID", "PIDFILE",
+                                  "ALL_PROCESS_CAPABILITIES"]
 
 
 class SystemContainers(object):
@@ -616,6 +617,12 @@ class SystemContainers(object):
                 return True
         return False
 
+
+    @staticmethod
+    def _get_all_capabilities():
+        all_caps = util.get_all_known_process_capabilities()
+        return ",\n".join(['"%s"' % i for i in all_caps]) + "\n"
+
     def _amend_values(self, values, manifest, name, image, image_id, destination, prefix=None, unit_file_support_pidfile=False):
         # When installing a new system container, set values in this order:
         #
@@ -642,6 +649,9 @@ class SystemContainers(object):
                 values["STATE_DIRECTORY"] = os.path.join(HOME, ".data")
             else:
                 values["STATE_DIRECTORY"] = "/var/lib"
+
+        if "ALL_PROCESS_CAPABILITIES" not in values:
+            values["ALL_PROCESS_CAPABILITIES"] = SystemContainers._get_all_capabilities()
 
         if manifest is not None and "defaultValues" in manifest:
             for key, val in manifest["defaultValues"].items():

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -1130,7 +1130,7 @@ def get_all_known_process_capabilities():
 
     mask = hex((1 << (last_cap + 1)) - 1)
 
-    out = subprocess.check_output([CAPSH_PATH, '--decode=%s' % mask], stderr=DEVNULL)
+    out = subprocess.check_output([CAPSH_PATH, '--decode={}'.format(mask)], stderr=DEVNULL)
 
     # The output looks like 0x0000003fffffffff=cap_chown,cap_dac_override,...
     # so take only the part after the '='

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -40,6 +40,7 @@ BWRAP_OCI_PATH = os.environ.get("BWRAP_OCI", "/usr/bin/bwrap-oci")
 RUNC_PATH = os.environ.get("RUNC", "/bin/runc")
 SKOPEO_PATH = os.environ.get("SKOPEO_PATH", "/usr/bin/skopeo")
 KPOD_PATH = os.environ.get("KPOD_PATH", "/usr/bin/kpod")
+CAPSH_PATH = os.environ.get("CAPSH_PATH", "/usr/sbin/capsh")
 
 try:
     from subprocess import DEVNULL  # pylint: disable=no-name-in-module
@@ -1115,3 +1116,26 @@ def remove_skopeo_prefixes(image):
         if image.startswith(remove):
             image = image.replace(remove, '')
     return image
+
+def get_all_known_process_capabilities():
+    """
+    Get all the known process capabilities
+
+    :returns: The list of known capabilities
+    :rtype: list
+    """
+
+    with open("/proc/sys/kernel/cap_last_cap", 'r') as f:
+        last_cap = int(f.read())
+
+    mask = hex((1 << (last_cap + 1)) - 1)
+
+    out = subprocess.check_output([CAPSH_PATH, '--decode=%s' % mask], stderr=DEVNULL)
+
+    # The output looks like 0x0000003fffffffff=cap_chown,cap_dac_override,...
+    # so take only the part after the '='
+    caps = str(out.decode().split("=")[1].strip())
+
+    caps_list = [i.upper() for i in caps.split(',')]
+
+    return [i for i in caps_list if not i[0].isdigit()]

--- a/tests/test-images/system-container-files/config.json.template
+++ b/tests/test-images/system-container-files/config.json.template
@@ -114,11 +114,9 @@
 	],
 	"hooks": {},
 	"linux": {
-		"capabilities": [
-			"CAP_AUDIT_WRITE",
-			"CAP_KILL",
-			"CAP_NET_BIND_SERVICE"
-		],
+	         "capabilities": {
+			"bounding": [${ALL_PROCESS_CAPABILITIES}]
+                },
 		"rlimits": [
 			{
 				"type": "RLIMIT_NOFILE",


### PR DESCRIPTION
## Description
it can be used by privileged containers to add all the capabilities known to the host.  It prevents hard coding the list in the config.json.template file so that the same image can be used on different kernel versions where there can be different capabilities supported.

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [x] Unittests
- [x] Integration Tests
