### PR TITLE
Atomic.run: fix help doc

### DIFF
--- a/Atomic/run.py
+++ b/Atomic/run.py
@@ -47,7 +47,7 @@ def cli(subparser):
     util.add_opt(runp)
     runp.add_argument("--replace", "-r", dest="replace", default=False,
                       action="store_true", help=_("Replaces an existing container by the same name"
-                                                  "if it exists."))
+                                                  " if it exists."))
     runp.add_argument("--storage", dest="storage", default=None,
                           help=_("Specify the storage. Default is currently '%s'.  You can"
                                  " change the default by editing /etc/atomic.conf and changing"


### PR DESCRIPTION
Signed-off-by: Alex Jia <ajia@redhat.com>


## Description
s/nameif/name if/.

$ atomic run -h |grep Replace
  --replace, -r         Replaces an existing container by the same nameif it

## Related Bugzillas
-
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
