### PR TITLE
atomic: honor UNINSTALL after stop of a container

### DIFF
--- a/Atomic/backends/_docker.py
+++ b/Atomic/backends/_docker.py
@@ -455,7 +455,6 @@ class DockerBackend(Backend):
             # have deleted it
             if self.has_container(name):
                 self.delete_container(con_obj.id)
-            return
 
         if args.force:
             self.delete_containers_by_image(iobject, force=True)


### PR DESCRIPTION
Honor the UNINSTALL label after the specified container was stopped.

Introduced by: 18959843d5f0c8bcf410e41051d228b944c3bf1a

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1576285

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
