### PR TITLE
syscontainers: ensure destdir exist

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -688,16 +688,19 @@ class SystemContainers(object):
         :type destdir: str
         """
         repo_stat = os.stat(repo)
-        destdir_stat = os.stat(destdir)
+        try:
+            destdir_stat = os.stat(destdir)
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                # The directory doesn't exist
+                os.makedirs(destdir)
+                destdir_stat = os.stat(destdir)
+            else:
+                raise e
+
         # Simple case: st_dev is different
         if repo_stat.st_dev != destdir_stat.st_dev:
             return False
-
-        try:
-            os.makedirs(destdir)
-        except OSError as e:
-            if e.errno != errno.EEXIST:
-                raise
 
         src_file = os.path.join(repo, "config")
         dest_file = os.path.join(destdir, "samefs-check-{}".format(os.getpid()))


### PR DESCRIPTION
## Description
When the ``destdir`` doesn't exist already exist the command would fail. This change creates the ``destdir`` before doing the first ``stat``.

## Related Issue Numbers
- https://github.com/projectatomic/atomic/issues/1138

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
