### PR TITLE
syscontainers: refactor handling rootfs into a function

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -286,7 +286,8 @@ class SystemContainers(object):
 
         return info, rpm_installed, installed_files_checksum
 
-    def _get_remote_location(self, remote_input):
+    @staticmethod
+    def _get_remote_location(remote_input):
         """
         Parse the remote input and return actual remote path
 
@@ -843,7 +844,7 @@ class SystemContainers(object):
         except (IndexError, TypeError):
             raise ValueError("Image {} not found".format(img))
 
-        remote_path = self._get_remote_location(remote)
+        remote_path = SystemContainers._get_remote_location(remote)
         if remote_path:
             exports = os.path.join(remote_path, "rootfs/exports")
         else:

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -333,6 +333,31 @@ class SystemContainers(object):
         # to access the rootfs in the same way as in the not --remote case.
         os.symlink(remote_rootfs, os.path.join(destination, "rootfs"))
 
+    def _prepare_rootfs_dirs(self, remote_path, destination, extract_only=False):
+        """
+        Generate rootfs path based on user inputs and make directories accordingly
+
+        :param remote_path: path for remote
+        :param destination: the destination location for a container
+        :param extract_only: if specified, only image layers will be checked out to destination
+        """
+
+        if extract_only:
+            rootfs = destination
+        elif remote_path:
+            rootfs = os.path.join(remote_path, "rootfs")
+        else:
+            destination = self._canonicalize_location(destination)
+            rootfs = os.path.join(destination, "rootfs")
+
+        if remote_path:
+            if not os.path.exists(destination):
+                os.makedirs(destination)
+        else:
+            if not os.path.exists(rootfs):
+                os.makedirs(rootfs)
+        return rootfs
+
     def install(self, image, name):
         """
         External container install logic.
@@ -861,23 +886,11 @@ class SystemContainers(object):
         if self.display:
             return values
 
-        if extract_only:
-            rootfs = destination
-        elif remote_path:
-            rootfs = os.path.join(remote_path, "rootfs")
-        else:
-            destination = self._canonicalize_location(destination)
-            rootfs = os.path.join(destination, "rootfs")
-
-        if remote_path:
-            if not os.path.exists(destination):
-                os.makedirs(destination)
-        else:
-            if not os.path.exists(rootfs):
-                os.makedirs(rootfs)
+        rootfs = self._prepare_rootfs_dirs(remote_path, destination, extract_only=extract_only)
 
         manifest = self._image_manifest(repo, rev)
 
+        # TODO: The "missing layer" check logic here can be refactored once we migrate to use skopeo only
         if not remote_path:
             rootfs_fd = None
             try:

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -890,7 +890,7 @@ class SystemContainers(object):
 
         manifest = self._image_manifest(repo, rev)
 
-        # TODO: The "missing layer" check logic here can be refactored once we migrate to use skopeo only
+        # todo: The "missing layer" check logic here can be refactored once we migrate to use skopeo only
         if not remote_path:
             rootfs_fd = None
             try:

--- a/tests/unit/test_syscontainers.py
+++ b/tests/unit/test_syscontainers.py
@@ -42,7 +42,7 @@ class TestSystemContainers_do_checkout(unittest.TestCase):
     """
     def test_get_remote_location(self):
         """
-        This function checks for 4 different cases _get_remote_location
+        This function checks for 4 different cases of _get_remote_location function
         1: when the remote is given as /xx and /xx/rootfs exist
         2: when the remote is given as /xx/rootfs and /xx/rootfs/usr exist
         3: when the remote input does not contain a rootfs
@@ -58,17 +58,16 @@ class TestSystemContainers_do_checkout(unittest.TestCase):
             os.mkdir(not_valid_location)
 
             # Here: we check for 4 different cases _get_remote_location verifies
-            sc = SystemContainers()
-            self.assertRaises(ValueError, sc._get_remote_location, non_existant_location)
+            self.assertRaises(ValueError, SystemContainers._get_remote_location, non_existant_location)
 
-            remote_path_one = sc._get_remote_location(tmpdir)
+            remote_path_one = SystemContainers._get_remote_location(tmpdir)
             # we default to real path here because on AH, / sometimes actually refer to /sysroot
             self.assertEqual(remote_path_one, os.path.realpath(tmpdir))
 
-            remote_path_two = sc._get_remote_location(rootfs_location)
+            remote_path_two = SystemContainers._get_remote_location(rootfs_location)
             self.assertEqual(remote_path_two, os.path.realpath(tmpdir))
 
-            self.assertRaises(ValueError, sc._get_remote_location, not_valid_location)
+            self.assertRaises(ValueError, SystemContainers._get_remote_location, not_valid_location)
         finally:
             # We then remove the directories to keep the user's fs clean
             shutil.rmtree(tmpdir)

--- a/tests/unit/test_syscontainers.py
+++ b/tests/unit/test_syscontainers.py
@@ -72,6 +72,46 @@ class TestSystemContainers_do_checkout(unittest.TestCase):
             # We then remove the directories to keep the user's fs clean
             shutil.rmtree(tmpdir)
 
+    def test_prepare_rootfs_dirs(self):
+        """
+        This function checks for 3 different cases for function '_prepare_rootfs_dirs'
+        1: extract specified with either destination/remote_path
+        2: remote_path and destination specified
+        3: only destination specified
+        """
+
+        try:
+            # Prepare the temp location for verifying
+            tmpdir = tempfile.mkdtemp()
+            extract_location = os.path.sep.join([tmpdir, "extract"])
+            remote_location  = os.path.sep.join([tmpdir, "remote"])
+            remote_destination_case = os.path.sep.join([tmpdir, "dest_one"])
+            destination_location = os.path.sep.join([tmpdir, "dest_two"])
+
+            sc = SystemContainers()
+
+            # Create expected rootfs for future comparison
+            expected_remote_rootfs = os.path.join(remote_location, "rootfs")
+            expected_dest_rootfs = os.path.join(destination_location, "rootfs")
+
+            # Here, we begin testing 3 different cases mentioned above
+            extract_rootfs = sc._prepare_rootfs_dirs(None, extract_location, extract_only=True)
+            self.assertTrue(os.path.exists(extract_rootfs), True)
+            self.assertEqual(extract_rootfs, extract_location)
+
+            remote_rootfs = sc._prepare_rootfs_dirs(remote_location, remote_destination_case)
+            self.assertEqual(remote_rootfs, expected_remote_rootfs)
+            self.assertTrue(os.path.exists(remote_destination_case), True)
+
+            # Note: since the location passed in is not in /var/xx format, canonicalize location
+            # should not have an effect, thus we don't worry about it here
+            destination_rootfs = sc._prepare_rootfs_dirs(None, destination_location)
+            self.assertEqual(destination_rootfs, expected_dest_rootfs)
+            self.assertTrue(os.path.exists(expected_dest_rootfs), True)
+
+        finally:
+            shutil.rmtree(tmpdir)
+
 @unittest.skipIf(no_mock, "Mock not found")
 class TestSystemContainers_container_exec(unittest.TestCase):
     """


### PR DESCRIPTION
## Description
 syscontainers: refactor handling rootfs into a function

In _do_checkout, we refactor the part for getting rootfs location
into a function.

A todo comment( refactoring 'missing image layer check') is also added
in this commit based on discussions on irc

A unit test is added for future regression


## Related Issue Numbers
- https://github.com/projectatomic/atomic/issues/1149


If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [x] Unittests
- [ ] Integration Tests
