### PR TITLE
syscontainers: add two new variables RUNTIME and ATOMIC

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -211,9 +211,10 @@ class SystemContainers(object):
         :rtype: int
         """
         try:
-            util.check_call([util.BWRAP_OCI_PATH, "--version"], stdout=DEVNULL)
+            runtime = self._get_oci_runtime()
+            util.check_call([runtime, "--version"], stdout=DEVNULL)
         except util.FileNotFound:
-            raise ValueError("Cannot install the container: bwrap-oci is needed to run user containers")
+            raise ValueError("Cannot install the container: the runtime {} is not installed".format(runtime))
 
         if not "--user" in str(util.check_output(["systemctl", "--help"], stdin=DEVNULL, stderr=DEVNULL)):
             raise ValueError("Cannot install the container: systemctl does not support --user")
@@ -277,6 +278,13 @@ class SystemContainers(object):
         :rtype: int
         """
         return_value = None
+
+        try:
+            runtime = self._get_oci_runtime()
+            util.check_call([runtime, "--version"], stdout=DEVNULL)
+        except util.FileNotFound:
+            raise ValueError("Cannot install the container: the runtime {} is not installed".format(runtime))
+
         # If we don't have a dockertar file or a reference to a docker engine image
         if not image.startswith('dockertar:/') and not (image.startswith("docker:") and image.count(':') > 1):
             image = util.remove_skopeo_prefixes(image)

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -513,8 +513,8 @@ class SystemContainers(object):
             stoppost = "{} delete '{}'".format(runtime, name)
             return [start, "", "", stoppost]
         else:
-            runc_commands = ["run", "kill"]
-            return ["{}{} {} '{}'".format(runtime, systemd_cgroup, command, name) for command in runc_commands] + ["", ""]
+            commands = ["run", "kill"]
+            return ["{}{} {} '{}'".format(runtime, systemd_cgroup, command, name) for command in commands] + ["", ""]
 
     def _get_systemd_destination_files(self, name, prefix=None):
         if self.user:
@@ -2417,7 +2417,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             raise ValueError("Command not supported in user mode")
 
         if is_container_running:
-            cmd = [util.RUNC_PATH, "exec"]
+            cmd = [self._get_oci_runtime(), "exec"]
             if tty:
                 cmd.extend(["--tty"])
             if detach:
@@ -2455,7 +2455,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
                     if is_runtime and not os.path.exists(src):
                         os.makedirs(src)
 
-                cmd = [util.RUNC_PATH, "run"]
+                cmd = [self._get_oci_runtime(), "run"]
                 cmd.extend([name])
                 subp = subprocess.Popen(cmd,
                                         cwd=temp_dir,

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -2415,9 +2415,6 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
 
         tty = os.isatty(0)
 
-        if util.is_user_mode():
-            raise ValueError("Command not supported in user mode")
-
         if is_container_running:
             cmd = [self._get_oci_runtime(), "exec"]
             if tty:

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -16,6 +16,7 @@ from Atomic.backends._docker_errors import NoDockerDaemon
 from ctypes import cdll, CDLL
 import uuid
 from .rpm_host_install import RPMHostInstall, RPM_NAME_PREFIX
+import __main__
 
 try:
     import gi
@@ -670,6 +671,9 @@ class SystemContainers(object):
 
         if 'RUNTIME' not in values:
             values["RUNTIME"] = self._get_oci_runtime()
+
+        if 'ATOMIC' not in values:
+            values["ATOMIC"] = os.path.abspath(__main__.__file__)
 
         if manifest is not None and "defaultValues" in manifest:
             for key, val in manifest["defaultValues"].items():

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -660,6 +660,9 @@ class SystemContainers(object):
         if "ALL_PROCESS_CAPABILITIES" not in values:
             values["ALL_PROCESS_CAPABILITIES"] = SystemContainers._get_all_capabilities()
 
+        if 'RUNTIME' not in values:
+            values["RUNTIME"] = self._get_oci_runtime()
+
         if manifest is not None and "defaultValues" in manifest:
             for key, val in manifest["defaultValues"].items():
                 if key not in values:
@@ -1290,13 +1293,12 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             if fullpath.endswith(".0") or fullpath.endswith(".1"):
                 continue
 
-            runtime = "bwrap-oci" if self.user else "runc"
             with open(os.path.join(fullpath, "info"), "r") as info_file:
                 info = json.load(info_file)
                 revision = info["revision"] if "revision" in info else ""
                 created = info["created"] if "created" in info else 0
                 image = info["image"] if "image" in info else ""
-                runtime = info["runtime"] if "runtime" in info else ""
+                runtime = info["runtime"] if "runtime" in info else self._get_oci_runtime()
 
             command = ""
             config_json = os.path.join(fullpath, "config.json")

--- a/docs/atomic-install.1.md
+++ b/docs/atomic-install.1.md
@@ -199,6 +199,8 @@ the host, $XDG_RUNTIME_DIR for user containers).
 
 **$UUID** UUID generated for this container.
 
+**$RUNTIME** The runtime used to execute the containers.
+
 **--system-package=auto|build|no|yes**
 Control how the container will be installed to the system.
 

--- a/docs/atomic-install.1.md
+++ b/docs/atomic-install.1.md
@@ -201,6 +201,8 @@ the host, $XDG_RUNTIME_DIR for user containers).
 
 **$RUNTIME** The runtime used to execute the containers.
 
+**$ATOMIC** Path to the atomic executable that is installing the container.
+
 **--system-package=auto|build|no|yes**
 Control how the container will be installed to the system.
 

--- a/tests/integration/test_system_containers_runtime.sh
+++ b/tests/integration/test_system_containers_runtime.sh
@@ -235,3 +235,6 @@ assert_matches ${SECRET} ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}-new/config.json
 ${ATOMIC} uninstall ${NAME}-new
 ${ATOMIC} install --name=${NAME}-new --runtime=/bin/ls --set=RECEIVER=${SECRET} --system atomic-test-system
 assert_matches /bin/ls /etc/systemd/system/${NAME}-new.service
+
+OUTPUT=$(! ${ATOMIC} install --name=${NAME}-new --runtime=/does/not/exist --set=RECEIVER=${SECRET} --system atomic-test-system-2 2>&1)
+grep "is not installed" <<< $OUTPUT

--- a/tests/integration/test_system_containers_runtime.sh
+++ b/tests/integration/test_system_containers_runtime.sh
@@ -236,5 +236,6 @@ ${ATOMIC} uninstall ${NAME}-new
 ${ATOMIC} install --name=${NAME}-new --runtime=/bin/ls --set=RECEIVER=${SECRET} --system atomic-test-system
 assert_matches /bin/ls /etc/systemd/system/${NAME}-new.service
 
-OUTPUT=$(! ${ATOMIC} install --name=${NAME}-new --runtime=/does/not/exist --set=RECEIVER=${SECRET} --system atomic-test-system-2 2>&1)
+${ATOMIC} uninstall ${NAME}-new
+OUTPUT=$(! ${ATOMIC} install --name=${NAME}-new --runtime=/does/not/exist --set=RECEIVER=${SECRET} --system atomic-test-system 2>&1)
 grep "is not installed" <<< $OUTPUT


### PR DESCRIPTION
## Description

They allow the creation of wrapper scripts in a much easier way:

For example a script `ls` exported to the host, but that is executed in the container could look like:

```
#!/bin/sh
exec $ATOMIC run $NAME ls $$@
```

the advantage of using ATOMIC compared to RUNTIME is that "atomic run" has more features compared to directly using the container runtime exec command, like the possibility of running commands when the container is not already running.

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [x] Integration Tests
