### PR TITLE
install: do not fail when ostree is not installed

### DIFF
--- a/Atomic/install.py
+++ b/Atomic/install.py
@@ -107,7 +107,7 @@ class Install(Atomic):
         if self.ostree_uri(self.image):
             return self.syscontainers.install(self.image, self.name)
         # Check if image exists
-        str_backend = 'ostree' if self.args.system else self.args.storage or storage
+        str_backend = 'ostree' if args_system else self.args.storage or storage
         be = be_utils.get_backend_from_string(str_backend)
         img_obj = be.has_image(self.args.image)
         if img_obj and img_obj.is_system_type:


### PR DESCRIPTION
Solves this exception:

'Namespace' object has no attribute 'system'
Traceback (most recent call last):
File "/usr/bin/atomic", line 185, in <module> sys.exit(_func())
File "/usr/local/lib/python2.7/dist-packages/Atomic/install.py", line
110, in install str_backend = 'ostree' if self.args.system else
self.args.storage or storage AttributeError: 'Namespace' object has no
attribute 'system'

Closes: https://github.com/projectatomic/atomic/issues/1165

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>


## Description


## Related Bugzillas
-
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
