### PR TITLE
syscontainers: allow the container name to end in .[01]

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1389,7 +1389,12 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             if not os.path.exists(fullpath):
                 continue
             if fullpath.endswith(".0") or fullpath.endswith(".1"):
-                continue
+                # Skip the deployments if we have a symlink named in
+                # the same name except the ".[01]" ending.
+                # We avoid duplicates as we are already including the container
+                # in the results from the symlink and not from the deployments.
+                if os.path.islink(fullpath[:-2]):
+                    continue
 
             with open(os.path.join(fullpath, "info"), "r") as info_file:
                 info = json.load(info_file)


### PR DESCRIPTION
we skipped file names just based on their ending without checking if
it is a symlink.  This prevented container with a name ending in .0 or
.1 to be uninstalled.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>