### PR TITLE
Provide scanner with image name and info

### DIFF
--- a/Atomic/scan.py
+++ b/Atomic/scan.py
@@ -154,6 +154,9 @@ class Scan(Atomic):
         # Create the output directory
         os.makedirs(self.results_dir)
 
+        # Record target information
+        self.record_inspect_info()
+
         docker_args = ['docker', 'run', '-t', '--rm', '-v', '/etc/localtime:/etc/localtime',
                        '-v', '{}:{}'.format(self.chroot_dir, '/scanin'), '-v',
                        '{}:{}:rw,Z'.format(self.results_dir, '/scanout')]
@@ -536,3 +539,18 @@ class Scan(Atomic):
 
     def remediate(self, script, iid, results_dir):
         util.check_call([sys.executable, script, '--id', iid, '--results_dir', results_dir])
+
+
+    def record_inspect_info(self):
+        """
+        Writes inspect information for each object passed to the scanner and
+        stores them in results_dir/inspect_info.json
+        :return: None
+        """
+
+        inspect = []
+        for scan_object in self.scan_list:
+            inspect.append(scan_object.config)
+
+        with open(os.path.join(self.results_dir, 'inspect_info.json'), 'w') as f:
+            json.dump(inspect, f, indent=4, separators=(',', ': '))


### PR DESCRIPTION
Issue #1190 asks for an enhancement to atomic scan where
the scanner could figure out the image|container inspect
information prior to the scan.  We do this now by writing
a file in the scanout/ dir.  The file is JSON formatted
and could be ingested by a scanner that needed that type
of information.  The path should bexi
/scanout/inspect_info.json.

Signed-off-by: baude <bbaude@redhat.com>


## Description


## Related Bugzillas
-
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
