### PR TITLE
rpm_host_install: fix TypeError with SELinux bindings

### DIFF
--- a/Atomic/rpm_host_install.py
+++ b/Atomic/rpm_host_install.py
@@ -21,7 +21,7 @@ class RPMHostInstall(object):
             except OSError:
                 pass
 
-            ctx = selinux.selabel_lookup_raw(selinux_hnd, dest, mode)
+            ctx = selinux.selabel_lookup_raw(selinux_hnd, str(dest), mode)
             selinux.setfscreatecon_raw(ctx[1])
 
         if os.path.isdir(src):
@@ -144,7 +144,7 @@ class RPMHostInstall(object):
                             data = src_file_obj.read()
 
                         if selinux_hnd is not None:
-                            ctx = selinux.selabel_lookup_raw(selinux_hnd, dest_path, os.stat(src_file).st_mode)
+                            ctx = selinux.selabel_lookup_raw(selinux_hnd, str(dest_path), os.stat(src_file).st_mode)
                             selinux.setfscreatecon_raw(ctx[1])
 
                         util.write_template(src_file, data, values or {}, dest_path)


### PR DESCRIPTION
It solves a TypeError exception:

Traceback (most recent call last):
  File "/bin/atomic", line 185, in <module>
    sys.exit(_func())
  File "/usr/lib/python2.7/site-packages/Atomic/install.py", line 134, in install
    return be.install(self.image, self.name)
  File "/usr/lib/python2.7/site-packages/Atomic/backends/_ostree.py", line 128, in install
    return self.syscontainers.install(image, name)
  File "/usr/lib/python2.7/site-packages/Atomic/syscontainers.py", line 563, in install
    return_value = self._install(image, name)
  File "/usr/lib/python2.7/site-packages/Atomic/syscontainers.py", line 686, in _install
    self._checkout_wrapper(repo, name, image, 0, SystemContainers.CHECKOUT_MODE_INSTALL, values=values, remote=self.args.remote, system_package=self.args.system_package)
  File "/usr/lib/python2.7/site-packages/Atomic/syscontainers.py", line 797, in _checkout_wrapper
    return self._checkout(repo, options)
  File "/usr/lib/python2.7/site-packages/Atomic/syscontainers.py", line 813, in _checkout
    return self._do_checkout(repo, options)
  File "/usr/lib/python2.7/site-packages/Atomic/syscontainers.py", line 1126, in _do_checkout
    rpm_install_content = self._handle_system_package_files(options, manifest, exports)
  File "/usr/lib/python2.7/site-packages/Atomic/syscontainers.py", line 469, in _handle_system_package_files
    new_installed_files_checksum = RPMHostInstall.rm_add_files_to_host(options["installed_files_checksum"], exports, options["prefix"] or "/", files_template=installed_files_template, values=options["values"], rename_files=rename_files, use_links=use_links)
  File "/usr/lib/python2.7/site-packages/Atomic/rpm_host_install.py", line 155, in rm_add_files_to_host
    created = RPMHostInstall._copyfile(selinux_hnd, src_file, dest_path, try_hardlink=try_hardlink)
  File "/usr/lib/python2.7/site-packages/Atomic/rpm_host_install.py", line 24, in _copyfile
    ctx = selinux.selabel_lookup_raw(selinux_hnd, dest, mode)
TypeError: in method 'selabel_lookup_raw', argument 3 of type 'char const *'

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1542144

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

