### PR TITLE
run: add option --runtime

### DIFF
--- a/Atomic/run.py
+++ b/Atomic/run.py
@@ -60,6 +60,8 @@ def cli(subparser):
                              Run.print_spc()))
     runp.add_argument("-d", "--detach", default=False, action="store_true",
                       help=_("run the container in the background"))
+    runp.add_argument("--runtime", dest="runtime", default=None,
+                      help=_('specify the OCI runtime to use for system and user containers'))
     if OSTREE_PRESENT:
         runp.add_argument("--set", dest="setvalues",
                           action='append',

--- a/bash/atomic
+++ b/bash/atomic
@@ -681,7 +681,8 @@ _atomic_run() {
 	       --display
 	       --quiet
 	       --replace
-	    --storage
+	       --runtime
+	       --storage
 	"
 
 	[ "$command" = "run" ] && all_options="$all_options"

--- a/docs/atomic-install.1.md
+++ b/docs/atomic-install.1.md
@@ -75,8 +75,8 @@ Change the OCI runtime used by the systemd service file for running
 system containers and user containers.  If runtime is not defined, the
 value **runtime** in the configuration file is used for system
 containers.  If there is no runtime defined in the configuration file
-as well, then the default **/bin/runc** is used for system containers.
-Conversely, for user containers the default value is **/bin/bwrap-oci**.
+as well, then the default **/usr/bin/runc** is used for system containers.
+Conversely, for user containers the default value is **/usr/bin/bwrap-oci**.
 
 **--set=NAME=VALUE**
 Set a value that is going to be used by a system container for its

--- a/docs/atomic-run.1.md
+++ b/docs/atomic-run.1.md
@@ -80,6 +80,14 @@ NAME will default to the IMAGENAME if it is not specified.
 
 **-r** **--replace**
    Replaces an existing container by the same name if it exists prior to running.
+
+**--runtime=PATH**
+   Change the OCI runtime used by the systemd service file for running
+   system containers and user containers.  If runtime is not defined, the
+   value **runtime** in the configuration file is used for system
+   containers.  If there is no runtime defined in the configuration file
+   as well, then the default **/usr/bin/runc** is used for system containers.
+   Conversely, for user containers the default value is **/usr/bin/bwrap-oci**.
    
 **--spc**
   Run container in super privileged container mode.  The image will run with the following command:

--- a/tests/integration/test_system_containers_runtime.sh
+++ b/tests/integration/test_system_containers_runtime.sh
@@ -61,6 +61,9 @@ systemctl start ${NAME}.service
 ${ATOMIC} run --storage ostree ${NAME} echo hello world again < /dev/null > ${WORK_DIR}/status.out
 assert_matches "hello world again" ${WORK_DIR}/status.out
 
+${ATOMIC} run --runtime /usr/bin/runc --storage ostree ${NAME} echo hello world < /dev/null > ${WORK_DIR}/status.out
+assert_matches "hello world" ${WORK_DIR}/status.out
+
 # Check the service is running
 systemctl status ${NAME}.service > ${WORK_DIR}/status.out
 assert_matches "Active: active (running)" ${WORK_DIR}/status.out


### PR DESCRIPTION
it allows to select a different OCI runtime to use for "atomic run --storage ostree"