### PR TITLE
syscontainers: correctly setup the rootfs SELinux label

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -17,6 +17,7 @@ from ctypes import cdll, CDLL
 import uuid
 from .rpm_host_install import RPMHostInstall, RPM_NAME_PREFIX
 import __main__
+import selinux
 
 try:
     import gi
@@ -226,6 +227,19 @@ class SystemContainers(object):
         # Same entrypoint
         return self.install(image, name)
 
+    def _create_rootfs(self, rootfs):
+        """
+        Ensure the rootfs directory exists and it has the correct SELinux label.
+        """
+        if os.getuid() == 0 and selinux.is_selinux_enabled() != 0:
+            label = selinux.getfilecon("/")[1]
+            selinux.setfscreatecon_raw(label)
+
+        try:
+            os.makedirs(rootfs)
+        finally:
+            selinux.setfscreatecon_raw(None)
+
     def build_rpm(self, repo, name, image, values, destination):
         """
         Create a checkout and generate an RPM file
@@ -247,7 +261,7 @@ class SystemContainers(object):
         temp_dir = tempfile.mkdtemp()
         rpm_content = os.path.join(temp_dir, "rpmroot")
         rootfs = os.path.join(rpm_content, "usr/lib/containers/atomic", name)
-        os.makedirs(rootfs)
+        self._create_rootfs(rootfs)
         try:
             self._checkout_wrapper(repo, name, image, 0, SystemContainers.CHECKOUT_MODE_INSTALL, values=values, destination=rootfs, prefix=rpm_content)
             if self.display:
@@ -358,7 +372,7 @@ class SystemContainers(object):
                 os.makedirs(destination)
         else:
             if not os.path.exists(rootfs):
-                os.makedirs(rootfs)
+                self._create_rootfs(rootfs)
         return rootfs
 
     def _write_config_to_dest(self, destination, exports_dir, values=None):
@@ -581,7 +595,7 @@ class SystemContainers(object):
         mounted_from_storage = False
         try:
             rootfs = os.path.sep.join([base_dir, 'rootfs'])
-            os.makedirs(rootfs)
+            self._create_rootfs(rootfs)
             try:
                 upperdir = os.path.sep.join([base_dir, 'upperdir'])
                 workdir = os.path.sep.join([base_dir, 'workdir'])
@@ -2537,7 +2551,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             layers_dir.append(rootfs)
             if os.path.exists(rootfs):
                 continue
-            os.makedirs(rootfs)
+            self._create_rootfs(rootfs)
             rootfs_fd = None
             try:
                 rootfs_fd = os.open(rootfs, os.O_DIRECTORY)

--- a/tests/integration/test_system_containers_install.sh
+++ b/tests/integration/test_system_containers_install.sh
@@ -59,6 +59,9 @@ test -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.0/tmpfiles-${NAME}.conf
 test -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.0/config.json
 test -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.0/info
 
+if sestatus | grep "SELinux status:.*enabled"; then
+    test "$(stat -c%C /)" = "$(stat -c%C ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.0/rootfs)"
+fi
 
 # 2. Check the value we set (--set) is exported into the config file
 assert_matches ${SECRET} ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.0/config.json


### PR DESCRIPTION
The files inside the container are labelled by Skopeo when the image is
pulled to the OSTree storage.

Instead the root directory is created by atomic and by default it gets
the label "unconfined_u:object_r:container_share_t:s0".

Make sure we label it with the same label of '/'.

We have changed the way files are labelled by Skopeo but we forgot to change

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1544175

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
