### PR TITLE
overlay: reintroduce error when using 'rw'

### DIFF
--- a/Atomic/mount.py
+++ b/Atomic/mount.py
@@ -576,6 +576,10 @@ class DockerMount(Mount):
         """
         OverlayFS mount backend.
         """
+        if 'rw' in options:
+            raise MountError('The OverlayFS backend does not support '
+                             'writeable mounts.')
+
         cid = self._identifier_as_cid(identifier)
 
         if self.mnt_mkdir:


### PR DESCRIPTION
the error message was mistakenly dropped with commit:

7179eab364831a8fdb1456e12dfe8085d2e04d67

Closes: https://github.com/projectatomic/atomic/issues/1222

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

