### PR TITLE
docker: restore uninstall when no container name is specified

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -901,6 +901,10 @@ class InstallData(object):
             for k, v in new_data.items():
                 if k not in install_data:
                     install_data[k] = []
+                for index, c in enumerate(install_data[k]):
+                    if c.get('container_name') == v.get('container_name') and c.get('id') == v.get('id'):
+                        del install_data[k][index]
+                        break
                 install_data[k].append(v)
         temp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
 
@@ -943,8 +947,13 @@ class InstallData(object):
             install_data = cls.read_install_data_locked()
             for installed_image in install_data:
                 containers = install_data[installed_image]
+                if not name and len(containers) > 1:
+                    raise ValueError("Name not specified but more than one container installed")
+
                 for index, container in enumerate(containers):
-                    if container['id'] == iid and container['container_name'] == name:
+                    if name is not None and container['container_name'] != name:
+                        continue
+                    if container['id'] == iid:
                         del containers[index]
                         install_data[installed_image] = containers
                         if len(containers) == 0:

--- a/tests/integration/test_display.sh
+++ b/tests/integration/test_display.sh
@@ -91,3 +91,11 @@ if [[ ${OUTPUT} != ${RESULT} ]]; then
     echo "Uninstall display failed for uninstall-1"
     exit 1
 fi
+
+# Add test case for issue #1217
+export ATOMIC_INSTALL_JSON=empty.json
+${ATOMIC} install atomic-test-1
+${ATOMIC} run atomic-test-1
+${ATOMIC} stop atomic-test-1
+${ATOMIC} --assumeyes containers delete atomic-test-1
+${ATOMIC} --debug uninstall atomic-test-1


### PR DESCRIPTION
If there is only one container installed, use it when no name is
specified to uninstall.

Closes: https://github.com/projectatomic/atomic/issues/1217

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>


## Description


## Related Bugzillas
-
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
