### PR TITLE
Refactor syscontainer manifest dup

### DIFF
--- a/tests/unit/test_rpm_host_install.py
+++ b/tests/unit/test_rpm_host_install.py
@@ -1,0 +1,112 @@
+#pylint: skip-file
+import os
+import shutil
+import tempfile
+import unittest
+import json
+from Atomic.rpm_host_install import RPMHostInstall
+
+
+no_mock = True
+try:
+    from unittest.mock import ANY, patch, call
+    no_mock = False
+except ImportError:
+    try:
+        from mock import ANY, patch, call
+        no_mock = False
+    except ImportError:
+        # Mock is already set to False
+        pass
+
+@unittest.skipIf(no_mock, "Mock not found")
+class TestRPMHostInstall(unittest.TestCase):
+
+    @patch("Atomic.rpm_host_install.RPMHostInstall.file_checksum")
+    def test_rm_add_files_to_host(self, _fc):
+        """
+        This function tests the following 3 functionalities:
+        1: When old_installed_files_checksum do exist, test if the files will be removed
+        2: When file is in the specified 'tempalte', check to see if its content get swapped
+        3: When file not in the template, files should be copied instead
+
+        Also Note, the function skips checking for the return value, as I felt the 'external effect' is what matters
+        in this test
+        """
+
+        _fc.return_value = "15"
+        def check_file_removal(tmpdir):
+            # Test for the first case
+            test_old_installed_file = tempfile.mkstemp(prefix=tmpdir)
+            test_old_installed_file_path = test_old_installed_file[1]
+            changed_file_dict = {test_old_installed_file_path : "0"}
+            non_changed_file_dict = {test_old_installed_file_path : "15"}
+
+            RPMHostInstall.rm_add_files_to_host(changed_file_dict, None)
+            self.assertTrue(os.path.exists(test_old_installed_file_path))
+            RPMHostInstall.rm_add_files_to_host(non_changed_file_dict, None)
+            self.assertFalse(os.path.exists(test_old_installed_file_path))
+
+        def setup_and_collect_export_hostfs_files(tmpdir):
+            exports_hostfs_dir = os.path.join(tmpdir, "hostfs")
+            exports_hostfs_tempdir = exports_hostfs_dir +  tmpdir
+            os.makedirs(exports_hostfs_tempdir)
+            # Note about the location here, as we have to make files start with /exports/hostfs
+            # and we want to use the benefit from tmpdir, we have to have the format of /exports/hostfs/tmpdir
+            exports_hostfs_file = os.path.join(exports_hostfs_tempdir, "test.file")
+
+            return exports_hostfs_file, exports_hostfs_dir
+
+        def get_real_exports_file_path(exports_hostfs_file, exports_hostfs_dir):
+            # Find the relative path of the file to exports/hostfs (which is actually the true path under '/' in this contenxt)
+            rel_file_path = os.path.relpath(exports_hostfs_file, exports_hostfs_dir)
+            real_file_path = os.path.join("/", rel_file_path)
+            template_set = [real_file_path]
+            return template_set
+
+        def write_exports_file(exports_hostfs_file):
+            # When the files are already set up, we begin calling function
+            content = {"test_one" : "$test_swap"}
+            with open(exports_hostfs_file, 'w') as json_file:
+                json_file.write(json.dumps(content, indent=4))
+                json_file.write("\n")
+
+        def prepare_test_case(tmpdir):
+            exports_host_file, exports_hostfs_dir = setup_and_collect_export_hostfs_files(tmpdir)
+            template_set = get_real_exports_file_path(exports_host_file, exports_hostfs_dir)
+            write_exports_file(exports_host_file)
+            values = {"test_swap" : "test_result"}
+
+            return template_set, values
+
+        def check_value_swap(template_set, values, tmpdir):
+            real_file_path = template_set[0]
+            RPMHostInstall.rm_add_files_to_host(None, tmpdir, files_template=template_set, values=values)
+            self.assertTrue(os.path.exists(real_file_path))
+            with open(real_file_path, "r") as f:
+                json_val = json.loads(f.read())
+            self.assertEqual(json_val["test_one"], "test_result")
+
+            # Do the cleanup and check last case
+            os.remove(real_file_path)
+
+        try:
+            tmpdir = tempfile.mkdtemp()
+
+            # Test for the first case
+            check_file_removal(tmpdir)
+
+            # Test for the second case
+            template_set, values = prepare_test_case(tmpdir)
+            check_value_swap(template_set, values, tmpdir)
+
+            # Test for the third case
+            real_file_path = template_set[0]
+            RPMHostInstall.rm_add_files_to_host(None, tmpdir)
+            self.assertTrue(os.path.exists(real_file_path))
+
+        finally:
+            shutil.rmtree(tmpdir)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_rpm_host_install.py
+++ b/tests/unit/test_rpm_host_install.py
@@ -19,6 +19,19 @@ except ImportError:
         # Mock is already set to False
         pass
 
+if no_mock:
+    # If there is no mock, we need need to create a fake
+    # patch decorator
+    def fake_patch(a, new=''):
+        def foo(func):
+            def wrapper(*args, **kwargs):
+                ret = func(*args, **kwargs)
+                return ret
+            return wrapper
+        return foo
+
+    patch = fake_patch
+
 @unittest.skipIf(no_mock, "Mock not found")
 class TestRPMHostInstall(unittest.TestCase):
 

--- a/tests/unit/test_syscontainers.py
+++ b/tests/unit/test_syscontainers.py
@@ -169,6 +169,22 @@ class TestSystemContainers_do_checkout(unittest.TestCase):
         finally:
             shutil.rmtree(tmpdir)
 
+    def test_get_manifest_attribtues(self):
+        """
+        This function checks 2 simple cases to verify the functionality of '_get_manifest_attribtues'
+        1: When the attribute is not in the manifest, a default val should be returned
+        2: When the key is there and manifest itself exist, its corresponding value should be returned
+        """
+        manifest = {"rename_files" : "test_val"}
+
+        # Test for the two cases mentioned above
+        test_val_one = SystemContainers._get_manifest_attributes(manifest, "rename_files", None)
+        self.assertEqual(test_val_one, "test_val")
+
+        test_val_two = SystemContainers._get_manifest_attributes(manifest, "non_existant", "test_two")
+        self.assertEqual(test_val_two, "test_two")
+
+
 @unittest.skipIf(no_mock, "Mock not found")
 class TestSystemContainers_container_exec(unittest.TestCase):
     """

--- a/tests/unit/test_syscontainers.py
+++ b/tests/unit/test_syscontainers.py
@@ -184,6 +184,29 @@ class TestSystemContainers_do_checkout(unittest.TestCase):
         test_val_two = SystemContainers._get_manifest_attributes(manifest, "non_existant", "test_two")
         self.assertEqual(test_val_two, "test_two")
 
+    def test_update_rename_file_value(self):
+        """
+        This function checks 2 different cases for function '_update_rename_file_value'
+        1: checks if the values will be successfully swapped given correct value combinations
+        2: checks when one of the values in "rename_files" is not replaced, error will come out
+        """
+
+        # Prepare for the values
+        sc = SystemContainers()
+        manifest = {"renameFiles" : {"testKey" : "$testVal",
+                                     "testKeySec" : "$testTwo"}}
+        values =  {"testVal" : "testSubOne",
+                    "testTwo" : "testSubTwo"}
+        secondValues = {"testVal" : "secondTestSubOne"}
+
+        # Test for the cases mentioned above
+        sc._update_rename_file_value(manifest, values)
+        self.assertEqual(manifest["renameFiles"]["testKey"], "testSubOne")
+        self.assertEqual(manifest["renameFiles"]["testKeySec"], "testSubTwo")
+
+        # Reset the value for next test case
+        manifest["renameFiles"]["testKey"] = "$testMisMatch"
+        self.assertRaises(ValueError, sc._update_rename_file_value, manifest, secondValues)
 
 @unittest.skipIf(no_mock, "Mock not found")
 class TestSystemContainers_container_exec(unittest.TestCase):


### PR DESCRIPTION
## Description
The goal of this pull request was to remove the local variables generated/used by manifest (i.e: installedFilesTemplate, renameFiles and noContainerService). 

Other than that, code section in `_do_checkout` function are also refactored into small functions. Details can be seen from the TODO list at the end of description. 

## Related Issue Numbers
- #1149 

## Related pull request 
- #1154 

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [x] Unittests
- [ ] Integration Tests

  ## TODO:
- [x] refactor upgrade tempfile cleaning
- [x] refactor rename files and unit test
- [x] refactor file installation and have a unit test for it  
https://github.com/projectatomic/atomic/blob/master/Atomic/syscontainers.py#L1022-L1032 
- [x] refactor writing info file https://github.com/projectatomic/atomic/blob/master/Atomic/syscontainers.py#L1035-L1056 (possibly have a unit test for it)
- [x] Refactor https://github.com/projectatomic/atomic/blob/master/Atomic/syscontainers.py#L1064-L1066
and https://github.com/projectatomic/atomic/blob/master/Atomic/syscontainers.py#L1080-L1083
to remove `has_container_service` completely
-  [x] **Last step** (I think), go back and remove the three local variables generated by manifest https://github.com/projectatomic/atomic/blob/master/Atomic/syscontainers.py#L961-L977