### PR TITLE
syscontainers: allow to override EXEC_*

### DIFF
--- a/docs/atomic-install.1.md
+++ b/docs/atomic-install.1.md
@@ -159,14 +159,6 @@ cannot be overriden by the user through **--set**:
 **$DESTDIR** Destination on the file system for the checked out
 container.
 
-**$EXEC_STARTPRE** Command to use for the systemd directive ExecStartPre=.
-
-**$EXEC_START** Command to use for the systemd directive ExecStart=.
-
-**$EXEC_STOP** Command to use for the systemd directive ExecStop=.
-
-**$EXEC_STOPPOST** Command to use for the systemd directive ExecStopPost=.
-
 **$HOST_UID** UID of the user on the system.
 
 **$HOST_GID** GID of the user on the system.
@@ -204,6 +196,14 @@ the host, $XDG_RUNTIME_DIR for user containers).
 **$RUNTIME** The runtime used to execute the containers.
 
 **$ATOMIC** Path to the atomic executable that is installing the container.
+
+**$EXEC_STARTPRE** Command to use for the systemd directive ExecStartPre=.
+
+**$EXEC_START** Command to use for the systemd directive ExecStart=.
+
+**$EXEC_STOP** Command to use for the systemd directive ExecStop=.
+
+**$EXEC_STOPPOST** Command to use for the systemd directive ExecStopPost=.
 
 **--system-package=auto|build|no|yes**
 Control how the container will be installed to the system.

--- a/tests/integration/test_system_containers_runtime.sh
+++ b/tests/integration/test_system_containers_runtime.sh
@@ -50,6 +50,8 @@ trap teardown EXIT
 
 OUTPUT=$(/bin/true)
 
+export SECRET=`dd if=/dev/urandom bs=4096 count=1 2> /dev/null | sha256sum`
+
 setup
 
 # 1. Install a system container and start/stop the container with systemctl
@@ -209,8 +211,10 @@ readlink ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME} > ${WORK_DIR}/link.out
 assert_matches ${NAME}.0 ${WORK_DIR}/link.out
 
 # Updating to a new image fails with missing variables
-OUTPUT=$(! ${ATOMIC} containers update ${NAME} --rebase atomic-test-system-update 2>&1)
-grep "unreplaced value for: ''VAR_WITH_NO_DEFAULT''" <<< $OUTPUT
+set +e
+${ATOMIC} containers update ${NAME} --rebase atomic-test-system-update > ${WORK_DIR}/update2.out 2>&1
+set -e
+assert_matches "unreplaced value for: ''VAR_WITH_NO_DEFAULT''" ${WORK_DIR}/update2.out
 readlink ${ATOMIC_OSTREE_CHECKOUT_PATH}/${NAME} > ${WORK_DIR}/link.out
 assert_matches ${NAME}.0 ${WORK_DIR}/link.out
 


### PR DESCRIPTION
There is no reason that these variables are hardcoded.  Allow users to
override them.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
