### PR TITLE
ostree: try hard links before copying files to the host

### DIFF
--- a/Atomic/rpm_host_install.py
+++ b/Atomic/rpm_host_install.py
@@ -81,7 +81,11 @@ class RPMHostInstall(object):
         return h.hexdigest()
 
     @staticmethod
-    def rm_add_files_to_host(old_installed_files_checksum, exports, prefix="/", files_template=None, values=None, rename_files=None):
+    def _should_use_hard_link(dest_path):
+        return dest_path.startswith("/usr/")
+
+    @staticmethod
+    def rm_add_files_to_host(old_installed_files_checksum, exports, prefix="/", files_template=None, values=None, rename_files=None, use_links=True):
         # if any file was installed on the host delete it
         if old_installed_files_checksum:
             for path, checksum in old_installed_files_checksum.items():
@@ -146,7 +150,8 @@ class RPMHostInstall(object):
                         shutil.copystat(src_file, dest_path)
                         created = True
                     else:
-                        created = RPMHostInstall._copyfile(selinux_hnd, src_file, dest_path)
+                        try_hardlink = use_links and RPMHostInstall._should_use_hard_link(dest_path)
+                        created = RPMHostInstall._copyfile(selinux_hnd, src_file, dest_path, try_hardlink=try_hardlink)
 
                     if created:
                         new_installed_files_checksum[rel_dest_path] = RPMHostInstall.file_checksum(dest_path)

--- a/Atomic/rpm_host_install.py
+++ b/Atomic/rpm_host_install.py
@@ -37,7 +37,8 @@ class RPMHostInstall(object):
             return True
         else:
             file_copied = False
-            # newer version of Skopeo/SELinux use the same SELinux context for f
+            # newer version of Skopeo/SELinux use the same SELinux context for system containers
+            # files as the host files at the same location i.e. /exports/hostfs/foo -> /foo.
             if try_hardlink and selinux_hnd is not None:
                 src_label = selinux.getfilecon(src)
                 # Files have the same label, we can use a hard link.
@@ -147,7 +148,7 @@ class RPMHostInstall(object):
                             selinux.setfscreatecon_raw(ctx[1])
 
                         util.write_template(src_file, data, values or {}, dest_path)
-                        shutil.copystat(src_file, dest_path)
+                        shutil.copymode(src_file, dest_path)
                         created = True
                     else:
                         try_hardlink = use_links and RPMHostInstall._should_use_hard_link(dest_path)

--- a/docs/atomic-install.1.md
+++ b/docs/atomic-install.1.md
@@ -151,6 +151,9 @@ The directives **installedFilesTemplate** and **renameFiles** from the
 **manifest.json** file can be used to modify the content and the final
 destination of the file.
 
+**useLinks** Specify if files copied to the host under */usr* should use
+hard links when possible.  By default it is True.
+
 This is the list of the variables that get a value from atomic and
 cannot be overriden by the user through **--set**:
 

--- a/tests/integration/test_system_containers_rpm.sh
+++ b/tests/integration/test_system_containers_rpm.sh
@@ -152,6 +152,9 @@ do
     test -e $i
 done
 
+# we are using useLinks=false in the manifest.json, so ensure there is only one link.
+test $(stat -c%h /usr/local/lib/renamed-atomic-test-system-hostfs) == 1
+
 echo "This message will not be deleted" > /usr/local/lib/secret-message
 
 ATOMIC_OSTREE_TEST_FORCE_IMAGE_ID=NEW-ID ${ATOMIC} containers update atomic-test-system-hostfs

--- a/tests/test-images/system-container-files-hostfs/manifest.json
+++ b/tests/test-images/system-container-files-hostfs/manifest.json
@@ -9,5 +9,6 @@
     },
     "installedFilesTemplate" : [
         "/usr/local/lib/secret-message-template"
-    ]
+    ],
+    "useLinks" : false
 }


### PR DESCRIPTION
## Description

We had several discussions about copying client (like docker, or crioctl) to the host to make easier using system containers.  In such a perspective, take advantage of the new SELinux labelling for system containers and try to use hard links instead of copying files when possible.

This to work requires: https://github.com/containers/image/pull/401