### PR TITLE
ci: use centos/7/atomic/smoketested

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -28,7 +28,7 @@ timeout: 30m
 inherit: true
 
 host:
-  distro: centos/7/atomic/alpha
+  distro: centos/7/atomic/smoketested
   specs:
     secondary-disk: 10
 


### PR DESCRIPTION
The `/alpha` image has been deprecated a while ago and now no longer
exists. Use the `/smoketested` image instead. For more information, see:

https://github.com/projectatomic/papr/blob/master/docs/DISTROS.md