### PR TITLE
syscontainers: implement "run IMAGE"

### DIFF
--- a/Atomic/backends/_ostree.py
+++ b/Atomic/backends/_ostree.py
@@ -165,11 +165,7 @@ class OSTreeBackend(Backend):
 
     def run(self, iobject, **kwargs):
         args = kwargs.get('args')
-        try:
-            name = iobject.name
-        except AttributeError:  # iobject isn't populated
-            raise ValueError('Unable to find an image named {} in {}'.format(
-                args.image, args.storage))
+        name = args.image
         if len(args.command) == 0:
             return self.syscontainers.start_service(name)
         self.syscontainers.set_args(args)

--- a/Atomic/backends/_ostree.py
+++ b/Atomic/backends/_ostree.py
@@ -172,6 +172,7 @@ class OSTreeBackend(Backend):
                 args.image, args.storage))
         if len(args.command) == 0:
             return self.syscontainers.start_service(name)
+        self.syscontainers.set_args(args)
         return self.syscontainers.container_exec(name, args.detach, args.command)
 
     def tag_image(self, src, dest):

--- a/Atomic/backends/_ostree.py
+++ b/Atomic/backends/_ostree.py
@@ -166,6 +166,8 @@ class OSTreeBackend(Backend):
     def run(self, iobject, **kwargs):
         args = kwargs.get('args')
         name = args.image
+        if args.name is not None:
+            raise ValueError("--name is not supported by this backend")
         if len(args.command) == 0:
             return self.syscontainers.start_service(name)
         self.syscontainers.set_args(args)

--- a/Atomic/run.py
+++ b/Atomic/run.py
@@ -4,6 +4,7 @@ from Atomic.backendutils import BackendUtils
 from Atomic.backends._docker import DockerBackend
 from . import util
 from Atomic.discovery import RegistryInspectError
+from .syscontainers import OSTREE_PRESENT
 
 try:
     from . import Atomic
@@ -59,6 +60,11 @@ def cli(subparser):
                              Run.print_spc()))
     runp.add_argument("-d", "--detach", default=False, action="store_true",
                       help=_("run the container in the background"))
+    if OSTREE_PRESENT:
+        runp.add_argument("--set", dest="setvalues",
+                          action='append',
+                          help=_("specify a variable in the VARIABLE=VALUE "
+                                 "form for a system container"))
     runp.add_argument("image", help=_("container image"))
     runp.add_argument("command", nargs=argparse.REMAINDER,
                       help=_("command to execute within the container. "

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -2665,6 +2665,7 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
             repo = self._get_ostree_repo()
             if not repo:
                 raise ValueError("Cannot find a configured OSTree repo")
+            name = self._pull_image_to_ostree(repo, name, False)
             return self._run_once(name, "run-once-{}".format(os.getpid()), args=args)
 
         is_container_running = self._is_service_active(name)

--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -642,7 +642,7 @@ class SystemContainers(object):
                 with open(template_tmpfiles, 'r') as infile:
                     tmp = os.path.sep.join([base_dir, 'tmpfiles.conf'])
                     util.write_template(template_tmpfiles, infile.read(), values, tmp)
-                    self._systemd_tmpfiles("--create", tmp)
+                    self._systemd_tmpfiles("--create", tmp, quiet=True)
                     tmpfiles_destination = tmp
 
             # Get the start command for the system container
@@ -655,7 +655,7 @@ class SystemContainers(object):
         finally:
             if tmpfiles_destination:
                 try:
-                    self._systemd_tmpfiles("--remove", tmpfiles_destination)
+                    self._systemd_tmpfiles("--remove", tmpfiles_destination, quiet=True)
                 except subprocess.CalledProcessError:
                     pass
             # Remove the temporary checkout
@@ -1789,9 +1789,10 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         except subprocess.CalledProcessError as e:
             raise ValueError(e.output)
 
-    def _systemd_tmpfiles(self, command, name):
+    def _systemd_tmpfiles(self, command, name, quiet=False):
         cmd = ["systemd-tmpfiles"] + [command, name]
-        util.write_out(" ".join(cmd))
+        if not quiet:
+            util.write_out(" ".join(cmd))
         if not self.display:
             util.check_call(cmd)
 

--- a/bash/atomic
+++ b/bash/atomic
@@ -677,8 +677,9 @@ _atomic_run() {
 	local all_options="$options_with_args
 		--help
 		--spc
+                --set
 	       --display
-	--quiet
+	       --quiet
 	       --replace
 	    --storage
 	"

--- a/docs/atomic-run.1.md
+++ b/docs/atomic-run.1.md
@@ -12,6 +12,7 @@ atomic-run - Execute container image run method
 [**-r**, **--replace**]
 [**--spc**]
 [**--storage**]
+[**--set**=*NAME*=*VALUE*]
 [**--quiet**]
 IMAGE [COMMAND] [ARG...]
 
@@ -85,9 +86,14 @@ NAME will default to the IMAGENAME if it is not specified.
 
 `/usr/bin/docker run -t -i --rm --privileged -v /:/host -v /run:/run --net=host --ipc=host --pid=host -e HOST=/host -e NAME=${NAME} -e IMAGE=${IMAGE} --name ${NAME} ${IMAGE}`
 
-**-storage**
+**--storage**
    Allows you to override the default definition for the storage backend where your image will reside if pulled.  If the image is already local,
 the --storage option will dictate where atomic should look for the image prior to running. Valid options are `docker` and `ostree`.
+
+**--set=NAME=VALUE**
+Set a value that is going to be used by a system container for its
+configuration and can be specified multiple times.  It is used only
+by --system.  OSTree is required for this feature to be available.
 
 
 **--quiet**

--- a/tests/integration/test_system_containers_install.sh
+++ b/tests/integration/test_system_containers_install.sh
@@ -141,6 +141,9 @@ ${ATOMIC} pull --storage ostree docker:atomic-test-runonce:latest
 ${ATOMIC} install --system --name=${NAME} --set RECEIVER=Pluto atomic-test-runonce:latest > ${WORK_DIR}/ps.out
 assert_matches "HI Pluto from Saturn" ${WORK_DIR}/ps.out
 
+${ATOMIC} run --storage ostree --set RECEIVER=Pluto atomic-test-runonce:latest echo Hello World > ${WORK_DIR}/ps.out
+assert_matches "Hello World" ${WORK_DIR}/ps.out
+
 test \! -e /etc/systemd/system/${NAME}.service
 test \! -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}
 test \! -e ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}.0


### PR DESCRIPTION
Implement "run --storage ostree IMAGE" so that the image is installed and executed interactively.

I've implemented it so we can replace a call to docker run in the Open Shift installer:

https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_version/tasks/first_master_containerized_version.yml#L22

that could be better done with atomic since we already need the image to run the master.

Another use case in the future could be to run containers such as Buildah, something like:

`atomic run --storage ostree registry.org/buildah bud /host/$(PWD)/ .`