### PR TITLE
ostree: fix mount when the `http:` prefix is used in the image name

### DIFF
--- a/Atomic/mount.py
+++ b/Atomic/mount.py
@@ -827,6 +827,8 @@ class OSTreeMount(Mount):
         if not OSTREE_PRESENT:
             return False
 
+        identifier = util.remove_skopeo_prefixes(identifier)
+
         options = ['remount', 'ro', 'nosuid', 'nodev']
         has_container = self.has_container(identifier)
         has_image = self.has_image(identifier)

--- a/Atomic/mount.py
+++ b/Atomic/mount.py
@@ -196,8 +196,11 @@ class Mount(Atomic):
 
         elif self.storage.lower() == "ostree":
             try:
-                if self._try_ostree_mount(best_mountpoint_for_storage):
-                    return
+                res = self._try_ostree_mount(best_mountpoint_for_storage)
+                # If ostree storage was explicitely requested, then we have to
+                # error out if the container/image could not be mounted.
+                if res == False:
+                    raise ValueError("Could not mount {}".format(self.image))
             except GLib.Error: # pylint: disable=catching-non-exception
                 self._no_such_image()
 

--- a/tests/integration/test_system_containers_mount.sh
+++ b/tests/integration/test_system_containers_mount.sh
@@ -65,7 +65,7 @@ OUTPUT=$(! ${ATOMIC} mount --live ${NAME} ${WORK_DIR}/mount 2>&1)
 grep "do not support --live" <<< $OUTPUT
 
 
-# 4. Check that --shared works
-${ATOMIC} mount --shared ${NAME} ${WORK_DIR}/mount
+# 4. Check that --shared works and that 'http:' is dropped
+${ATOMIC} mount --shared http:${NAME} ${WORK_DIR}/mount
 test -e ${WORK_DIR}/mount/usr/bin/greet.sh
 ${ATOMIC} umount ${WORK_DIR}/mount


### PR DESCRIPTION
Fix "atomic mount" for system containers when `http:` is added to the image name

/cc @peterbaouoft 