### PR TITLE
Refactor syscontainer config dup

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -625,15 +625,6 @@ class SystemContainers(object):
                 tmpfilesout = os.path.join(SYSTEMD_TMPFILES_DEST, "%s.conf" % name)
         return unitfileout, tmpfilesout
 
-    def _resolve_remote_path(self, remote_path):
-        if not remote_path:
-            return None
-
-        real_path = os.path.realpath(remote_path)
-        if not os.path.exists(real_path):
-            raise ValueError("The container's rootfs is set to remote, but the remote rootfs does not exist")
-        return real_path
-
     def _checkout_wrapper(self, repo, name, img, deployment, mode, values=None, destination=None, extract_only=False, remote=None, prefix=None, installed_files_checksum=None, system_package='no'):
         """
         Wrapper function that groups parameters into a dictionary for better readbility

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -973,7 +973,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         else:
             systemd_template = SYSTEMD_UNIT_FILE_DEFAULT_TEMPLATE
 
-        values = self._amend_values(options["values"], manifest, options["name"], options["img"], image_id, options["destination"], options["prefix"], unit_file_support_pidfile=SystemContainers._template_support_pidfile(systemd_template))
+        options["values"] = self._amend_values(options["values"], manifest, options["name"], options["img"], image_id, options["destination"], options["prefix"], unit_file_support_pidfile=SystemContainers._template_support_pidfile(systemd_template))
 
         src = os.path.join(exports, "config.json")
         destination_path = os.path.join(options["destination"], "config.json")
@@ -981,7 +981,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             shutil.copyfile(src, destination_path)
         elif os.path.exists(src + ".template"):
             with open(src + ".template", 'r') as infile:
-                util.write_template(src + ".template", infile.read(), values, destination_path)
+                util.write_template(src + ".template", infile.read(), options["values"], destination_path)
         else:
             self._generate_default_oci_configuration(options["destination"])
 

--- a/tests/unit/test_syscontainers.py
+++ b/tests/unit/test_syscontainers.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 import unittest
 import subprocess
+import json
 
 from Atomic import util
 from Atomic.syscontainers import SystemContainers
@@ -108,6 +109,61 @@ class TestSystemContainers_do_checkout(unittest.TestCase):
             destination_rootfs = sc._prepare_rootfs_dirs(None, destination_location)
             self.assertEqual(destination_rootfs, expected_dest_rootfs)
             self.assertTrue(os.path.exists(expected_dest_rootfs), True)
+
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_write_config_to_dest(self):
+        """
+        This function checks 3 different cases for function 'write_config_to_dest'
+        1: checks when exports/config.json exist, the files are copied correctly
+        2: checks exports/config.json.template exist, the template is copied, and values inside the template are swapped by values
+        3: checks the  configuration was correct when the above 2 cases do not apply
+        """
+
+        def check_attr_in_json_file(json_file, attr_name, value, second_attr=None):
+            # We don't check existance here, because in this context, files do exist
+            with open(json_file, "r") as f:
+                json_val = json.loads(f.read())
+                actual_val =  json_val[attr_name][second_attr] if second_attr else json_val[attr_name]
+                self.assertEqual(actual_val, value)
+
+        try:
+            # Prepare the temp directory for verification
+            tmpdir = tempfile.mkdtemp()
+            dest_location = os.path.sep.join([tmpdir, "dest"])
+            dest_location_config = os.path.join(dest_location, "config.json")
+            # Note: in this context, the location of exports should not matter, as we are only copying files from exports
+            # in this function
+            exports_location = os.path.join(tmpdir, "rootfs/exports")
+            exports_json = os.path.join(exports_location, "config.json")
+
+            os.makedirs(exports_location)
+            os.mkdir(dest_location)
+            values = {"test_one": "$hello_test"}
+            with open(exports_json, 'w') as json_file:
+                json_file.write(json.dumps(values, indent=4))
+                json_file.write("\n")
+            new_values = {"hello_test" : "new_val"}
+
+            sc = SystemContainers()
+            sc._write_config_to_dest(dest_location, exports_location)
+            self.assertTrue(os.path.exists(dest_location_config), True)
+            check_attr_in_json_file(dest_location_config, "test_one", "$hello_test")
+            # We remove the file to keep the destination clean for next operation
+            os.remove(dest_location_config)
+
+            # Renmae exports/config.json to exports/config.json.template
+            os.rename(exports_json, exports_json + ".template")
+            sc._write_config_to_dest(dest_location, exports_location, new_values)
+            self.assertTrue(os.path.exists(dest_location_config), True)
+            check_attr_in_json_file(dest_location_config, "test_one", "new_val")
+            os.remove(dest_location_config)
+
+            # Note: in this case, the configuration is generated and changed via 'generate_default_oci_configuration' which uses runc. Thus, we assume when user tries to run the unit test with this function, he will have runc installed
+            sc._write_config_to_dest(dest_location, os.path.join(tmpdir, "not_exist"))
+            self.assertTrue(os.path.exists(dest_location_config), True)
+            check_attr_in_json_file(dest_location_config, "root", "rootfs", second_attr="path")
 
         finally:
             shutil.rmtree(tmpdir)

--- a/tests/unit/test_syscontainers.py
+++ b/tests/unit/test_syscontainers.py
@@ -153,14 +153,15 @@ class TestSystemContainers_do_checkout(unittest.TestCase):
             # We remove the file to keep the destination clean for next operation
             os.remove(dest_location_config)
 
-            # Renmae exports/config.json to exports/config.json.template
+            # Rename exports/config.json to exports/config.json.template
             os.rename(exports_json, exports_json + ".template")
             sc._write_config_to_dest(dest_location, exports_location, new_values)
             self.assertTrue(os.path.exists(dest_location_config), True)
             check_attr_in_json_file(dest_location_config, "test_one", "new_val")
             os.remove(dest_location_config)
 
-            # Note: in this case, the configuration is generated and changed via 'generate_default_oci_configuration' which uses runc. Thus, we assume when user tries to run the unit test with this function, he will have runc installed
+            # Note: in this case, the configuration is generated and changed via 'generate_default_oci_configuration' which uses runc.
+            # Thus, we assume when user tries to run the unit test with this function, he will have runc installed
             sc._write_config_to_dest(dest_location, os.path.join(tmpdir, "not_exist"))
             self.assertTrue(os.path.exists(dest_location_config), True)
             check_attr_in_json_file(dest_location_config, "root", "rootfs", second_attr="path")


### PR DESCRIPTION
## Description
This pull request removes the unused function introduced earlier and contains refactoring for write config in '_do_checkout' function,
this refactoring also removes the duplication of writing config in 'run_once'

There should not be functional impact with this commit.

A unit test is added for future regression


## Related Issue Numbers
- https://github.com/projectatomic/atomic/issues/1149

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [x] Unittests
- [ ] Integration Tests
