### PR TITLE
requirements.txt: Remove gi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ setuptools
 docker-py
 websocket-client>=0.11.0
 six>=1.3.0
-gi
 xattr
 python-dateutil
 PyYAML


### PR DESCRIPTION
## Description

The gi referenced in ``requirements.txt`` ends up pulling an unrelated library named ``gi`` which is not ``python-gobject`` related.

## Example of Problem
```
$ virtualenv-3 /tmp/testing
Using base prefix '/usr'
New python executable in /tmp/testing/bin/python3
Also creating executable in /tmp/testing/bin/python
Installing setuptools, pip, wheel...done.
$ . /tmp/testing/bin/activate
(testing)$ pip install -r requirements.txt 
Collecting requests>=2.4.3 (from -r requirements.txt (line 1))
  Using cached requests-2.18.4-py2.py3-none-any.whl
Requirement already satisfied: setuptools in /tmp/testing/lib/python3.6/site-packages (from -r requirements.txt (line 2))
Collecting docker-py (from -r requirements.txt (line 3))
  Using cached docker_py-1.10.6-py2.py3-none-any.whl
Collecting websocket-client>=0.11.0 (from -r requirements.txt (line 4))
  Using cached websocket_client-0.44.0-py2.py3-none-any.whl
Collecting six>=1.3.0 (from -r requirements.txt (line 5))
  Using cached six-1.11.0-py2.py3-none-any.whl
Collecting gi (from -r requirements.txt (line 6))
Collecting xattr (from -r requirements.txt (line 7))
Collecting python-dateutil (from -r requirements.txt (line 8))
  Using cached python_dateutil-2.6.1-py2.py3-none-any.whl
Collecting PyYAML (from -r requirements.txt (line 9))
Collecting urllib3 (from -r requirements.txt (line 10))
  Using cached urllib3-1.22-py2.py3-none-any.whl
Collecting chardet<3.1.0,>=3.0.2 (from requests>=2.4.3->-r requirements.txt (line 1))
  Using cached chardet-3.0.4-py2.py3-none-any.whl
Collecting idna<2.7,>=2.5 (from requests>=2.4.3->-r requirements.txt (line 1))
  Using cached idna-2.6-py2.py3-none-any.whl
Collecting certifi>=2017.4.17 (from requests>=2.4.3->-r requirements.txt (line 1))
  Downloading certifi-2017.11.5-py2.py3-none-any.whl (330kB)
    100% |████████████████████████████████| 337kB 1.8MB/s 
Collecting docker-pycreds>=0.2.1 (from docker-py->-r requirements.txt (line 3))
  Using cached docker_pycreds-0.2.1-py2.py3-none-any.whl
Collecting cffi>=1.0.0 (from xattr->-r requirements.txt (line 7))
  Downloading cffi-1.11.2-cp36-cp36m-manylinux1_x86_64.whl (419kB)
    100% |████████████████████████████████| 430kB 1.9MB/s 
Collecting pycparser (from cffi>=1.0.0->xattr->-r requirements.txt (line 7))
Installing collected packages: chardet, idna, urllib3, certifi, requests, six, websocket-client, docker-pycreds, docker-py, gi, pycparser, cffi, xattr, python-dateutil, PyYAML
Successfully installed PyYAML-3.12 certifi-2017.11.5 cffi-1.11.2 chardet-3.0.4 docker-py-1.10.6 docker-pycreds-0.2.1 gi-1.2 idna-2.6 pycparser-2.18 python-dateutil-2.6.1 requests-2.18.4 six-1.11.0 urllib3-1.22 websocket-client-0.44.0 xattr-0.9.2
(testing) $ pip freeze | grep gi
gi==1.2
(testing) $
```

The ``gi``  library installed can be found [here](https://pypi.python.org/pypi/gi/1.2)