### PR TITLE
syscontainer: let uninstall fail when name specified

### DIFF
--- a/Atomic/backends/_ostree.py
+++ b/Atomic/backends/_ostree.py
@@ -128,6 +128,8 @@ class OSTreeBackend(Backend):
         return self.syscontainers.install(image, name)
 
     def uninstall(self, iobject, name=None, **kwargs):
+        if name is not None:
+            raise ValueError("System containers do not support --name. Please use atomic uninstall NAME")
         return self.syscontainers.uninstall(iobject.name)
 
     def prune(self):


### PR DESCRIPTION
Based on discussion https://github.com/projectatomic/atomic/issues/1199#issuecomment-369153184,
we want to disallow user to specify --name option for uninstalling system containers.

Instead, we should encourage user to delete container using atomic
containers delete


## Description


## Related Bugzillas
-
-

## Related Issue Numbers
- https://github.com/projectatomic/atomic/issues/1199
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
