### PR TITLE
syscontainer: remove of fallback version of skopeo

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -2062,10 +2062,6 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         args, img = self._convert_to_skopeo(image)
         return util.skopeo_inspect(img, args)
 
-    def _skopeo_get_layers(self, image, layers):
-        _, img = self._convert_to_skopeo(image)
-        return util.skopeo_layers(img, [], layers)
-
     def _image_manifest(self, repo, rev):
         return SystemContainers._get_commit_metadata(repo, rev, "docker.manifest")
 
@@ -2274,7 +2270,8 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
 
         if can_use_skopeo_copy:
             return self._check_system_oci_image_skopeo_copy(repo, img, src_creds=src_creds)
-        return self._check_system_oci_image_no_skopeo_copy(repo, img, imagebranch)
+        else:
+            raise ValueError("Skopeo version too old, please install the newest version")
 
     def _check_system_oci_image_skopeo_copy(self, repo, img, src_creds=None):
         repo = self.get_ostree_repo_location()
@@ -2291,37 +2288,6 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             util.skopeo_copy("docker://" + img, destination, dest_ostree_tmp_dir=temp_dir, insecure=insecure, src_creds=src_creds)
         finally:
             shutil.rmtree(temp_dir, ignore_errors=True)
-        return True
-
-    def _check_system_oci_image_no_skopeo_copy(self, repo, img, imagebranch):
-        try:
-            manifest = self._skopeo_get_manifest(img)
-        except ValueError:
-            raise ValueError("Unable to find {}".format(img))
-        layers = SystemContainers.get_layers_from_manifest(manifest)
-        missing_layers = []
-        for i in layers:
-            layer = i.replace("sha256:", "")
-            has_layer = repo.resolve_rev("%s%s" % (OSTREE_OCIIMAGE_PREFIX, layer), True)[1]
-            if not has_layer:
-                missing_layers.append(layer)
-                util.write_out("Pulling layer %s" % layer)
-        layers_dir = None
-        try:
-            layers_to_import = {}
-            if len(missing_layers):
-                layers_dir = self._skopeo_get_layers(img, missing_layers)
-                for root, _, files in os.walk(layers_dir):
-                    for f in files:
-                        if f.endswith(".tar"):
-                            layer_file = os.path.join(root, f)
-                            layer = f.replace(".tar", "")
-                            if not repo.resolve_rev("%s%s" % (OSTREE_OCIIMAGE_PREFIX, layer), True)[1]:
-                                layers_to_import[layer] = layer_file
-            self._import_layers_into_ostree(repo, imagebranch, manifest, layers_to_import)
-        finally:
-            if layers_dir:
-                shutil.rmtree(layers_dir)
         return True
 
     @staticmethod

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -2165,13 +2165,18 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
 
     def _skopeo_copy_img_to_ostree(self, img, skopeo_img_source, src_creds=None, insecure=None):
         """
-        Pefrom skopeo copy operation to copy images from img_source to ostree location based on image
+        Perform skopeo copy operation to copy images from img_source to ostree location based on image
         name
         :param img: image name
+        :type img: str
         :param skopeo_img_source: the source for skopeo copying
-        :src_creds: source credientials if pulled from online registries
-        :insecure: tell skopeo whether the registry is secure or not
+        :type skopeo_img_source: str
+        :param src_creds: source credentials if pulled from online registries
+        :type src_creds: str in the form of USERNAME[:PASSWORD]
+        :param insecure: tell skopeo whether the registry is secure or not
+        :type insecure: bool
         :returns: True if successfully performed copy operation, a ValueError can be raised upon failures
+        :rtype: bool
         """
         repo = self.get_ostree_repo_location()
 
@@ -2191,7 +2196,9 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         """
         Retrieve the image name from the dockertar file
         :param tarpath: the path of the docker tar file
+        :type tarpath: str
         :returns: the true image name got from the dockertar
+        :rtype: str
         """
         temp_dir = tempfile.mkdtemp()
         try:

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -179,6 +179,12 @@ class SystemContainers(object):
     def _pull_image_to_ostree(self, repo, image, upgrade, src_creds=None):
         if not repo:
             raise ValueError("Cannot find a configured OSTree repo")
+
+        # Since we are migrating to use skopeo only, we will move the check for ostree upper level too
+        can_use_skopeo_copy = util.check_output([util.SKOPEO_PATH, "copy", "--help"]).decode().find("ostree") >= 0
+        if not can_use_skopeo_copy:
+            raise ValueError("Skopeo version too old, Please use skopeo version after 1.21")
+
         if image.startswith("docker:") and image.count(':') > 1:
             image = self._pull_docker_image(image.replace("docker:", "", 1))
         elif image.startswith("dockertar:/"):
@@ -2125,9 +2131,19 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         return layers
 
     def _pull_docker_image(self, image):
-        with tempfile.NamedTemporaryFile(mode="w") as temptar:
-            util.check_call(["docker", "save", "-o", temptar.name, image])
-            return self._pull_docker_tar(temptar.name, image)
+        """
+        Use skopeo to copy docker image from docker daemon to ostree
+
+        :param image: The full name of image to pull. E.g: docker:image:latest
+        :type image: str
+        :returns image name
+        :rtype: str
+        """
+        skopeo_source = "docker-daemon:" + image
+        self._skopeo_copy_img_to_ostree(image, skopeo_source)
+
+        # Return back the image name for future usages
+        return image
 
     def _pull_docker_tar(self, tarpath, image):
         """
@@ -2140,10 +2156,6 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         :rtype: str
         """
         image_name = SystemContainers._get_image_name_from_dockertar(tarpath) or image
-        can_use_skopeo_copy = util.check_output([util.SKOPEO_PATH, "copy", "--help"]).decode().find("ostree") >= 0
-
-        if not can_use_skopeo_copy:
-            raise ValueError("Skopeo version too old, Please use version after 1.21")
 
         skopeo_source = "docker-archive:" + tarpath
         self._skopeo_copy_img_to_ostree(image_name, skopeo_source)
@@ -2229,12 +2241,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             # and never let it fail.
             pass
 
-        can_use_skopeo_copy = util.check_output([util.SKOPEO_PATH, "copy", "--help"]).decode().find("ostree") >= 0
-
-        if can_use_skopeo_copy:
-            return self._check_system_oci_image_skopeo_copy(img, src_creds=src_creds)
-        else:
-            raise ValueError("Skopeo version too old, please install the newest version")
+        return self._check_system_oci_image_skopeo_copy(img, src_creds=src_creds)
 
     def _check_system_oci_image_skopeo_copy(self, img, src_creds=None):
         # Pass the original name to "skopeo copy" so we don't resolve it in atomic

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -181,10 +181,10 @@ class SystemContainers(object):
         if not repo:
             raise ValueError("Cannot find a configured OSTree repo")
         if image.startswith("docker:") and image.count(':') > 1:
-            image = self._pull_docker_image(repo, image.replace("docker:", "", 1))
+            image = self._pull_docker_image(image.replace("docker:", "", 1))
         elif image.startswith("dockertar:/"):
             tarpath = image.replace("dockertar:/", "", 1)
-            image = self._pull_docker_tar(repo, tarpath, os.path.basename(tarpath).replace(".tar", ""))
+            image = self._pull_docker_tar(tarpath, os.path.basename(tarpath).replace(".tar", ""))
         else: # Assume "oci:"
             self._check_system_oci_image(repo, image, upgrade, src_creds=src_creds)
         return image
@@ -2197,12 +2197,63 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
 
         repo.commit_transaction(None)
 
-    def _pull_docker_image(self, repo, image):
+    def _pull_docker_image(self, image):
         with tempfile.NamedTemporaryFile(mode="w") as temptar:
             util.check_call(["docker", "save", "-o", temptar.name, image])
-            return self._pull_docker_tar(repo, temptar.name, image)
+            return self._pull_docker_tar(temptar.name, image)
 
-    def _pull_docker_tar(self, repo, tarpath, image):
+    def _pull_docker_tar(self, tarpath, image):
+        """
+        Resolves a docker tar and pull its content into ostree using skopeo
+        :param tarpath: the path for the docker tar file
+        :type tarpath: str
+        :param image: the default image name extracted from tar file name
+        :type image: str
+        :returns: the resolved image name that will be pulled into ostree
+        :rtype: str
+        """
+        image_name = SystemContainers._get_image_name_from_dockertar(tarpath) or image
+        can_use_skopeo_copy = util.check_output([util.SKOPEO_PATH, "copy", "--help"]).decode().find("ostree") >= 0
+
+        if not can_use_skopeo_copy:
+            raise ValueError("Skopeo version too old, Please use version after 1.21")
+
+        skopeo_source = "docker-archive:" + tarpath
+        self._skopeo_copy_img_to_ostree(image_name, skopeo_source)
+
+        # Return the image name for future usages
+        return image_name
+
+    def _skopeo_copy_img_to_ostree(self, img, skopeo_img_source, src_creds=None, insecure=None):
+        """
+        Pefrom skopeo copy operation to copy images from img_source to ostree location based on image
+        name
+        :param img: image name
+        :param skopeo_img_source: the source for skopeo copying
+        :src_creds: source credientials if pulled from online registries
+        :insecure: tell skopeo whether the registry is secure or not
+        :returns: True if successfully performed copy operation, a ValueError can be raised upon failures
+        """
+        repo = self.get_ostree_repo_location()
+
+        checkout = self._get_system_checkout_path()
+        destdir = checkout if os.path.exists(checkout) else None
+        temp_dir = tempfile.mkdtemp(prefix=".", dir=destdir)
+
+        destination = "ostree:{}@{}".format(img, repo)
+        try:
+            util.skopeo_copy(skopeo_img_source, destination, dest_ostree_tmp_dir=temp_dir, insecure=insecure, src_creds=src_creds)
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+        return True
+
+    @staticmethod
+    def _get_image_name_from_dockertar(tarpath):
+        """
+        Retrieve the image name from the dockertar file
+        :param tarpath: the path of the docker tar file
+        :returns: the true image name got from the dockertar
+        """
         temp_dir = tempfile.mkdtemp()
         try:
             with tarfile.open(tarpath, 'r') as t:
@@ -2213,28 +2264,13 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
                     with open(manifest_file, 'r') as mfile:
                         manifest = mfile.read()
                     for m in json.loads(manifest):
-                        if "Config" in m:
-                            config_file = os.path.join(temp_dir, m["Config"])
-                            with open(config_file, 'r') as config:
-                                config = json.loads(config.read())
-                                labels = config['config']['Labels']
-                        imagename = m["RepoTags"][0] if m.get("RepoTags") else image
-                        imagebranch = "%s%s" % (OSTREE_OCIIMAGE_PREFIX, SystemContainers._encode_to_ostree_ref(imagename))
-                        input_layers = m["Layers"]
-                        self._pull_dockertar_layers(repo, imagebranch, temp_dir, input_layers, labels=labels)
+                        imagename = m["RepoTags"][0] if m.get("RepoTags") else None
                 else:
                     repositories = ""
                     repositories_file = os.path.join(temp_dir, "repositories")
                     with open(repositories_file, 'r') as rfile:
                         repositories = rfile.read()
                     imagename = list(json.loads(repositories).keys())[0]
-                    imagebranch = "%s%s" % (OSTREE_OCIIMAGE_PREFIX, SystemContainers._encode_to_ostree_ref(imagename))
-                    input_layers = []
-                    for name in os.listdir(temp_dir):
-                        if name == "repositories":
-                            continue
-                        input_layers.append(name + "/layer.tar")
-                    self._pull_dockertar_layers(repo, imagebranch, temp_dir, input_layers)
             return imagename
         finally:
             shutil.rmtree(temp_dir)
@@ -2269,26 +2305,15 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         can_use_skopeo_copy = util.check_output([util.SKOPEO_PATH, "copy", "--help"]).decode().find("ostree") >= 0
 
         if can_use_skopeo_copy:
-            return self._check_system_oci_image_skopeo_copy(repo, img, src_creds=src_creds)
+            return self._check_system_oci_image_skopeo_copy(img, src_creds=src_creds)
         else:
             raise ValueError("Skopeo version too old, please install the newest version")
 
-    def _check_system_oci_image_skopeo_copy(self, repo, img, src_creds=None):
-        repo = self.get_ostree_repo_location()
-
-        checkout = self._get_system_checkout_path()
-        destdir = checkout if os.path.exists(checkout) else None
-        temp_dir = tempfile.mkdtemp(prefix=".", dir=destdir)
-
+    def _check_system_oci_image_skopeo_copy(self, img, src_creds=None):
         # Pass the original name to "skopeo copy" so we don't resolve it in atomic
         insecure, img = self._get_skopeo_args(img, full_resolution=False)
-
-        destination = "ostree:{}@{}".format(img, repo)
-        try:
-            util.skopeo_copy("docker://" + img, destination, dest_ostree_tmp_dir=temp_dir, insecure=insecure, src_creds=src_creds)
-        finally:
-            shutil.rmtree(temp_dir, ignore_errors=True)
-        return True
+        skopeo_img_src = "docker://" + img
+        return self._skopeo_copy_img_to_ostree(img, skopeo_img_src, src_creds=src_creds, insecure=insecure)
 
     @staticmethod
     def _generate_tmpfiles_data(missing_bind_paths):

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -7,7 +7,6 @@ import tarfile
 from string import Template
 import calendar
 import shutil
-import stat # pylint: disable=bad-python3-import
 import subprocess
 import time
 import errno
@@ -2125,78 +2124,6 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             layers = manifest.get("Layers")
         return layers
 
-    def _import_layers_into_ostree(self, repo, imagebranch, manifest, layers):
-        def get_directory_size(path):
-            size = 0
-            seen = {}
-            for root, _, files in os.walk(path):
-                for f in files:
-                    s = os.lstat(os.path.join(root, f))
-                    key = "%s-%s" % (s.st_dev, s.st_ino)
-                    if key not in seen:
-                        seen[key] = key
-                        size += s.st_size
-            return GLib.Variant('s', str(size))
-
-        repo.prepare_transaction()
-        for layer, tar in layers.items():
-            mtree = OSTree.MutableTree()
-            def filter_func(*args):
-                info = args[2]
-
-                if info.get_file_type() == Gio.FileType.SPECIAL:
-                    return OSTree.RepoCommitFilterResult.SKIP
-
-                if info.get_file_type() == Gio.FileType.DIRECTORY:
-                    info.set_attribute_uint32("unix::mode", info.get_attribute_uint32("unix::mode") | stat.S_IWUSR)
-                return OSTree.RepoCommitFilterResult.ALLOW
-
-            modifier = OSTree.RepoCommitModifier.new(0, filter_func, None)
-
-            checkout = self._get_system_checkout_path()
-            destdir = checkout if os.path.exists(checkout) else None
-
-            try:
-                temp_dir = tempfile.mkdtemp(prefix=".", dir=destdir)
-                # NOTE: tarfile has an issue with utf8. This works around the problem
-                # by using the systems tar command.
-                # Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1194473
-                subprocess.check_call(['tar', '-xf', tar, '-C', temp_dir])
-                if self.user:
-                    SystemContainers._correct_dir_permissions_for_user(temp_dir)
-
-                repo.write_directory_to_mtree(Gio.File.new_for_path(temp_dir), mtree, modifier)
-                root = repo.write_mtree(mtree)[1]
-
-                metav = GLib.Variant("a{sv}", {'docker.layer': GLib.Variant('s', layer),
-                                               'docker.size': get_directory_size(temp_dir)})
-                csum = repo.write_commit(None, "", None, metav, root)[1]
-            finally:
-                shutil.rmtree(temp_dir, ignore_errors=True)
-
-            repo.transaction_set_ref(None, "%s%s" % (OSTREE_OCIIMAGE_PREFIX, layer), csum)
-
-        # create a $OSTREE_OCIIMAGE_PREFIX$image-$tag branch
-        if not isinstance(manifest, str):
-            manifest = json.dumps(manifest)
-
-        metadata = GLib.Variant("a{sv}", {'docker.manifest': GLib.Variant('s', manifest)})
-        mtree = OSTree.MutableTree()
-        file_info = Gio.FileInfo()
-        file_info.set_attribute_uint32("unix::uid", 0)
-        file_info.set_attribute_uint32("unix::gid", 0)
-        file_info.set_attribute_uint32("unix::mode", 0o755 | stat.S_IFDIR)
-
-        dirmeta = OSTree.create_directory_metadata(file_info, None)
-        csum_dirmeta = repo.write_metadata(OSTree.ObjectType.DIR_META, None, dirmeta)[1]
-        mtree.set_metadata_checksum(OSTree.checksum_from_bytes(csum_dirmeta))
-
-        root = repo.write_mtree(mtree)[1]
-        csum = repo.write_commit(None, "", None, metadata, root)[1]
-        repo.transaction_set_ref(None, imagebranch, csum)
-
-        repo.commit_transaction(None)
-
     def _pull_docker_image(self, image):
         with tempfile.NamedTemporaryFile(mode="w") as temptar:
             util.check_call(["docker", "save", "-o", temptar.name, image])
@@ -2417,40 +2344,6 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         if not repo:
             return False
         return bool(self._resolve_image(repo, img, allow_multiple=True))
-
-    def _pull_dockertar_layers(self, repo, imagebranch, temp_dir, input_layers, labels=None):
-        layers = {}
-        next_layer = {}
-        top_layer = None
-        for i in input_layers:
-            layer = i.replace("/layer.tar", "")
-            layers[layer] = os.path.join(temp_dir, i)
-            with open(os.path.join(temp_dir, layer, "json"), 'r') as f:
-                json_layer = json.loads(f.read())
-                parent = json_layer.get("parent")
-                if not parent:
-                    top_layer = layer
-                next_layer[parent] = layer
-
-        layers_map = {}
-        enc = sys.getdefaultencoding()
-        for k, v in layers.items():
-            out = util.check_output([ATOMIC_LIBEXEC + '/dockertar-sha256-helper', v],
-                                    stderr=DEVNULL)
-            layers_map[k] = out.decode(enc).replace("\n", "")
-        layers_ordered = []
-
-        it = top_layer
-        while it:
-            layers_ordered.append(layers_map[it])
-            it = next_layer.get(it)
-
-        manifest = json.dumps({"Layers" : layers_ordered, "Labels" : labels})
-
-        layers_to_import = {}
-        for k, v in layers.items():
-            layers_to_import[layers_map[k]] = v
-        self._import_layers_into_ostree(repo, imagebranch, manifest, layers_to_import)
 
     def validate_layer(self, layer):
         """

--- a/tests/integration/setup-scripts/system_containers_setup.sh
+++ b/tests/integration/setup-scripts/system_containers_setup.sh
@@ -43,3 +43,7 @@ export PYTHON=${PYTHON:-/usr/bin/python}
 export ATOMIC_OSTREE_REPO=${WORK_DIR}/repo
 export ATOMIC_OSTREE_CHECKOUT_PATH=${WORK_DIR}/checkout
 export NAME="test-system-container-$$"
+
+# This is to prevent the case where the ostree checkout path
+# can be non-existent when no container installation happens prior
+mkdir -p $ATOMIC_OSTREE_CHECKOUT_PATH

--- a/tests/integration/test_system_containers_images.sh
+++ b/tests/integration/test_system_containers_images.sh
@@ -120,7 +120,7 @@ def make_number(x):
 def is_different(x, y):
     x = make_number(x)
     y = make_number(y)
-    return abs(x - y) > x * 0.01
+    return abs(x - y) > x * 0.04
 
 _sizes = [str(i["virtual_size"]) for i in json.load(sys.stdin) if i['repo']=='atomic-test-system']
 sizes = [size for size in _sizes if size != '']

--- a/tests/integration/test_system_containers_pull.sh
+++ b/tests/integration/test_system_containers_pull.sh
@@ -1,0 +1,65 @@
+#!/bin/bash -x
+set -euo pipefail
+IFS=$'\n\t'
+
+. ./tests/integration/setup-scripts/system_containers_setup.sh
+
+# The pull test of system containers, mainly to
+# test out the new usage of skopeo copy, it covers
+# 1: pull dockertar with a custom name (dockertar:customimagename)
+# 2: pull dockertar with same image name (dockertar:image)
+# 3: pull from docker daemon (docker:)
+
+teardown() {
+    set +o pipefail
+
+    # For now, we only delete the refs from ostree
+    ostree --repo=${ATOMIC_OSTREE_REPO} refs --delete ociimage &> /dev/null || true
+
+    # Remove the generated tar file to avoid affecting other tests
+    rm -rf ${WORK_DIR}/atomic-test-random-name || true
+    rm -rf ${WORK_DIR}/atomic-test-system || true
+}
+
+check_image_existence() {
+    image_name=$1; shift
+    ref_name=$1; shift
+
+    # Check for image appearance
+    ${ATOMIC} images list -f type=ostree > ${WORK_DIR}/images.out
+    assert_matches $image_name ${WORK_DIR}/images.out
+
+    # Check for ostree refs
+    ostree --repo=${ATOMIC_OSTREE_REPO} refs > ${WORK_DIR}/ostree_refs.out
+    assert_matches $ref_name ${WORK_DIR}/ostree_refs.out
+}
+
+cleanup_image() {
+    image_name=$1
+    ${ATOMIC} --assumeyes images delete -f --storage ostree $image_name
+    ${ATOMIC} images prune
+    ${ATOMIC} images list -f type=ostree > ${WORK_DIR}/images.out
+    assert_not_matches $image_name ${WORK_DIR}/images.out
+}
+
+trap teardown EXIT
+
+OUTPUT=$(/bin/true)
+
+# 1: Pull docker tar and check from image list
+docker save -o ${WORK_DIR}/atomic-test-random-name atomic-test-system
+${ATOMIC} pull --storage ostree dockertar:/${WORK_DIR}/atomic-test-random-name
+check_image_existence "atomic-test-system" "ociimage/atomic-test-system_3Alatest"
+cleanup_image "atomic-test-system"
+
+# 2: Pull docker tar with default name and check image
+docker save atomic-test-system > ${WORK_DIR}/atomic-test-system
+${ATOMIC} pull --storage ostree dockertar:/${WORK_DIR}/atomic-test-system
+check_image_existence "atomic-test-system" "ociimage/atomic-test-system_3Alatest"
+cleanup_image "atomic-test-system"
+
+# 3: Pull from local docker and check
+${ATOMIC} pull --storage ostree docker:atomic-test-system:latest
+check_image_existence "atomic-test-system" "ociimage/atomic-test-system_3Alatest"
+cleanup_image "atomic-test-system"
+


### PR DESCRIPTION
Based on discussion, skopeo is assumed to include support for
ostree copy from now on.

The users will now be noted to install the newest version
if their skopeo version does not support copy to ostree.

## Related Issue Numbers
- https://github.com/projectatomic/atomic/issues/1177
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [x] Integration Tests
