### PR TITLE
syscontainers: drop pull from a remote ostree

### DIFF
--- a/Atomic/install.py
+++ b/Atomic/install.py
@@ -182,7 +182,7 @@ class Install(Atomic):
 
     @staticmethod
     def ostree_uri(image_name):
-        for i in ['dockertar:', 'ostree:', 'docker:']:
+        for i in ['dockertar:', 'docker:']:
             if image_name.startswith(i):
                 return True
         return False

--- a/docs/atomic-pull.1.md
+++ b/docs/atomic-pull.1.md
@@ -45,12 +45,6 @@ that the saved tarball is specified:
 
 `atomic pull --storage ostree dockertar:/path/to/the/image.tar`
 
-An 'ostree' image refers to an image which is fetched from a remote
-OSTree repository.  The remote has to be already configured in the
-local OSTree repository:
-
-`atomic pull --storage ostree ostree:REMOTE/branch`
-
 If the user is not privileged, the image will be stored in the user
 specific repository.
 


### PR DESCRIPTION
this code was added for pulling directly from an OSTree repository.  It
wasn't never really used and it expects the image to be fully exploded
in an ostree commit without supporting OCI layers.

Dropping this part also avoid confusion with what we do with Skopeo
where "ostree:" is supported both as source and destination.

Closes: https://github.com/projectatomic/atomic/issues/1193

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
