### PR TITLE
images: fix validation and add--all to validate all the images

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1462,6 +1462,12 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             virtual_size = self._get_virtual_size(repo, manifest)
             if 'Labels' in manifest:
                 labels = manifest['Labels']
+            else:
+                config = self._image_config(repo, manifest)
+                if config:
+                    config = json.loads(config)
+                    if 'config' in config and 'Labels' in config['config']:
+                        labels = config['config']['Labels']
             image_id = SystemContainers._get_image_id(repo, commit_rev, manifest) or image_id
 
         if self.user:
@@ -1833,6 +1839,17 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
     def _image_manifest(self, repo, rev):
         return SystemContainers._get_commit_metadata(repo, rev, "docker.manifest")
 
+    def _image_config(self, repo, manifest):
+        if 'config' not in manifest:
+            return None
+
+        layer = SystemContainers._drop_sha256_prefix(manifest['config']['digest'])
+
+        rev = repo.resolve_rev("%s%s" % (OSTREE_OCIIMAGE_PREFIX, layer), True)[1]
+        if rev is None:
+            return None
+        return SystemContainers._read_commit_file(repo, rev, "/content")
+
     def get_manifest(self, image, remote=False):
         """
         Returns the manifest for an image.
@@ -2102,6 +2119,19 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         if key not in metadata.keys():
             return None
         return metadata[key]
+
+    @staticmethod
+    def _read_commit_file(repo, rev, path):
+        commit = repo.read_commit(rev)[1]
+        if not commit:
+            return None
+        content = commit.get_root().get_child(path)
+        if not content.query_exists():
+            return None
+        istream = content.read()
+        with os.fdopen(istream.get_fd()) as f:
+            data = f.read()
+        return data
 
     def extract(self, img, destination):
         """

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -2288,7 +2288,8 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
                 elif res == OSTree.RepoCommitIterResult.END:
                     break
 
-        current_rev = repo.resolve_rev("%s%s" % (OSTREE_OCIIMAGE_PREFIX, layer), False)[1]
+        imagebranch = SystemContainers._get_ostree_image_branch(layer)
+        current_rev = repo.resolve_rev(imagebranch, True)[1]
         if not current_rev:
             raise ValueError("Layer not found: %s.  Please pull the image again" % layer.replace("sha256:", ""))
 

--- a/Atomic/verify.py
+++ b/Atomic/verify.py
@@ -52,7 +52,7 @@ class Verify(Atomic):
     def verify(self):
         if self.args.debug:
             util.write_out(str(self.args))
-        local_layers, remote_layers = self._verify()
+        be, local_layers, remote_layers = self._verify()
         if not self._layers_match(local_layers, remote_layers) or self.args.verbose:
             col = "{0:30} {1:20} {2:20} {3:1}"
             util.write_out("\n{} contains the following images:\n".format(self.image))
@@ -63,10 +63,12 @@ class Verify(Atomic):
                                           local_layers[layer_int].long_version[:20],
                                           remote_layers[layer_int].long_version[:20],
                                           differs))
-            util.write_out("\n")
+                util.write_out("\n")
+        if not self.args.no_validate:
+            be.validate_layer(self.image)
 
     def verify_dbus(self):
-        local_layers, remote_layers = self._verify()
+        _, local_layers, remote_layers = self._verify()
         layers = []
         for layer_int in range(len(local_layers)):
             layer = {}
@@ -81,7 +83,7 @@ class Verify(Atomic):
         be, img_obj = self.backend_utils.get_backend_and_image_obj(self.image, str_preferred_backend=self.args.storage or storage, required=True if self.args.storage else False)
         remote_img_name  = "{}:latest".format(util.Decompose(img_obj.fq_name).no_tag)
         remote_img_obj = be.make_remote_image(remote_img_name)
-        return img_obj.layers, remote_img_obj.layers
+        return be, img_obj.layers, remote_img_obj.layers
 
     def get_tagged_images(self, names, layers):
         """

--- a/bash/atomic
+++ b/bash/atomic
@@ -340,6 +340,7 @@ _atomic_images_verify() {
 	"
 	local all_options="$options_with_args
 		-h --help
+		-a --all
 		--no-validate
 	"
 

--- a/docs/atomic-images.1.md
+++ b/docs/atomic-images.1.md
@@ -142,6 +142,9 @@ Atomic --assumeyes option can be used
 [**-v|--verbose**]
    Will output the status of each base image that makes up the image being verified.
 
+[**-a|--all**]
+   Will verify all images in a storage.
+
 # version OPTIONS
 [**-h|--help**]
   Print usage statement


### PR DESCRIPTION
the "images validate" support seemed to be broken as there is no validation done.

This PR does:

- some refactoring of the Docker backend.  All the Docker image validation part is moved to backends/_docker.py

- enable again image validation.  Honor `--no-validate` (which is already present) to skip it.

- add option `-all` to more easily validate all images in one shot.
