### PR TITLE
syscontainers: refactor part of remote logic into a function

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -296,9 +296,9 @@ class SystemContainers(object):
         remote_path = self._resolve_remote_path(remote_input)
         if remote_path:
             remote_rootfs = os.path.sep.join([remote_path, "rootfs"])
-            if os.path.exists(remote_path):
+            if os.path.exists(remote_rootfs):
                 util.write_out("The remote rootfs for this container is set to be {}".format(remote_rootfs))
-            elif os.path.exists(os.path.sep.join([remote_input, "usr"])):  # Assume that the user directly gave the location of the rootfs
+            elif os.path.exists(os.path.sep.join([remote_path, "usr"])):  # Assume that the user directly gave the location of the rootfs
                 remote_path = os.path.dirname(remote_path)  # Use the parent directory as the "container location"
             else:
                 raise ValueError("--remote was specified but the given location does not contain a rootfs")

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -286,6 +286,24 @@ class SystemContainers(object):
 
         return info, rpm_installed, installed_files_checksum
 
+    def _get_remote_location(self, remote_input):
+        """
+        Parse the remote input and return actual remote path
+
+        :param remote_input: input path from user
+        :returns: the parsed remote location
+        """
+        remote_path = self._resolve_remote_path(remote_input)
+        if remote_path:
+            remote_rootfs = os.path.sep.join([remote_path, "rootfs"])
+            if os.path.exists(remote_path):
+                util.write_out("The remote rootfs for this container is set to be {}".format(remote_rootfs))
+            elif os.path.exists(os.path.sep.join([remote_input, "usr"])):  # Assume that the user directly gave the location of the rootfs
+                remote_path = os.path.dirname(remote_path)  # Use the parent directory as the "container location"
+            else:
+                raise ValueError("--remote was specified but the given location does not contain a rootfs")
+        return remote_path
+
     def install(self, image, name):
         """
         External container install logic.
@@ -806,17 +824,8 @@ class SystemContainers(object):
         except (IndexError, TypeError):
             raise ValueError("Image {} not found".format(img))
 
-        remote_path = self._resolve_remote_path(remote)
-
+        remote_path = self._get_remote_location(remote)
         if remote_path:
-            remote_rootfs = os.path.sep.join([remote_path, "rootfs"])
-            if os.path.exists(remote_rootfs):
-                util.write_out("The remote rootfs for this container is set to be {}".format(remote_rootfs))
-            elif os.path.exists(os.path.sep.join([remote, "usr"])):  # Assume that the user directly gave the location of the rootfs
-                remote_rootfs = remote
-                remote_path = os.path.dirname(remote_path)  # Use the parent directory as the "container location"
-            else:
-                raise ValueError("--remote was specified but the given location does not contain a rootfs")
             exports = os.path.join(remote_path, "rootfs/exports")
         else:
             exports = os.path.join(destination, "rootfs/exports")
@@ -926,12 +935,12 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
                     config = json.loads(config_file.read())
                 except ValueError:
                     raise ValueError("Invalid config.json file in given remote location: {}.".format(destination_path))
-                config['root']['path'] = remote_rootfs
+                config['root']['path'] = rootfs
             with open(destination_path, 'w') as config_file:
                 config_file.write(json.dumps(config, indent=4))
             # create a symlink to the real rootfs, so that it is possible
             # to access the rootfs in the same way as in the not --remote case.
-            os.symlink(remote_rootfs, os.path.join(destination, "rootfs"))
+            os.symlink(rootfs, os.path.join(destination, "rootfs"))
 
         # When upgrading, stop the service and remove previously installed
         # tmpfiles, before restarting the service.

--- a/tests/unit/test_syscontainers.py
+++ b/tests/unit/test_syscontainers.py
@@ -57,10 +57,10 @@ class TestSystemContainers_do_checkout(unittest.TestCase):
             # Here: we check for 3 different cases _get_remote_location verifies
             sc = SystemContainers()
             remote_path_one = sc._get_remote_location('/tmp/test-remote/')
-            self.assertEqual(remote_path_one, '/tmp/test-remote')
+            self.assertEqual(remote_path_one, os.path.realpath('/tmp/test-remote'))
 
             remote_path_two = sc._get_remote_location('/tmp/test-remote/rootfs/')
-            self.assertEqual(remote_path_two, '/tmp/test-remote')
+            self.assertEqual(remote_path_two, os.path.realpath('/tmp/test-remote'))
 
             self.assertRaises(ValueError, sc._get_remote_location, '/tmp/not-valid-test')
         finally:

--- a/tests/unit/test_syscontainers.py
+++ b/tests/unit/test_syscontainers.py
@@ -35,6 +35,38 @@ if no_mock:
 
     patch = fake_patch
 
+@unittest.skipIf(no_mock, "Mock not found")
+class TestSystemContainers_do_checkout(unittest.TestCase):
+    """
+    Unit tests for refactored function from SystemContainers.do_checkout method.
+    """
+    def test_get_remote_location(self):
+        """
+        We create temp directories in tmp folder, then remove it after the test completes
+
+        """
+        # Create directories for 3 different cases '_get_remote_location' is checking
+        try:
+            os.makedirs('/tmp/test-remote/rootfs/usr')
+            os.mkdir('/tmp/not-valid-test')
+        # If the directories already exist, we do not error out here
+        except OSError:
+            pass
+
+        try:
+            # Here: we check for 3 different cases _get_remote_location verifies
+            sc = SystemContainers()
+            remote_path_one = sc._get_remote_location('/tmp/test-remote/')
+            self.assertEqual(remote_path_one, '/tmp/test-remote')
+
+            remote_path_two = sc._get_remote_location('/tmp/test-remote/rootfs/')
+            self.assertEqual(remote_path_two, '/tmp/test-remote')
+
+            self.assertRaises(ValueError, sc._get_remote_location, '/tmp/not-valid-test')
+        finally:
+            # We then remove the directories to keep the user's fs clean
+            os.rmdir('/tmp/not-valid-test')
+            shutil.rmtree('/tmp/test-remote')
 
 @unittest.skipIf(no_mock, "Mock not found")
 class TestSystemContainers_container_exec(unittest.TestCase):


### PR DESCRIPTION
The code logic for getting remote path was "refactored" into a new
function to shorten the length of 'do_checkout' method.

Remote_rootfs is also discarded as it appears that when 'remote_path' is
specified, the rootfs location will represent the remote_rootfs location

There shouldn't be any functional impact from this commit

Feedback is always welcome =).
~**Note: the unit test is in progress, first submit without it here for comments/testing purposes**~
~( Although I am not too sure if unit tests is needed here, it will be great if someone could clarify the~
~situations where a unit test would best fit :p)~

## Related Issue Numbers
- https://github.com/projectatomic/atomic/issues/1149
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [x] Unittests
- [ ] Integration Tests
