### PR TITLE
trust, sign: prevent gpg warnings to be printed

### DIFF
--- a/Atomic/sign.py
+++ b/Atomic/sign.py
@@ -134,16 +134,17 @@ class Sign(Atomic):
                                      "overwrite it, please delete this file first")
 
                 util.skopeo_standalone_sign(expanded_image_name, manifest_file.name,
-                                            self.get_fingerprint(signer), fq_sig_path, debug=self.args.debug)
+                                            self.get_fingerprint(signer, self.args.debug), fq_sig_path, debug=self.args.debug)
                 util.write_out("Created: {}".format(fq_sig_path))
 
             finally:
                 os.remove(manifest_file.name)
 
     @staticmethod
-    def get_fingerprint(signer):
+    def get_fingerprint(signer, debug):
         cmd = ['gpg2', '--no-permission-warning', '--with-colons', '--fingerprint', signer]
-        stdout = util.check_output(cmd)
+        stderr = None if debug else util.DEVNULL
+        stdout = util.check_output(cmd, stderr=stderr)
         for line in stdout.splitlines():
             _line = line.decode('utf-8')
             if _line.startswith('fpr:'):

--- a/Atomic/trust.py
+++ b/Atomic/trust.py
@@ -227,7 +227,8 @@ class Trust(Atomic):
         if not token.scheme or not token.netloc:
             if not os.path.exists(key_reference):
                 cmd = ["gpg2", "--armor", "--export", key_reference]
-                keydata = util.check_output(cmd)
+                stderr = None if self.args.debug else util.DEVNULL
+                keydata = util.check_output(cmd, stderr=stderr)
                 if not keydata:
                     raise ValueError("The public key reference '%s' was not "
                                      "found as a file or in the user's GPG "
@@ -502,7 +503,8 @@ class Trust(Atomic):
                 key = tmpkey.name
             cmd = ["gpg2", "--with-colons", key]
             try:
-                results = util.check_output(cmd).decode('utf-8')
+                stderr = None if self.args.debug else util.DEVNULL
+                results = util.check_output(cmd, stderr=stderr).decode('utf-8')
             except util.FileNotFound:
                 results = ""
             if tmpkey:


### PR DESCRIPTION
I've noticed this warning while using "atomic trust show":

gpg: WARNING: no command supplied.  Trying to guess what you mean ...

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>