### PR TITLE
install: support multiple containers per image

### DIFF
--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -483,7 +483,7 @@ class DockerBackend(Backend):
         if cmd:
             result = util.check_call(cmd, env=atomic.cmd_env())
             if result == 0:
-                util.InstallData.delete_by_id(iobject.id, ignore=ignore)
+                util.InstallData.delete_by_id(iobject.id, name, ignore=ignore)
             return result
 
         system_package_nvra = None
@@ -494,8 +494,9 @@ class DockerBackend(Backend):
             RPMHostInstall.uninstall_rpm(system_package_nvra)
 
         # Delete the entry in the install data
-        util.InstallData.delete_by_id(iobject.id, ignore=ignore)
-        return self.delete_image(iobject.image, force=args.force)
+        last_image = util.InstallData.delete_by_id(iobject.id, name, ignore=ignore)
+        if last_image:
+            return self.delete_image(iobject.image, force=args.force)
 
     def version(self, image):
         return self.get_layers(image)

--- a/Atomic/install.py
+++ b/Atomic/install.py
@@ -171,7 +171,7 @@ class Install(Atomic):
             if result == 0:
                 if installation or install_args:
                     # Only write the install data if the installation worked.
-                    util.InstallData.write_install_data(install_data)
+                    util.InstallData.write_install_data(install_data, append=True)
             return result
 
 

--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -866,46 +866,54 @@ def file_lock(path):
 class InstallData(object):
 
     @classmethod
+    def read_install_data_locked(cls):
+        try:
+            with open(ATOMIC_INSTALL_JSON, 'r') as f:
+                # Backwards compatibility - we previously created an empty file explicitly;
+                # see https://github.com/projectatomic/atomic/pull/966
+                if os.fstat(f.fileno()).st_size == 0:
+                    return {}
+                data = json.load(f)
+                # Backwards compatibility - we supported only one container per image
+                # if the file is stored in the old format, then automatically convert
+                # it to the new format where each image name can refer to a list of
+                # installed containers.
+                for k, v in data.items():
+                    if isinstance(v, dict):
+                        data[k] = [v]
+                return data
+        except IOError as e:
+            if e.errno == errno.ENOENT:
+                return {}
+            raise e
+
+    @classmethod
     def read_install_data(cls):
         with file_lock(ATOMIC_INSTALL_JSON):
-            try:
-                with open(ATOMIC_INSTALL_JSON, 'r') as f:
-                    # Backwards compatibility - we previously created an empty file explicitly;
-                    # see https://github.com/projectatomic/atomic/pull/966
-                    if os.fstat(f.fileno()).st_size == 0:
-                        return {}
-                    data = json.load(f)
-                    # Backwards compatibility - we supported only one container per image
-                    # if the file is stored in the old format, then automatically convert
-                    # it to the new format where each image name can refer to a list of
-                    # installed containers.
-                    for k, v in data.items():
-                        if isinstance(v, dict):
-                            data[k] = [v]
-                    return data
-            except IOError as e:
-                if e.errno == errno.ENOENT:
-                    return {}
-                raise e
+            return cls.read_install_data_locked()
+
+    @classmethod
+    def write_install_data_locked(cls, new_data, append=False):
+        install_data = cls.read_install_data_locked()
+        if not append:
+            install_data = new_data
+        else:
+            for k, v in new_data.items():
+                if k not in install_data:
+                    install_data[k] = []
+                install_data[k].append(v)
+        temp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+
+        json.dump(install_data, temp_file)
+        temp_file.close()
+        if not os.path.exists(ATOMIC_VAR_LIB):
+            os.makedirs(ATOMIC_VAR_LIB)
+        shutil.move(temp_file.name, ATOMIC_INSTALL_JSON)
 
     @classmethod
     def write_install_data(cls, new_data, append=False):
-        install_data = cls.read_install_data()
         with file_lock(ATOMIC_INSTALL_JSON):
-            if not append:
-                install_data = new_data
-            else:
-                for k, v in new_data.items():
-                    if k not in install_data:
-                        install_data[k] = []
-                    install_data[k].append(v)
-            temp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
-
-            json.dump(install_data, temp_file)
-            temp_file.close()
-            if not os.path.exists(ATOMIC_VAR_LIB):
-                os.makedirs(ATOMIC_VAR_LIB)
-            shutil.move(temp_file.name, ATOMIC_INSTALL_JSON)
+            return cls.write_install_data_locked(new_data, append)
 
     @classmethod
     def get_install_data_by_id(cls, iid):
@@ -931,18 +939,19 @@ class InstallData(object):
     @classmethod
     def delete_by_id(cls, iid, name, ignore=False):
         last_image = False
-        install_data = cls.read_install_data()
-        for installed_image in install_data:
-            containers = install_data[installed_image]
-            for index, container in enumerate(containers):
-                if container['id'] == iid and container['container_name'] == name:
-                    del containers[index]
-                    install_data[installed_image] = containers
-                    if len(containers) == 0:
-                        del install_data[installed_image]
-                        last_image = True
-                    cls.write_install_data(install_data)
-                    return last_image
+        with file_lock(ATOMIC_INSTALL_JSON):
+            install_data = cls.read_install_data_locked()
+            for installed_image in install_data:
+                containers = install_data[installed_image]
+                for index, container in enumerate(containers):
+                    if container['id'] == iid and container['container_name'] == name:
+                        del containers[index]
+                        install_data[installed_image] = containers
+                        if len(containers) == 0:
+                            del install_data[installed_image]
+                            last_image = True
+                        cls.write_install_data_locked(install_data)
+                        return last_image
         if not ignore:
             raise ValueError("Unable to find {} in the installed containers".format(iid))
 

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -203,9 +203,9 @@ class TestAtomicUtil(unittest.TestCase):
 
 
 class MockIO(object):
-    original_data = {"install_test": {"install_date": "2017-03-22 17:19:41", "id": "49779293ca711789a77bbdc35547a6b9ecb193a51b4e360fea95c4d206605d18"}}
-    new_data_fq = {"install_date": "2017-04-22 17:19:41","id": "16e9fdecc1febc87fb1ca09271009cf5f28eb8d4aec5515922ef298c145a6726"}
-    new_data_name= {"install_date": "2017-04-22 17:19:41","id": "16e9fdecc1febc87fb1ca09271009cf5f28eb8d4aec5515922ef298c145a6726"}
+    original_data = {"install_test": [{"install_date": "2017-03-22 17:19:41", "id": "49779293ca711789a77bbdc35547a6b9ecb193a51b4e360fea95c4d206605d18"}]}
+    new_data_fq = [{"install_date": "2017-04-22 17:19:41","id": "16e9fdecc1febc87fb1ca09271009cf5f28eb8d4aec5515922ef298c145a6726"}]
+    new_data_name= [{"install_date": "2017-04-22 17:19:41","id": "16e9fdecc1febc87fb1ca09271009cf5f28eb8d4aec5515922ef298c145a6726"}]
     install_data = original_data
 
     @classmethod
@@ -218,7 +218,6 @@ class MockIO(object):
 
     @classmethod
     def reset_data(cls):
-        cls.install_data = {}
         cls.install_data = cls.original_data
 
     @classmethod


### PR DESCRIPTION
Change the install data format to keep a list of containers for each image installed, so that multiple containers for the same image can be installed and uninstalled.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1559935