### PR TITLE
syscontainers: refactor duplicated info reading

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -265,6 +265,25 @@ class SystemContainers(object):
             shutil.rmtree(temp_dir)
         return None
 
+    @staticmethod
+    def _gather_installed_files_info (checkout, name):
+        """
+        Get the corresponding fields from info file based on the container name
+
+        :param checkout: path for checkout
+        :param name: name for the container
+        :returns: info object, rpm_installed field value, installed_files_checksum field value
+        """
+        with open(os.path.join(checkout, name, "info"), "r") as info_file:
+            info = json.loads(info_file.read())
+            rpm_installed = info["rpm-installed"] if "rpm-installed" in info else None
+            installed_files_checksum = info["installed-files-checksum"] if "installed-files-checksum" in info else None
+            if installed_files_checksum is None:
+                installed_files = info["installed-files"] if "installed-files" in info else None
+                installed_files_checksum = {k : "" for k in installed_files}
+
+        return info, rpm_installed, installed_files_checksum
+
     def install(self, image, name):
         """
         External container install logic.
@@ -1114,7 +1133,9 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         if not repo:
             raise ValueError("Cannot find a configured OSTree repo")
 
-        path = os.path.join(self._get_system_checkout_path(), name)
+        checkout = self._get_system_checkout_path()
+
+        path = os.path.join(checkout, name)
         with open(os.path.join(path, "info"), 'r') as info_file:
             info = json.loads(info_file.read())
             self.args.remote = info['remote']
@@ -1125,17 +1146,10 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         if os.path.realpath(path).endswith(".0"):
             next_deployment = 1
 
-        with open(os.path.join(self._get_system_checkout_path(), name, "info"), "r") as info_file:
-            info = json.loads(info_file.read())
-
+        info, rpm_installed, installed_files_checksum = self._gather_installed_files_info(checkout, name)
         image = rebase or info["image"]
         values = info["values"]
         revision = info["revision"] if "revision" in info else None
-        installed_files_checksum = info["installed-files-checksum"] if "installed-files-checksum" in info else None
-        if installed_files_checksum is None:
-            installed_files = info["installed-files"] if "installed-files" in info else None
-            installed_files_checksum = {k : "" for k in installed_files}
-        rpm_installed = info["rpm-installed"] if "rpm-installed" in info else None
         system_package = info["system-package"] if "system-package" in info else None
         runtime = info["runtime"] if "runtime" in info else None
 
@@ -1179,23 +1193,17 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         :param name: The container to rollback.
         :type name: str
         """
-        path = os.path.join(self._get_system_checkout_path(), name)
+        checkout = self._get_system_checkout_path()
+        path = os.path.join(checkout, name)
         destination = "%s.%d" % (path, (1 if os.path.realpath(path).endswith(".0") else 0))
         if not os.path.exists(destination):
             raise ValueError("Error: Cannot find a previous deployment to rollback located at %s" % destination)
 
-        installed_files = None
+        info, rpm_installed, installed_files_checksum = self._gather_installed_files_info(checkout, name)
         rename_files = None
-        with open(os.path.join(self._get_system_checkout_path(), name, "info"), "r") as info_file:
-            info = json.loads(info_file.read())
-            rpm_installed = info["rpm-installed"] if "rpm-installed" in info else None
-            installed_files_checksum = info["installed-files-checksum"] if "installed-files-checksum" in info else None
-            if installed_files_checksum is None:
-                installed_files = info["installed-files"] if "installed-files" in info else None
-                installed_files_checksum = {k : "" for k in installed_files}
-            installed_files_template = info["installed-files-template"] if "installed-files-template" in info and rpm_installed is None else None
-            has_container_service = info["has-container-service"] if "has-container-service" in info else True
-            rename_files = info["rename-installed-files"] if "rename-installed-files" in info else None
+        installed_files_template = info["installed-files-template"] if "installed-files-template" in info and rpm_installed is None else None
+        has_container_service = info["has-container-service"] if "has-container-service" in info else True
+        rename_files = info["rename-installed-files"] if "rename-installed-files" in info else None
 
         was_service_active = has_container_service and self._is_service_active(name)
         unitfileout, tmpfilesout = self._get_systemd_destination_files(name)
@@ -1622,13 +1630,14 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             RPMHostInstall.uninstall_rpm("%s-%s" % (RPM_NAME_PREFIX, name))
             return
 
-        if not os.path.exists(os.path.join(self._get_system_checkout_path(), name)):
+        checkout = self._get_system_checkout_path()
+
+        if not os.path.exists(os.path.join(checkout, name)):
             return
 
-        with open(os.path.join(self._get_system_checkout_path(), name, "info"), "r") as info_file:
+        with open(os.path.join(checkout, name, "info"), "r") as info_file:
             info = json.loads(info_file.read())
             has_container_service = info["has-container-service"] if "has-container-service" in info else True
-            rpm_installed = info["rpm-installed"] if "rpm-installed" in info else None
 
         unitfileout, tmpfilesout = self._get_systemd_destination_files(name)
         if has_container_service:
@@ -1654,14 +1663,8 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
                 pass
             os.unlink(tmpfilesout)
 
-        checkout = self._get_system_checkout_path()
-        installed_files = None
-        with open(os.path.join(checkout, name,  "info"), 'r') as info_file:
-            info = json.loads(info_file.read())
-            installed_files_checksum = info["installed-files-checksum"] if "installed-files-checksum" in info else None
-            installed_files = info["installed-files"] if "installed-files" in info else []
-            if installed_files_checksum == None:
-                installed_files_checksum = {k: "" for k in installed_files}
+        info, rpm_installed, installed_files_checksum = self._gather_installed_files_info(checkout, name)
+
         if installed_files_checksum:
             RPMHostInstall.rm_add_files_to_host(installed_files_checksum, None)
 


### PR DESCRIPTION
Removal of duplicated code sections for reading info fields from multiple functions.

- This is one of my first attempt of doing code refactoring, if there is anything I did horribly wrong, please tell me asap =)

- This refactoring is from part of https://github.com/projectatomic/atomic/issues/1149, it refactored duplicated code sections for installed files fields

- Shouldn't have any functionality change here, will see how the test goes (test seems passing locally)