### PR TITLE
syscontainer: fix for missing images display in ostree backend

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1702,7 +1702,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             if repo is None:
                 return []
         revs = [x for x in repo.list_refs()[1] if x.startswith(OSTREE_OCIIMAGE_PREFIX) \
-                and (get_all or SystemContainers.is_hex(get_img_ref_str(x)))]
+                and (get_all or not SystemContainers.is_hex(get_img_ref_str(x)))]
 
         return [self._inspect_system_branch(repo, x) for x in revs]
 

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1623,12 +1623,13 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         commit = repo.load_commit(commit_rev)[1]
 
         timestamp = OSTree.commit_get_timestamp(commit)
-        branch_id = SystemContainers._decode_from_ostree_ref(imagebranch.replace(OSTREE_OCIIMAGE_PREFIX, ""))
+        img_ref_str = SystemContainers._get_img_ref_str(imagebranch)
+        branch_id = SystemContainers._decode_from_ostree_ref(img_ref_str)
 
         image_id = commit_rev
         id_ = None
 
-        if SystemContainers.is_hex(branch_id):
+        if SystemContainers._is_hex(branch_id):
             image_id = branch_id
             tag = "<none>"
         elif '@sha256:' in branch_id:
@@ -1694,20 +1695,21 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         :returns: A list of image data structures.
         :rtype: list
         """
-        def get_img_ref_str(ostree_ref_str):
-            return ostree_ref_str.replace(OSTREE_OCIIMAGE_PREFIX, "")
-
         if repo is None:
             repo = self._get_ostree_repo()
             if repo is None:
                 return []
         revs = [x for x in repo.list_refs()[1] if x.startswith(OSTREE_OCIIMAGE_PREFIX) \
-                and (get_all or not SystemContainers.is_hex(get_img_ref_str(x)))]
+                and (get_all or not SystemContainers._is_hex(SystemContainers._get_img_ref_str(x)))]
 
         return [self._inspect_system_branch(repo, x) for x in revs]
 
     @staticmethod
-    def is_hex(s):
+    def _get_img_ref_str(ostree_ref_str):
+        return ostree_ref_str.replace(OSTREE_OCIIMAGE_PREFIX, "")
+
+    @staticmethod
+    def _is_hex(s):
         try:
             int(s, 16)
             return True
@@ -1923,8 +1925,8 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
 
         for i in repo.list_refs()[1]:
             if i.startswith(OSTREE_OCIIMAGE_PREFIX):
-                img_ref_str = i.replace(OSTREE_OCIIMAGE_PREFIX, "")
-                if SystemContainers.is_hex(img_ref_str):
+                img_ref_str = SystemContainers._get_img_ref_str(i)
+                if SystemContainers._is_hex(img_ref_str):
                     refs[i] = False
                 else:
                     invalid_encoding = False

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1628,7 +1628,8 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         image_id = commit_rev
         id_ = None
 
-        if SystemContainers.is_hex(branch_id):
+        is_layer_ref = SystemContainers.is_hex(branch_id) and len(branch_id) == 64
+        if is_layer_ref:
             image_id = branch_id
             tag = "<none>"
         elif '@sha256:' in branch_id:

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1628,7 +1628,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         image_id = commit_rev
         id_ = None
 
-        if len(branch_id) == 64:
+        if SystemContainers.is_hex(branch_id):
             image_id = branch_id
             tag = "<none>"
         elif '@sha256:' in branch_id:
@@ -1694,14 +1694,25 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         :returns: A list of image data structures.
         :rtype: list
         """
+        def get_img_ref_str(ostree_ref_str):
+            return ostree_ref_str.replace(OSTREE_OCIIMAGE_PREFIX, "")
+
         if repo is None:
             repo = self._get_ostree_repo()
             if repo is None:
                 return []
         revs = [x for x in repo.list_refs()[1] if x.startswith(OSTREE_OCIIMAGE_PREFIX) \
-                and (get_all or len(x) != len(OSTREE_OCIIMAGE_PREFIX) + 64)]
+                and (get_all or SystemContainers.is_hex(get_img_ref_str(x)))]
 
         return [self._inspect_system_branch(repo, x) for x in revs]
+
+    @staticmethod
+    def is_hex(s):
+        try:
+            int(s, 16)
+            return True
+        except ValueError:
+            return False
 
     def _is_service_active(self, name):
         try:
@@ -1912,11 +1923,12 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
 
         for i in repo.list_refs()[1]:
             if i.startswith(OSTREE_OCIIMAGE_PREFIX):
-                if len(i) == len(OSTREE_OCIIMAGE_PREFIX) + 64:
+                img_ref_str = i.replace(OSTREE_OCIIMAGE_PREFIX, "")
+                if SystemContainers.is_hex(img_ref_str):
                     refs[i] = False
                 else:
                     invalid_encoding = False
-                    for c in i.replace(OSTREE_OCIIMAGE_PREFIX, ""):
+                    for c in img_ref_str:
                         if not str.isalnum(str(c)) and c not in '.-_':
                             invalid_encoding = True
                             break

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1628,8 +1628,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         image_id = commit_rev
         id_ = None
 
-        is_layer_ref = SystemContainers.is_hex(branch_id) and len(branch_id) == 64
-        if is_layer_ref:
+        if SystemContainers.is_hex(branch_id):
             image_id = branch_id
             tag = "<none>"
         elif '@sha256:' in branch_id:

--- a/tests/unit/test_syscontainers.py
+++ b/tests/unit/test_syscontainers.py
@@ -317,8 +317,8 @@ class TestSystemContainers_miscellaneous(unittest.TestCase):
         self.assertTrue(qual_img_with_tag_ref.endswith("_3Atag"))
 
         non_qual_img_without_tag_ref = SystemContainers._encode_to_ostree_ref(non_qual_img_without_tag)
-        self.assertFalse(SystemContainers.is_hex(non_qual_img_without_tag_ref))
-
+        ref_is_hex = SystemContainers._is_hex(non_qual_img_without_tag_ref)
+        self.assertFalse(ref_is_hex)
         non_qual_img_with_tag_ref = SystemContainers._encode_to_ostree_ref(non_qual_img_with_tag)
         self.assertTrue(non_qual_img_with_tag_ref.endswith("_3Atag"))
 

--- a/tests/unit/test_syscontainers.py
+++ b/tests/unit/test_syscontainers.py
@@ -304,6 +304,10 @@ class TestSystemContainers_miscellaneous(unittest.TestCase):
         when calling _encode_to_ostree_ref
         """
 
+        def ensure_ref_is_not_hex(ref):
+            ref_is_hex = SystemContainers._is_hex(ref)
+            self.assertFalse(ref_is_hex)
+
         qual_img_without_tag = "registry.fedoraproject.org/f27/kubernetes-apiserver"
         qual_img_with_tag = qual_img_without_tag + ":tag"
         non_qual_img_without_tag = "cafe"
@@ -311,16 +315,19 @@ class TestSystemContainers_miscellaneous(unittest.TestCase):
 
         qual_img_without_tag_ref = SystemContainers._encode_to_ostree_ref(qual_img_without_tag)
         self.assertTrue(qual_img_without_tag_ref.endswith("latest"))
+        ensure_ref_is_not_hex(qual_img_without_tag_ref)
 
         # The encoded ref will have ":" translated to _3A (unicode)
         qual_img_with_tag_ref = SystemContainers._encode_to_ostree_ref(qual_img_with_tag)
         self.assertTrue(qual_img_with_tag_ref.endswith("_3Atag"))
+        ensure_ref_is_not_hex(qual_img_with_tag_ref)
 
         non_qual_img_without_tag_ref = SystemContainers._encode_to_ostree_ref(non_qual_img_without_tag)
-        ref_is_hex = SystemContainers._is_hex(non_qual_img_without_tag_ref)
-        self.assertFalse(ref_is_hex)
+        ensure_ref_is_not_hex(non_qual_img_without_tag_ref)
+
         non_qual_img_with_tag_ref = SystemContainers._encode_to_ostree_ref(non_qual_img_with_tag)
         self.assertTrue(non_qual_img_with_tag_ref.endswith("_3Atag"))
+        ensure_ref_is_not_hex(non_qual_img_with_tag_ref)
 
 @unittest.skipIf(no_mock, "Mock not found")
 class TestSystemContainers_container_exec(unittest.TestCase):

--- a/tests/unit/test_syscontainers.py
+++ b/tests/unit/test_syscontainers.py
@@ -292,6 +292,37 @@ class TestSystemContainers_do_checkout(unittest.TestCase):
         self.assertEqual(rpm_install_output_third["new_installed_files_checksum"], expected_checksum)
 
 @unittest.skipIf(no_mock, "Mock not found")
+class TestSystemContainers_miscellaneous(unittest.TestCase):
+    """
+    Unit tests for general / utility functions in syscontainers.py
+    """
+    def test_encode_to_ostree_ref(self):
+        """
+        Verify that 1: image after encoded to ostree ref will be no longer hex
+        2: image contains no tag will have tag latest appended
+        3: qualified image(image with registry included) and non-qualified image will behave in the same way
+        when calling _encode_to_ostree_ref
+        """
+
+        qual_img_without_tag = "registry.fedoraproject.org/f27/kubernetes-apiserver"
+        qual_img_with_tag = qual_img_without_tag + ":tag"
+        non_qual_img_without_tag = "cafe"
+        non_qual_img_with_tag = non_qual_img_without_tag + ":tag"
+
+        qual_img_without_tag_ref = SystemContainers._encode_to_ostree_ref(qual_img_without_tag)
+        self.assertTrue(qual_img_without_tag_ref.endswith("latest"))
+
+        # The encoded ref will have ":" translated to _3A (unicode)
+        qual_img_with_tag_ref = SystemContainers._encode_to_ostree_ref(qual_img_with_tag)
+        self.assertTrue(qual_img_with_tag_ref.endswith("_3Atag"))
+
+        non_qual_img_without_tag_ref = SystemContainers._encode_to_ostree_ref(non_qual_img_without_tag)
+        self.assertFalse(SystemContainers.is_hex(non_qual_img_without_tag_ref))
+
+        non_qual_img_with_tag_ref = SystemContainers._encode_to_ostree_ref(non_qual_img_with_tag)
+        self.assertTrue(non_qual_img_with_tag_ref.endswith("_3Atag"))
+
+@unittest.skipIf(no_mock, "Mock not found")
 class TestSystemContainers_container_exec(unittest.TestCase):
     """
     Unit tests for the SystemContainres.container_exec method.


### PR DESCRIPTION
This fixes https://github.com/projectatomic/atomic/issues/1179.

Before, we assumed the image ref with 64 characters is default to
image layers(images with repository <none>), but as issue 1179
pointed out, there are some exceptions.

We now migrated to check if the ref is hex. If the ref is hex, we
can conclude it should be images with repository <none>


## Description


## Related Bugzillas
-
-

## Related Issue Numbers
- https://github.com/projectatomic/atomic/issues/1179.
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
