### PR TITLE
Atomic/util.py: Handle TOML

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -92,9 +92,16 @@ def get_registries():
     if registries_tool_path() is not None:
         registries_json = load_registries_from_yaml()
         # Eliminate any duplicates with set.
-        _registries = list(set(registries_json.get("registries", [])))
-        _insecure_registries = list(set(registries_json.get('insecure_registries', [])))
-        _blocked_registries = list(set(registries_json.get('block_registries', [])))
+        if "registries.search" in registries_json:
+            # We are dealing with toml
+            _registries = list(set(registries_json.get("registries.search", []).get("registries", [])))
+            _insecure_registries = list(set(registries_json.get("registries.insecure", []).get("registries", [])))
+            _blocked_registries= list(set(registries_json.get("registries.block", []).get("registries", [])))
+        else:
+            # We are dealing with yaml
+            _registries = list(set(registries_json.get("registries", [])))
+            _insecure_registries = list(set(registries_json.get('insecure_registries', [])))
+            _blocked_registries = list(set(registries_json.get('block_registries', [])))
         duplicate_secure_insecure = list(set(_registries).intersection(_insecure_registries))
         if len(duplicate_secure_insecure) > 0:
             raise ValueError("There are duplicate values for registries and insecure registries.  Please correct "


### PR DESCRIPTION
Make sure that when TOML input for registries is used,
it is parsed correctly.  Also, remain able to parse
YAML if still being used.

Signed-off-by: baude <bbaude@redhat.com>


## Description


## Related Bugzillas
-
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
