### PR TITLE
atomic: uninstall checks for container existance before rm'ng it

### DIFF
--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -450,8 +450,12 @@ class DockerBackend(Backend):
         # We have a container by that name, need to stop and delete it
         if con_obj:
             if con_obj.running:
-                self.stop_container(con_obj, args=atomic.args)
-            self.delete_container(con_obj.id)
+                self.stop_container(con_obj, args=atomic.args, atomic=atomic)
+            # Check if the container is still present.  stop_container might
+            # have deleted it
+            if self.has_container(name):
+                self.delete_container(con_obj.id)
+            return
 
         if args.force:
             self.delete_containers_by_image(iobject, force=True)


### PR DESCRIPTION
a container might be deleted by the stop label, if it was started with
--rm.  Check for its presence before attempting to delete it.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1576285

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>


## Description


## Related Bugzillas
-
-

## Related Issue Numbers
-
-

## Pull Request Checklist:

If your Pull request contains new features or functions, tests are required. If the PR is a bug fix and no tests exist, please consider adding some to prevent regressions.
- [ ] Unittests
- [ ] Integration Tests
