### PR TITLE
images: add cache for dangling images

### DIFF
--- a/Atomic/backends/_containers_storage.py
+++ b/Atomic/backends/_containers_storage.py
@@ -224,7 +224,7 @@ class ContainersStorageBackend(Backend): #pylint: disable=metaclass-assignment
             image_objects.append(self._make_image(image['id'], image))
         return image_objects
 
-    def get_dangling_images(self):
+    def get_dangling_images(self, force_update=True):
         images = json.loads(util.kpod(["images", "--filter", "dangling=true", "--format", "json"]))
         return [x['id'] for x in images]
 

--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -76,6 +76,7 @@ class DockerBackend(Backend):
     def __init__(self):
         self.input = None
         self._d = None
+        self._dangling_images = None
 
     @property
     def available(self):
@@ -411,8 +412,10 @@ class DockerBackend(Backend):
             util.write_out("Removed dangling Image {}".format(iid))
         return 0
 
-    def get_dangling_images(self):
-        return self._get_images(get_all=True, quiet=True, filters={"dangling": True})
+    def get_dangling_images(self, force_update=True):
+        if self._dangling_images == None or force_update:
+            self._dangling_images = self._get_images(get_all=True, quiet=True, filters={"dangling": True})
+        return self._dangling_images
 
     def install(self, image, name, **kwargs):
         pass

--- a/Atomic/backends/_ostree.py
+++ b/Atomic/backends/_ostree.py
@@ -149,7 +149,7 @@ class OSTreeBackend(Backend):
         return layers
 
     @staticmethod
-    def get_dangling_images():
+    def get_dangling_images(force_update=True):  # pylint: disable=unused-argument
         return []
 
     def make_remote_image(self, image):

--- a/Atomic/images.py
+++ b/Atomic/images.py
@@ -195,7 +195,7 @@ class Images(Atomic):
 
             else:
                 indicator = ""
-                if image.is_dangling:
+                if image.is_dangling_cached:
                     indicator += "*"
                 elif image.used:
                     indicator += ">"

--- a/Atomic/objects/image.py
+++ b/Atomic/objects/image.py
@@ -187,10 +187,12 @@ class Image(object): # pylint: disable=eq-without-hash
         return _version
 
     @property
+    def is_dangling_cached(self):
+        return self.id in self.backend.get_dangling_images(force_update=False)
+
+    @property
     def is_dangling(self):
-        if self.id in self.backend.get_dangling_images():
-            return True
-        return False
+        return self.id in self.backend.get_dangling_images(force_update=True)
 
     @property
     def virtual_size(self):


### PR DESCRIPTION
do not reload the list of all the images every time we check if an image
is dangling.  This makes "images list" extremely slow when used on the
Docker backend.

On my system (with ~100 images), this patch brings down the wall clock
from ~10 seconds to ~0.5 seconds:

$ /usr/bin/time -v ./atomic images list -a 2>&1 | grep "wall clock"
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:09.84

to:

$ /usr/bin/time -v ./atomic images list -a 2>&1 | grep "wall clock"
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.58

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>