### PR TITLE
syscontainers: allow to override the OCI runtime

### DIFF
--- a/Atomic/install.py
+++ b/Atomic/install.py
@@ -89,7 +89,7 @@ class Install(Atomic):
         storage_set = False if self.args.storage is None else True
         storage = _storage if not storage_set else self.args.storage
         args_system = getattr(self.args, 'system', None)
-        args_user= getattr(self.args, 'user', None)
+        args_user = getattr(self.args, 'user', None)
         if (args_system or args_user) and storage != 'ostree' and storage_set:
             raise ValueError("The --system and --user options are only available for the 'ostree' storage.")
         be_utils = BackendUtils()

--- a/Atomic/install.py
+++ b/Atomic/install.py
@@ -67,6 +67,8 @@ def cli(subparser):
                                      help=_('install a system container'))
         installp.add_argument("--system-package", dest="system_package", default="auto",
                               help=_('control how to install the package.  It accepts `auto`, `yes`, `no`, `build`'))
+        installp.add_argument("--runtime", dest="runtime", default=None,
+                              help=_('specify the OCI runtime to use for system and user containers'))
         installp.add_argument("--rootfs", dest="remote",
                               help=_("choose an existing exploded container/image to use "
                                      "its rootfs as a remote, read-only rootfs for the "

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -154,6 +154,10 @@ class SystemContainers(object):
         except (NameError, AttributeError):
             pass
 
+        if not self.user and not self.runtime:
+            self.runtime = self.get_atomic_config_item(["runtime"])
+
+
     @staticmethod
     def _split_set_args(setvalues):
         values = {}

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -83,7 +83,8 @@ class SystemContainers(object):
         self.args = None
         self.setvalues = None
         self.display = False
-        self._runtime = None
+        self.runtime = None
+        self._runtime_from_info_file = None
 
     def get_atomic_config_item(self, config_item):
         """
@@ -145,6 +146,11 @@ class SystemContainers(object):
 
         try:
             self.setvalues = args.setvalues
+        except (NameError, AttributeError):
+            pass
+
+        try:
+            self.runtime = self.args.runtime
         except (NameError, AttributeError):
             pass
 
@@ -468,8 +474,11 @@ class SystemContainers(object):
             conf.write(json.dumps(configuration, indent=4))
 
     def _get_oci_runtime(self):
-        if self._runtime:
-            return self._runtime
+        if self.runtime:
+            return self.runtime
+
+        if self._runtime_from_info_file:
+            return self._runtime_from_info_file
 
         if self.user:
             return util.BWRAP_OCI_PATH
@@ -1094,7 +1103,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             return
 
         if runtime is not None:
-            self._runtime = runtime
+            self._runtime_from_info_file = runtime
         if system_package is None:
             system_package = 'yes' if rpm_installed else 'no'
         self._checkout(repo, name, image, next_deployment, True, values, remote=self.args.remote, installed_files=installed_files, system_package=system_package)

--- a/bash/atomic
+++ b/bash/atomic
@@ -721,6 +721,7 @@ _atomic_install() {
 		--help
 	       --display
 	       --rootfs
+	       --runtime
 	       --storage
 	       --system
 	       --system-package

--- a/docs/atomic-install.1.md
+++ b/docs/atomic-install.1.md
@@ -70,6 +70,12 @@ root filesystem. The existing rootfs will be used as the new
 system container's rootfs (read only), and thus the new container
 will only contain config and info files.
 
+**--runtime=PATH**
+Change the OCI runtime used by the systemd service file for running
+system containers and user containers.  The default **/bin/runc** is
+used for system containers.  Conversely, for user containers the
+default value is **/bin/bwrap-oci**.
+
 **--set=NAME=VALUE**
 Set a value that is going to be used by a system container for its
 configuration and can be specified multiple times.  It is used only

--- a/docs/atomic-install.1.md
+++ b/docs/atomic-install.1.md
@@ -72,9 +72,11 @@ will only contain config and info files.
 
 **--runtime=PATH**
 Change the OCI runtime used by the systemd service file for running
-system containers and user containers.  The default **/bin/runc** is
-used for system containers.  Conversely, for user containers the
-default value is **/bin/bwrap-oci**.
+system containers and user containers.  If runtime is not defined, the
+value **runtime** in the configuration file is used for system
+containers.  If there is no runtime defined in the configuration file
+as well, then the default **/bin/runc** is used for system containers.
+Conversely, for user containers the default value is **/bin/bwrap-oci**.
 
 **--set=NAME=VALUE**
 Set a value that is going to be used by a system container for its

--- a/tests/integration/test_system_containers_runtime.sh
+++ b/tests/integration/test_system_containers_runtime.sh
@@ -229,3 +229,8 @@ assert_matches "new-receiver" ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}-new/config.
 
 ${ATOMIC} containers rollback ${NAME}-new
 assert_matches ${SECRET} ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}-new/config.json
+
+# 11. Test --runtime
+${ATOMIC} uninstall ${NAME}-new
+${ATOMIC} install --name=${NAME}-new --runtime=/bin/ls --set=RECEIVER=${SECRET} --system atomic-test-system
+assert_matches /bin/ls /etc/systemd/system/${NAME}-new.service

--- a/tests/integration/test_system_containers_runtime.sh
+++ b/tests/integration/test_system_containers_runtime.sh
@@ -15,6 +15,7 @@ IFS=$'\n\t'
 # 8. Repeated updates/rollbacks
 # 9. Update --rebase
 # 10. Updating/rolling back a container with a remote rootfs
+# 11. Verify --runtime is honored
 
 setup () {
     ${ATOMIC} pull --storage ostree docker:atomic-test-system:latest


### PR DESCRIPTION
Allow to override the OCI runtime binary used with an environment variable