### PR TITLE
syscontainers: fix repo location detection

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -119,6 +119,7 @@ class SystemContainers(object):
         options.overwrite_mode = OSTree.RepoCheckoutOverwriteMode.UNION_FILES
         options.process_whiteouts = True
         options.disable_fsync = True
+        options.no_copy_fallback = True
         if self.user:
             options.mode = OSTree.RepoCheckoutMode.USER
         repo.checkout_at(options, rootfs_fd, rootfs, rev)


### PR DESCRIPTION
Improve the detection of the repo being on the same file system as the checkout path by trying to link a file.  This is necessary since on a bind mount the st_dev for the two directories is the same, but hardlinks will still fail with EXDEV.

Also, change the test in _canonicalize_location to check that on an Atomic Host /sysroot/ostree/deploy/*/var/* and /var/* have the same st_dev and st_ino.  It is necessary so that files created under /sysroot are visible in /var, and in this case it is fine the two locations are on different file systems.
