### PR TITLE
util: correctly set the error from Skopeo

### DIFF
--- a/Atomic/util.py
+++ b/Atomic/util.py
@@ -1094,7 +1094,7 @@ class SkopeoError(object):
         self.msg = ""
         for line in shlex.split(string_error):
             key, _, msg = line.partition("=")
-            setattr(SkopeoError, key, msg)
+            setattr(self, key, msg)
 
 def write_template(inputfilename, data, values, destination):
     if destination:


### PR DESCRIPTION
$ atomic install --system --system-package=no registry.fedoraproject.org/f28/etcd
Error reading manifest latest in registry.fedoraproject.org/f28/etcd: manifest unknown: manifest unknown

Closes: https://github.com/projectatomic/atomic/issues/1224

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>


## Description


## Related Bugzillas
-
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
