### PR TITLE
Begin changing atomic to work with alternatives to docker CLI

### DIFF
--- a/Atomic/Export.py
+++ b/Atomic/Export.py
@@ -27,7 +27,7 @@ def export_docker(graph, export_location, force):
                     raise ValueError("Please delete dangling images before running atomic storage export")
 
             util.write_out("Deleting dangling images")
-            util.check_call([util.default_docker(), "rmi", "-f"]+dangling_images)
+            util.check_call([util.default_runtime(), "rmi", "-f"]+dangling_images)
 
         #Save the docker storage driver
         storage_driver = client.info()["Driver"]
@@ -66,7 +66,7 @@ def export_images(export_location):
         tags = " ".join(images[Id])
         util.write_out("Exporting image: {0}".format(Id[:12]))
         with open(export_location + '/images/' + Id, 'w') as f:
-            util.check_call([util.default_docker(), "save", tags], stdout=f)
+            util.check_call([util.default_runtime(), "save", tags], stdout=f)
 
 def export_containers(graph, export_location):
     """

--- a/Atomic/Import.py
+++ b/Atomic/Import.py
@@ -46,7 +46,7 @@ def import_images(import_location):
     for image in images:
         util.write_out("Importing image: {0}".format(image[:12]))
         with open(subdir + '/' + image) as f:
-            util.check_call([util.default_docker(), "load"], stdin=f)
+            util.check_call([util.default_runtime(), "load"], stdin=f)
 
 def import_containers(graph, import_location):
     """

--- a/Atomic/atomic.py
+++ b/Atomic/atomic.py
@@ -55,7 +55,7 @@ class Atomic(object):
         self.images_cache = []
         self.images_all_cache = []
         self.active_containers = []
-        self.docker_cmd = None
+        self.runtime_cmd = None
         self.debug = False
         self.is_python2 = (int(sys.version[0])) < 3
         self.useTTY = True
@@ -74,10 +74,10 @@ class Atomic(object):
         except NoDockerDaemon:
             pass
 
-    def docker_binary(self):
-        if not self.docker_cmd:
-            self.docker_cmd = util.default_docker()
-        return self.docker_cmd
+    def runtime_binary(self):
+        if not self.runtime_cmd:
+            self.runtime_cmd = util.default_runtime()
+        return self.runtime_cmd
 
     def get_label(self, label, image=None):
         inspect = self._inspect_image(image)
@@ -253,6 +253,9 @@ class Atomic(object):
 
     def gen_cmd(self, cargs):
         args = []
+        # Replace "docker" command with default runtime
+        if cargs[0] == "docker":
+            cargs[0] = util.default_runtime()
         for c in cargs:
             if c == "IMAGE":
                 args.append(self.image)

--- a/Atomic/install.py
+++ b/Atomic/install.py
@@ -178,7 +178,7 @@ class Install(Atomic):
 
     @staticmethod
     def print_install():
-        return "%s %s %s" % (util.default_docker(), " ".join(INSTALL_ARGS), "/usr/bin/INSTALLCMD")
+        return "%s %s %s" % (util.default_runtime(), " ".join(INSTALL_ARGS), "/usr/bin/INSTALLCMD")
 
     @staticmethod
     def ostree_uri(image_name):

--- a/Atomic/run.py
+++ b/Atomic/run.py
@@ -124,8 +124,8 @@ class Run(Atomic):
 
     @staticmethod
     def print_run():
-        return "%s run %s" % (util.default_docker(), " ".join(RUN_ARGS))
+        return "%s run %s" % (util.default_runtime(), " ".join(RUN_ARGS))
 
     @staticmethod
     def print_spc():
-        return "%s run %s" % (util.default_docker(), " ".join(SPC_ARGS))
+        return "%s run %s" % (util.default_runtime(), " ".join(SPC_ARGS))

--- a/Atomic/storage.py
+++ b/Atomic/storage.py
@@ -143,11 +143,12 @@ class Storage(Atomic):
                 raise ValueError("You must specify the --graph storage path to reset /var/lib/docker or /var/lib/docker-latest")
             if os.path.exists("/var/lib/docker"):
                 self.graphdir = "/var/lib/docker"
-            else:
-                if os.path.exists("/var/lib/docker-latest"):
+            else if os.path.exists("/var/lib/docker-latest"):
                     self.graphdir = "/var/lib/docker-latest"
-                else:
-                    raise ValueError("Could not find any default graph storage path. Specify one using --graph option")
+            else if os.path.exists("/var/lib/containers/storage"):
+                    self.graphdir = "/var/lib/containers/storage"
+            else:
+                raise ValueError("Could not find any default graph storage path. Specify one using --graph option")
 
     def reset(self):
         root=self.graphdir

--- a/Atomic/uninstall.py
+++ b/Atomic/uninstall.py
@@ -65,5 +65,5 @@ class Uninstall(Atomic):
 
     @staticmethod
     def print_uninstall():
-        return "%s %s %s" % (util.default_docker(), " ".join(INSTALL_ARGS), "/usr/bin/UNINSTALLCMD")
+        return "%s %s %s" % (util.default_runtime(), " ".join(INSTALL_ARGS), "/usr/bin/UNINSTALLCMD")
 

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -519,17 +519,17 @@ def get_scanners():
                 pass
     return scanners
 
-def default_docker():
-    if not default_docker.cache:
+def default_runtime():
+    if not default_runtime.cache:
         atomic_config = get_atomic_config()
         if os.path.exists("/var/lib/docker"):
-            docker = "docker"
+            runtime = "docker"
         else:
-            docker = "docker-latest"
+            runtime = "podman"
 
-        default_docker.cache = atomic_config.get('default_docker', docker)
-    return default_docker.cache
-default_docker.cache = None
+        default_runtime.cache = atomic_config.get('default_docker', runtime)
+    return default_runtime.cache
+default_runtime.cache = None
 
 def default_docker_lib():
     try:


### PR DESCRIPTION
This patch should allow systems with podman installed and no
docker CLI to be able to run.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
