### PR TITLE
backendutils: fix crash when Docker is not running

### DIFF
--- a/Atomic/backendutils.py
+++ b/Atomic/backendutils.py
@@ -51,9 +51,6 @@ class BackendUtils(object):
     def _get_backend(self, backend):
         return self.get_backend_from_string(backend, init=False)
 
-    def _get_backend_index_from_string(self, str_backend):
-        return [x().backend for x in self.BACKENDS].index(str_backend)
-
     @staticmethod
     def backend_has_image(backend, img):
         return True if backend.has_image(img) else False
@@ -85,7 +82,8 @@ class BackendUtils(object):
             if required:
                 raise ValueError("Unable to find {} in the {} backend".format(img, str_preferred_backend))
             # Didnt find in preferred, need to remove it from the list now
-            del backends[self._get_backend_index_from_string(str_preferred_backend)]
+            if be in backends:
+                del backends[backends.index(be)]
 
         # Did not find it in the preferred backend, keep looking
         img_in_backends = []
@@ -126,7 +124,8 @@ class BackendUtils(object):
             if required:
                 raise ValueError("Unable to find {} in the {} backend".format(container_name, str_preferred_backend))
             # Didnt find in preferred, need to remove it from the list now
-            del backends[self._get_backend_index_from_string(str_preferred_backend)]
+            if be in backends:
+                del backends[backends.index(be)]
 
         container_in_backends = []
         for backend in backends:


### PR DESCRIPTION
_get_backend_index_from_string returned a wrong index as it considers
all the backends supported, not the current ones available.

Take rid of the function and lookup directly into the available backends
list.

Fix this exception:

Namespace(_class=<class 'Atomic.uninstall.Uninstall'>, args=[], assumeyes=False, debug=True, display=False, force=False, func='uninstall', ignore=False, image='etcd', name=None, opt1=None, opt2=None, opt3=None, profile=False, storage='ostree')
list assignment index out of range
Traceback (most recent call last):
  File "./atomic", line 185, in <module>
    sys.exit(_func())
  File "atomic/Atomic/uninstall.py", line 54, in uninstall
    be, img_obj = beu.get_backend_and_image_obj(self.args.image, str_preferred_backend=self.args.storage)
  File "atomic/Atomic/backendutils.py", line 88, in get_backend_and_image_obj
    del backends[self._get_backend_index_from_string(str_preferred_backend)]
IndexError: list assignment index out of range

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
