### PR TITLE
syscontainers: add a warning if pulling a not fully qualified image

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1954,6 +1954,15 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             if not missing_layers:
                 return False
 
+        try:
+            d = util.Decompose(img)
+            if d.registry == "":
+                util.write_err("The image `{}` is not fully qualified.  The default registry configured for Skopeo will be used.".format(img))
+        except:  # pylint: disable=bare-except
+            # This is used only to raise a warning to the user, so catch any exception
+            # and never let it fail.
+            pass
+
         can_use_skopeo_copy = util.check_output([util.SKOPEO_PATH, "copy", "--help"]).decode().find("ostree") >= 0
 
         if can_use_skopeo_copy:

--- a/docs/atomic-pull.1.md
+++ b/docs/atomic-pull.1.md
@@ -59,9 +59,9 @@ It tells Skopeo to not do TLS verification on the specified registry.
 
 `atomic pull --storage ostree http:REGISTRY/IMAGE:TAG`
 
-Not fully qualified images are supported when pulling to 'ostree',
-although it is suggested to use a fully qualified name to refer
-unambiguously to an image.
+Images where the registry is not specified are supported
+when pulling to 'ostree'.  However, we recommend that you use a
+fully qualified name to refer unambiguously to the image.
 
 If your /etc/containers/policy.json requires signature verification, the 
 pulled image is verified prior to being made available to the local docker

--- a/docs/atomic-pull.1.md
+++ b/docs/atomic-pull.1.md
@@ -59,6 +59,10 @@ It tells Skopeo to not do TLS verification on the specified registry.
 
 `atomic pull --storage ostree http:REGISTRY/IMAGE:TAG`
 
+Not fully qualified images are supported when pulling to 'ostree',
+although it is suggested to use a fully qualified name to refer
+unambiguously to an image.
+
 If your /etc/containers/policy.json requires signature verification, the 
 pulled image is verified prior to being made available to the local docker
 daemon. When interacting with a docker registry, Atomic uses the policy 


### PR DESCRIPTION
Not fully qualified images are ambiguous in the ostree reference as
internally e.g. docker.io/busybox and busybox are stored as two
separate references.  Suggest the user to use a fully qualified name
to avoid the ambiguosity.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
