### PR TITLE
syscontainers: read labels from v1Compatibility

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1646,7 +1646,13 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             virtual_size = self._get_virtual_size(repo, manifest)
             if 'Labels' in manifest:
                 labels = manifest['Labels']
-            else:
+            elif 'history' in manifest:
+                for i in manifest['history']:
+                    if 'v1Compatibility' in i:
+                        config = json.loads(i['v1Compatibility'])
+                        if 'container_config' in config and 'Labels' in config['container_config']:
+                            labels.update(config['container_config']['Labels'])
+            if labels is None or len(labels) == 0:
                 config = self._image_config(repo, manifest)
                 if config:
                     config = json.loads(config)


### PR DESCRIPTION
Images coming from registry.access.redhat.com through "skopeo copy"
have this information in the v1Compatibility block.  Use this
information so we can correctly catch "atomic.run".

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
