### PR TITLE
syscontainers: rebase pulls the image when missing

### DIFF
--- a/Atomic/syscontainers.py
+++ b/Atomic/syscontainers.py
@@ -1340,6 +1340,9 @@ Warning: You may want to modify `%s` before starting the service""" % os.path.jo
         if os.path.realpath(path).endswith(".0"):
             next_deployment = 1
 
+        if rebase:
+            rebase = self._pull_image_to_ostree(repo, rebase, False)
+
         info, rpm_installed, installed_files_checksum = SystemContainers._gather_installed_files_info(system_checkout_path, name)
         image = rebase or info["image"]
         values = info["values"]

--- a/tests/integration/test_system_containers_runtime.sh
+++ b/tests/integration/test_system_containers_runtime.sh
@@ -20,6 +20,7 @@ IFS=$'\n\t'
 setup () {
     ${ATOMIC} pull --storage ostree docker:atomic-test-system:latest
     ${ATOMIC} pull --storage ostree docker:atomic-test-system-update:latest
+    docker tag atomic-test-system:latest atomic-test-system-new:latest
 }
 
 teardown () {
@@ -224,6 +225,9 @@ assert_matches "running" ${WORK_DIR}/ps.out
 ${ATOMIC} containers rollback ${NAME}
 assert_matches ${SECRET} ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}/config.json
 assert_matches 8083 ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME}/config.json
+
+# Update can rebase to an image not present in the repository.
+${ATOMIC} containers update ${NAME} --rebase docker:atomic-test-system-new:latest > ${WORK_DIR}/update.out
 
 
 # 10. Updating/rolling back an image with a remote rootfs works


### PR DESCRIPTION
atomic containers update --rebase=$TO $CONTAINER attempts to pull the
image if it is missing in the repository.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
