### PR TITLE
syscontainers: set SELinux label for files copied to the host

### DIFF
--- a/tests/integration/test_system_containers_rpm.sh
+++ b/tests/integration/test_system_containers_rpm.sh
@@ -96,6 +96,7 @@ for i in /usr/local/lib/renamed-atomic-test-system-hostfs /usr/local/lib/secret-
 do
     assert_matches $i rpm_file_list
     test -e $i
+    matchpathcon -V $i
 done
 
 # This is not a template file, the $RECEIVER is not replaced


### PR DESCRIPTION
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
